### PR TITLE
ART-953 fix generation of wsdls for mixed mode validators

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/core/IDualModeValidator.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/IDualModeValidator.java
@@ -2,5 +2,5 @@ package nl.nn.adapterframework.core;
 
 public interface IDualModeValidator {
 
-	public IPipe getResponseValidator(IPipe externalResponseValidator);
+	public IPipe getResponseValidator();
 }

--- a/core/src/main/java/nl/nn/adapterframework/core/IXmlValidator.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/IXmlValidator.java
@@ -1,11 +1,17 @@
 package nl.nn.adapterframework.core;
 
+import java.util.Set;
+
 import nl.nn.adapterframework.configuration.ConfigurationException;
+import nl.nn.adapterframework.validation.XSD;
 
 public interface IXmlValidator extends IPipe {
 
 	public ConfigurationException getConfigurationException();
-//	public String getMessageRoot();
-//	public String getEnvelopeRoot();
+
+	public String getMessageRoot();
 	
+	public String getSchema();
+	public String getSchemaLocation();
+	public Set<XSD> getXsds() throws ConfigurationException;
 }

--- a/core/src/main/java/nl/nn/adapterframework/core/PipeLine.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeLine.java
@@ -295,7 +295,7 @@ public class PipeLine implements ICacheEnabled, HasStatistics {
 		IPipe inputValidator = getInputValidator();
 		IPipe outputValidator = getOutputValidator();
 		if (inputValidator!=null && outputValidator==null && inputValidator instanceof IDualModeValidator) {
-			outputValidator=((IDualModeValidator)inputValidator).getResponseValidator(outputValidator);
+			outputValidator=((IDualModeValidator)inputValidator).getResponseValidator();
 			setOutputValidator(outputValidator);
 		}
 		if (inputValidator != null) {

--- a/core/src/main/java/nl/nn/adapterframework/pipes/Json2XmlValidator.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/Json2XmlValidator.java
@@ -198,10 +198,6 @@ public class Json2XmlValidator extends XmlValidator {
 		return result;
 	}
 	
-	protected String getJsonRootElement(IPipeLineSession session) {
-		return getRoot();
-	}
-	
 	protected PipeRunResult alignJson(String messageToValidate, IPipeLineSession session) throws PipeRunException, XmlValidatorException {
 
 		ValidationContext context;
@@ -215,7 +211,7 @@ public class Json2XmlValidator extends XmlValidator {
 		String resultEvent;
 		String out=null;
 		try {
-			Json2Xml aligner = new Json2Xml(validatorHandler, context.getXsModels(), isCompactJsonArrays(), getJsonRootElement(session), isStrictJsonArraySyntax());
+			Json2Xml aligner = new Json2Xml(validatorHandler, context.getXsModels(), isCompactJsonArrays(), getMessageRoot(session), isStrictJsonArraySyntax());
 			if (StringUtils.isNotEmpty(getTargetNamespace())) {
 				aligner.setTargetNamespace(getTargetNamespace());
 			}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
@@ -404,7 +404,7 @@ public class MessageSendingPipe extends FixedForwardPipe implements HasSender, H
 		IPipe inputValidator = getInputValidator();
 		IPipe outputValidator = getOutputValidator();
 		if (inputValidator!=null && outputValidator==null && inputValidator instanceof IDualModeValidator) {
-			outputValidator=((IDualModeValidator)inputValidator).getResponseValidator(outputValidator);
+			outputValidator=((IDualModeValidator)inputValidator).getResponseValidator();
 			setOutputValidator(outputValidator);
 		}
 		if (inputValidator!=null) {

--- a/core/src/main/java/nl/nn/adapterframework/soap/SoapValidator.java
+++ b/core/src/main/java/nl/nn/adapterframework/soap/SoapValidator.java
@@ -85,11 +85,11 @@ public class SoapValidator extends Json2XmlValidator {
                     .getInstance();
             configWarnings.add(log, "soapBody not specified");
         }
-        addInputRootValidation(Arrays.asList("Envelope", "Body", soapBody));
+        addRequestRootValidation(Arrays.asList("Envelope", "Body", soapBody));
         if (StringUtils.isNotEmpty(outputSoapBody)) {
-            addOutputRootValidation(Arrays.asList("Envelope", "Body", outputSoapBody));
+            addResponseRootValidation(Arrays.asList("Envelope", "Body", outputSoapBody));
         }
-        addInputRootValidation(Arrays.asList("Envelope", "Header", soapHeader));
+        addRequestRootValidation(Arrays.asList("Envelope", "Header", soapHeader));
         List<String> invalidRootNamespaces = new ArrayList<String>();
         for (SoapVersion version : versions) {
             invalidRootNamespaces.add(version.getNamespace());
@@ -114,9 +114,13 @@ public class SoapValidator extends Json2XmlValidator {
         throw new IllegalArgumentException("The noNamespaceSchemaLocation attribute isn't supported");
     }
 
-    @Override
-	protected String getJsonRootElement(IPipeLineSession session) {
-		return isOutputModeEnabled(session)?getOutputSoapBody():getSoapBody();
+	@Override
+	public String getMessageRoot() {
+		return getSoapBody();
+	}
+	@Override
+	public String getResponseRoot() {
+		return getOutputSoapBody();
 	}
 
 

--- a/core/src/main/java/nl/nn/adapterframework/soap/WsdlUtils.java
+++ b/core/src/main/java/nl/nn/adapterframework/soap/WsdlUtils.java
@@ -29,7 +29,7 @@ import org.apache.xerces.util.XMLChar;
 import javanet.staxutils.IndentingXMLStreamWriter;
 import nl.nn.adapterframework.core.IAdapter;
 import nl.nn.adapterframework.core.IListener;
-import nl.nn.adapterframework.pipes.XmlValidator;
+import nl.nn.adapterframework.core.IXmlValidator;
 import nl.nn.adapterframework.receivers.ReceiverBase;
 import nl.nn.adapterframework.util.XmlUtils;
 
@@ -56,29 +56,39 @@ public abstract class WsdlUtils {
         return result;
     }
 
-    public static String getEsbSoapParadigm(XmlValidator xmlValidator) {
-        return getEsbSoapParadigm(xmlValidator, false);
-    }
-
-    public static String getEsbSoapParadigm(XmlValidator xmlValidator, boolean outputMode) {
-        if (xmlValidator instanceof SoapValidator) {
-        	String soapBody;
-        	if (outputMode) {
-            	soapBody = ((SoapValidator)xmlValidator).getOutputSoapBody();
-        	} else {
-            	soapBody = ((SoapValidator)xmlValidator).getSoapBody();
-        	}
-            if (soapBody != null) {
-                int i = soapBody.lastIndexOf('_');
-                if (i != -1) {
-                    return soapBody.substring(i + 1);
-                }
+      // 2017-10-17 Previous version, before 
+//    public static String getEsbSoapParadigm(XmlValidator xmlValidator, boolean outputMode) {
+//        if (xmlValidator instanceof SoapValidator) {
+//        	String soapBody;
+//        	if (outputMode) {
+//            	soapBody = ((SoapValidator)xmlValidator).getOutputSoapBody();
+//        	} else {
+//            	soapBody = ((SoapValidator)xmlValidator).getSoapBody();
+//        	}
+//            if (soapBody != null) {
+//                int i = soapBody.lastIndexOf('_');
+//                if (i != -1) {
+//                    return soapBody.substring(i + 1);
+//                }
+//            }
+//        }
+//        return null;
+//    }
+    
+    
+    
+    public static String getEsbSoapParadigm(IXmlValidator xmlValidator) {
+    	String soapBody = xmlValidator.getMessageRoot();
+        if (soapBody != null) {
+            int i = soapBody.lastIndexOf('_');
+            if (i != -1) {
+                return soapBody.substring(i + 1);
             }
         }
         return null;
     }
 
-    public static String getFirstNamespaceFromSchemaLocation(XmlValidator inputValidator) {
+    public static String getFirstNamespaceFromSchemaLocation(IXmlValidator inputValidator) {
         String schemaLocation = inputValidator.getSchemaLocation();
         if (schemaLocation != null) {
             String[] split =  schemaLocation.trim().split("\\s+");

--- a/core/src/test/java/nl/nn/adapterframework/pipes/WsdlXmlValidatorMixedModeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/WsdlXmlValidatorMixedModeTest.java
@@ -65,7 +65,7 @@ public class WsdlXmlValidatorMixedModeTest {
         val.setSchemaLocation("http://ibissource.org/XSD/Generic/MessageHeader/2 schema1 http://api.ibissource.org/GetPolicyDetails schema2");
         val.registerForward(new PipeForward("success", null));
         val.configure();
-        val.getResponseValidator(null).configure();
+        val.getResponseValidator().configure();
         return val;
     }
 
@@ -106,8 +106,8 @@ public class WsdlXmlValidatorMixedModeTest {
     public void testPipeLineProcessorProcessOutputValidation(IPipe inputValidator, IPipe outputValidator, String msg, String failureReason) throws IOException {
     	if (ooMode) {
     		IPipe responseValidator;
-    		if (inputValidator!=null && inputValidator instanceof IDualModeValidator) {
-    			responseValidator=((IDualModeValidator)inputValidator).getResponseValidator(outputValidator);
+    		if (inputValidator!=null && outputValidator==null && inputValidator instanceof IDualModeValidator) {
+    			responseValidator=((IDualModeValidator)inputValidator).getResponseValidator();
     		} else {
     			responseValidator=outputValidator;
     		}
@@ -147,7 +147,7 @@ public class WsdlXmlValidatorMixedModeTest {
     @Test
     public void testMixedValidator() throws Exception {
         WsdlXmlValidator val = getMixedValidator();
-        IPipe outputValidator =val.getResponseValidator(null);
+        IPipe outputValidator =val.getResponseValidator();
         validate(val,REQUEST,null);
         validate(val,RESPONSE,"Illegal element");
         validate(outputValidator,RESPONSE,null);

--- a/core/src/test/java/nl/nn/adapterframework/pipes/XmlValidatorTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/XmlValidatorTest.java
@@ -225,10 +225,16 @@ public class XmlValidatorTest {
         return getValidator(schemaLocation, addNamespaceToSchema, implementation);
     }
 
-    public static XmlValidator getValidator(String schemaLocation, Class<AbstractXmlValidator> implementation) throws ConfigurationException {
-        return getValidator(schemaLocation, false, implementation);
+    public static XmlValidator getUnconfiguredValidator(String schemaLocation, Class<AbstractXmlValidator> implementation) throws ConfigurationException {
+        return getUnconfiguredValidator(schemaLocation, false, implementation);
     }
+
     public static XmlValidator getValidator(String schemaLocation, boolean addNamespaceToSchema, Class<AbstractXmlValidator> implementation) throws ConfigurationException {
+    	XmlValidator validator=getUnconfiguredValidator(schemaLocation, addNamespaceToSchema, implementation);
+    	validator.configure();
+    	return validator;
+    }
+    public static XmlValidator getUnconfiguredValidator(String schemaLocation, boolean addNamespaceToSchema, Class<AbstractXmlValidator> implementation) {
         XmlValidator validator = new XmlValidator();
         try {
             validator.setImplementation(implementation);
@@ -241,7 +247,6 @@ public class XmlValidatorTest {
         }
         validator.registerForward(getSuccess());
         validator.setThrowException(true);
-        validator.configure();
         validator.setFullSchemaChecking(true);
         return validator;
     }

--- a/core/src/test/java/nl/nn/adapterframework/soap/WsdlTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/soap/WsdlTest.java
@@ -21,19 +21,6 @@ import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.stream.XMLStreamException;
 
-import nl.nn.adapterframework.configuration.Configuration;
-import nl.nn.adapterframework.configuration.ConfigurationException;
-import nl.nn.adapterframework.core.Adapter;
-import nl.nn.adapterframework.core.PipeLine;
-import nl.nn.adapterframework.http.WebServiceListener;
-import nl.nn.adapterframework.pipes.XmlValidator;
-import nl.nn.adapterframework.pipes.XmlValidatorTest;
-import nl.nn.adapterframework.receivers.ReceiverBase;
-import nl.nn.adapterframework.util.XmlUtils;
-import nl.nn.adapterframework.validation.AbstractXmlValidator;
-import nl.nn.adapterframework.validation.JavaxXmlValidator;
-import nl.nn.adapterframework.validation.XercesXmlValidator;
-
 import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -43,6 +30,20 @@ import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
+
+import nl.nn.adapterframework.configuration.Configuration;
+import nl.nn.adapterframework.configuration.ConfigurationException;
+import nl.nn.adapterframework.core.Adapter;
+import nl.nn.adapterframework.core.IPipe;
+import nl.nn.adapterframework.core.PipeLine;
+import nl.nn.adapterframework.http.WebServiceListener;
+import nl.nn.adapterframework.pipes.XmlValidator;
+import nl.nn.adapterframework.pipes.XmlValidatorTest;
+import nl.nn.adapterframework.receivers.ReceiverBase;
+import nl.nn.adapterframework.util.XmlUtils;
+import nl.nn.adapterframework.validation.AbstractXmlValidator;
+import nl.nn.adapterframework.validation.JavaxXmlValidator;
+import nl.nn.adapterframework.validation.XercesXmlValidator;
 
 
 /**
@@ -78,10 +79,33 @@ public class WsdlTest {
 	}
 
 	@Test
+	public void basicMixed() throws XMLStreamException, IOException, ParserConfigurationException, SAXException, ConfigurationException, URISyntaxException, NamingException {
+		XmlValidator inputValidator=getXmlValidatorInstance("a", "b", "WsdlTest/test.xsd", "urn:webservice1 WsdlTest/test.xsd");
+		IPipe outputValidator=inputValidator.getResponseValidator();
+		PipeLine simple = mockPipeLine(inputValidator, outputValidator, "urn:webservice1", "Test1");
+		Wsdl wsdl = new Wsdl(simple);
+		wsdl.init();
+		test(wsdl, "WsdlTest/webservice1.test.wsdl");
+	}
+
+	@Test
 	public void includeXsdInWsdl() throws XMLStreamException, IOException, ParserConfigurationException, SAXException, ConfigurationException, URISyntaxException, NamingException {
 		PipeLine simple = mockPipeLine(
 				getXmlValidatorInstance("a", "WsdlTest/test.xsd", "urn:webservice1 WsdlTest/test.xsd"),
 				getXmlValidatorInstance("b", "WsdlTest/test.xsd", "urn:webservice1 WsdlTest/test.xsd"), "urn:webservice1", "IncludeXsds");
+
+		Wsdl wsdl = new Wsdl(simple);
+        wsdl.setUseIncludes(true);
+        wsdl.init();
+		test(wsdl, "WsdlTest/includexsds.test.wsdl");
+	}
+
+
+	@Test
+	public void includeXsdInWsdlMixed() throws XMLStreamException, IOException, ParserConfigurationException, SAXException, ConfigurationException, URISyntaxException, NamingException {
+		XmlValidator inputValidator=getXmlValidatorInstance("a", "b", "WsdlTest/test.xsd", "urn:webservice1 WsdlTest/test.xsd");
+		IPipe outputValidator=inputValidator.getResponseValidator();
+		PipeLine simple = mockPipeLine(inputValidator, outputValidator, "urn:webservice1", "IncludeXsds");
 
 		Wsdl wsdl = new Wsdl(simple);
         wsdl.setUseIncludes(true);
@@ -112,17 +136,26 @@ public class WsdlTest {
         test(wsdl, "WsdlTest/noroottag.test.wsdl");
     }
 
+    @Test
+    public void noroottagMixed() throws XMLStreamException, IOException, SAXException, ParserConfigurationException, URISyntaxException, ConfigurationException, NamingException {
+		XmlValidator inputValidator=getXmlValidatorInstance(null, "b", "WsdlTest/test.xsd", "urn:webservice1 WsdlTest/test.xsd");
+		IPipe outputValidator=inputValidator.getResponseValidator();
+		PipeLine simple = mockPipeLine(inputValidator, outputValidator, "urn:webservice1", "TestRootTag");
+        Wsdl wsdl = new Wsdl(simple);
+        wsdl.init();
+        test(wsdl, "WsdlTest/noroottag.test.wsdl");
+    }
 
 
 
 
     @Test
-    public void wubCalculateQuoteAndPolicyValuesLifeRetail () throws XMLStreamException, IOException, SAXException, ParserConfigurationException, URISyntaxException, ConfigurationException, NamingException {
+    public void wubCalculateQuoteAndPolicyValuesLifeRetail() throws XMLStreamException, IOException, SAXException, ParserConfigurationException, URISyntaxException, ConfigurationException, NamingException {
         PipeLine pipe = mockPipeLine(
-            getXmlValidatorInstance("CalculationRequest", null,
+            getXmlValidatorInstance("CalculationRequest", null, null,
                 "http://wub2nn.nn.nl/CalculateQuoteAndPolicyValuesLifeRetail " +
 						"WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail/xsd/CalculationRequestv2.1.xsd"),
-            getXmlValidatorInstance("CalculationResponse", null,
+            getXmlValidatorInstance("CalculationResponse", null, null,
                 "http://wub2nn.nn.nl/CalculateQuoteAndPolicyValuesLifeRetail_response " +
 						"WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail/xsd/CalculationRespons.xsd"),
             "http://wub2nn.nn.nl/CalculateQuoteAndPolicyValuesLifeRetail", "WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail");
@@ -130,20 +163,30 @@ public class WsdlTest {
         wsdl.init();
         wsdl.setUseIncludes(true);
         test(wsdl, "WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail.test.wsdl");
+    }
 
+    @Test
+    public void wubCalculateQuoteAndPolicyValuesLifeRetailMixed() throws XMLStreamException, IOException, SAXException, ParserConfigurationException, URISyntaxException, ConfigurationException, NamingException {
+    	XmlValidator inputValidator=getXmlValidatorInstance("CalculationRequest", "CalculationResponse", null,
+    			"http://wub2nn.nn.nl/CalculateQuoteAndPolicyValuesLifeRetail WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail/xsd/CalculationRequestv2.1.xsd "+
+    			"http://wub2nn.nn.nl/CalculateQuoteAndPolicyValuesLifeRetail_response  WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail/xsd/CalculationRespons.xsd");
+    	IPipe outputValidator = inputValidator.getResponseValidator();
+    	PipeLine pipe = mockPipeLine(inputValidator, outputValidator, 
+            "http://wub2nn.nn.nl/CalculateQuoteAndPolicyValuesLifeRetail", "WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail");
+        Wsdl wsdl = new Wsdl(pipe);
+        wsdl.init();
+        wsdl.setUseIncludes(true);
+        test(wsdl, "WsdlTest/CalculateQuoteAndPolicyValuesLifeRetail.test.wsdl");
     }
 
     @Test
     public void wubFindIntermediary() throws XMLStreamException, IOException, SAXException, ParserConfigurationException, URISyntaxException, ConfigurationException, NamingException {
         PipeLine pipe = mockPipeLine(
-            getXmlValidatorInstance("FindIntermediaryREQ", null,
-                "http://wub2nn.nn.nl/FindIntermediary " +
-						"WsdlTest/FindIntermediary/xsd/XSD_FindIntermediary_v1.1_r1.0.xsd"),
-            getXmlValidatorInstance("FindIntermediaryRLY", null,
-                "http://wub2nn.nn.nl/FindIntermediary " +
-						"WsdlTest/FindIntermediary/xsd/XSD_FindIntermediary_v1.1_r1.0.xsd"),
-            "http://wub2nn.nn.nl/FindIntermediary",
-				"WsdlTest/FindIntermediary");
+            getXmlValidatorInstance("FindIntermediaryREQ", null, null,
+                "http://wub2nn.nn.nl/FindIntermediary WsdlTest/FindIntermediary/xsd/XSD_FindIntermediary_v1.1_r1.0.xsd"),
+            getXmlValidatorInstance("FindIntermediaryRLY", null, null,
+                "http://wub2nn.nn.nl/FindIntermediary WsdlTest/FindIntermediary/xsd/XSD_FindIntermediary_v1.1_r1.0.xsd"),
+            "http://wub2nn.nn.nl/FindIntermediary", "WsdlTest/FindIntermediary");
         Wsdl wsdl = new Wsdl(pipe);
         wsdl.init();
         wsdl.setUseIncludes(true);
@@ -153,6 +196,20 @@ public class WsdlTest {
         // assertEquals(2, wsdl.getXSDs(true).size()); TODO?
     }
 
+    @Test
+    public void wubFindIntermediaryMixed() throws XMLStreamException, IOException, SAXException, ParserConfigurationException, URISyntaxException, ConfigurationException, NamingException {
+    	XmlValidator inputValidator=getXmlValidatorInstance("FindIntermediaryREQ", "FindIntermediaryRLY", null,
+                		"http://wub2nn.nn.nl/FindIntermediary WsdlTest/FindIntermediary/xsd/XSD_FindIntermediary_v1.1_r1.0.xsd");
+    	IPipe outputValidator = inputValidator.getResponseValidator();
+        PipeLine pipe = mockPipeLine(inputValidator, outputValidator, "http://wub2nn.nn.nl/FindIntermediary", "WsdlTest/FindIntermediary");
+        Wsdl wsdl = new Wsdl(pipe);
+        wsdl.setUseIncludes(true);
+        wsdl.init();
+        assertTrue(wsdl.isUseIncludes());
+		test(wsdl, "WsdlTest/FindIntermediary.test.wsdl");
+        zip(wsdl);
+        // assertEquals(2, wsdl.getXSDs(true).size()); TODO?
+    }
 
     protected void test(Wsdl wsdl, String testWsdl) throws IOException, SAXException, ParserConfigurationException, XMLStreamException, URISyntaxException, NamingException, ConfigurationException {
         wsdl.setDocumentation("test");
@@ -179,14 +236,20 @@ public class WsdlTest {
     }
 
     protected XmlValidator getXmlValidatorInstance(String rootTag, String schema, String schemaLocation) throws ConfigurationException {
-        XmlValidator validator = XmlValidatorTest.getValidator(schemaLocation, implementation);
+    	return getXmlValidatorInstance(rootTag, null, schema, schemaLocation);
+    }
+    
+    protected XmlValidator getXmlValidatorInstance(String rootTag, String responseRootTag, String schema, String schemaLocation) throws ConfigurationException {
+        XmlValidator validator = XmlValidatorTest.getUnconfiguredValidator(schemaLocation, implementation);
         validator.setSchema(schema);
         validator.setRoot(rootTag);
+        if (responseRootTag!=null) {
+        	validator.setResponseRoot(responseRootTag);
+        }
         return validator;
     }
 
-
-    protected PipeLine mockPipeLine(XmlValidator inputValidator, XmlValidator outputValidator, String targetNamespace, String adapterName) {
+    protected PipeLine mockPipeLine(IPipe inputValidator, IPipe outputValidator, String targetNamespace, String adapterName) {
         PipeLine simple = mock(PipeLine.class);
         when(simple.getInputValidator()).thenReturn(inputValidator);
         when(simple.getOutputValidator()).thenReturn(outputValidator);


### PR DESCRIPTION
WSDL now works based on interface IXmlValidator, and does not need to be (and is) no longer aware of mixed mode