### PR TITLE
Change stop adapter / receiver button style to a more neutral style

### DIFF
--- a/webapp/src/main/webapp/iaf/gui/css/style.css
+++ b/webapp/src/main/webapp/iaf/gui/css/style.css
@@ -1,7 +1,6 @@
 @import url("https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700");
 @import url("https://fonts.googleapis.com/css?family=Roboto:400,300,500,700");
 
-
 h1,
 h2,
 h3,
@@ -609,6 +608,16 @@ body.canvas-menu.mini-navbar nav.navbar-static-side {
 .btn-danger.btn-outline {
   color: #ed5565;
 }
+.btn-gray {
+  border-color: #adadad;
+  background-color: #b7b7b7;
+}
+.btn-gray:hover {
+  background-color: #ec4758;
+  border-color: #ec4758;
+  color: #fff;
+}
+.btn-gray.btn-outline:hover
 .btn-primary.btn-outline:hover,
 .btn-success.btn-outline:hover,
 .btn-info.btn-outline:hover,

--- a/webapp/src/main/webapp/iaf/gui/css/style.css
+++ b/webapp/src/main/webapp/iaf/gui/css/style.css
@@ -3793,6 +3793,11 @@ code {
 }
 .adapters .ibox-title {
   cursor: pointer;
+  min-height: 40px;
+  padding: 10px 15px 7px;
+}
+.adapters .ibox {
+  margin-bottom: 15px;
 }
 .ibox-title.warning {
   border-color: #f7a54a;

--- a/webapp/src/main/webapp/iaf/gui/js/controllers.js
+++ b/webapp/src/main/webapp/iaf/gui/js/controllers.js
@@ -520,6 +520,51 @@ angular.module('iaf.beheerconsole')
 	};
 
 	$scope.changeConfiguration = function(name) {
+		// Create new receiverSummary
+		var receiverSummary = {
+			started 	: 0,
+			starting 	: 0,
+			stopped 	: 0,
+			stopping 	: 0,
+			error 		: 0
+		};
+		// Create new adapterSummary
+		var adapterSummary = {
+			started 	: 0,
+			starting 	: 0,
+			stopped 	: 0,
+			stopping 	: 0,
+			error 		: 0
+		};
+		// Create new messageSummary
+		var messageSummary = {
+			info:0,
+			warn:0,
+			error:0
+		};
+		// Loop trough adapters
+		for(x in $scope.adapters){
+			var adapter = $scope.adapters[x];
+			
+			// Only adapters for active config
+			if(adapter.configuration == name || name == 'All'){
+				adapterSummary[adapter.status]++;
+				
+				// Loop trough receivers of adapter
+				for(y in adapter.receivers){
+					receiverSummary[adapter.receivers[y].state]++;
+				}
+				// Loop trough messages of adapter
+				for(z in adapter.messages) {
+					messageSummary[adapter.messages[z].level.toLowerCase()]++;
+				}
+			};
+		};
+		
+		// Update the view
+		$scope.messageSummary = messageSummary
+		$scope.adapterSummary = adapterSummary;
+		$scope.receiverSummary = receiverSummary;
 		$scope.selectedConfiguration = name;
 	};
 

--- a/webapp/src/main/webapp/iaf/gui/views/ShowConfigurationStatus.html
+++ b/webapp/src/main/webapp/iaf/gui/views/ShowConfigurationStatus.html
@@ -4,9 +4,17 @@
 <div class="wrapper wrapper-content animated fadeInRight">
     <uib-alert ng-repeat="alert in alerts" type="{{alert.type}}" close="closeAlert($index)">{{alert.message}}</uib-alert>
     <div class="row">
+    	<div class="col-lg-12 tabs-container ">
+        	<ul class="nav nav-tabs" role="menu" uib-dropdown-menu="">
+                <li ng-class="{active : selectedConfiguration == 'All'}"><a ng-click="changeConfiguration('All')">All</a></li>
+                <li ng-class="{active : selectedConfiguration == configuration.name}" ng-repeat="configuration in configurations">
+                    <a ng-click="changeConfiguration(configuration.name)">{{configuration.name}}</a>
+                </li>
+            </ul> 
+        </div>
         <div class="col-lg-12">
             <div class="float-e-margins">
-                <div class="ibox-title">
+                <div class="ibox-title" style="border:none">
                     <h4>Adapter summary</h4>
                 </div>
                 <div class="ibox-content">
@@ -98,21 +106,6 @@
                                 <label class="btn btn-primary btn-outline btn-xs" ng-model="status.filter.started" ng-click="applyFilter(status.filter)" uib-btn-checkbox>Started</label>
                                 <label class="btn btn-danger btn-outline btn-xs" ng-model="status.filter.stopped" ng-click="applyFilter(status.filter)" uib-btn-checkbox>Stopped</label>
                                 <label class="btn btn-warning btn-outline btn-xs" ng-model="status.filter.warning" ng-click="applyFilter(status.filter)" uib-btn-checkbox>Warning</label>
-                            </div>
-                        </div>
-                        <div class="col-lg-5">
-                            <span style="font-weight:700;margin-right:4px;">Configuration:</span>
-                            <div class="btn-group" uib-dropdown>
-                                <button type="button" class="btn btn-default" uib-dropdown-toggle>
-                                    {{selectedConfiguration}} <span class="caret"></span>
-                                </button>
-                                <ul role="menu" uib-dropdown-menu="">
-                                    <li><a ng-click="changeConfiguration('All')">All</a></li>
-                                    <li class="divider"></li>
-                                    <li ng-repeat="configuration in configurations">
-                                        <a ng-click="changeConfiguration(configuration.name)">{{configuration.name}}</a>
-                                    </li>
-                                </ul>
                             </div>
                         </div>
                     </div>

--- a/webapp/src/main/webapp/iaf/gui/views/ShowConfigurationStatus.html
+++ b/webapp/src/main/webapp/iaf/gui/views/ShowConfigurationStatus.html
@@ -146,7 +146,7 @@
                                         </td>
                                         <td class="col-md-6" ng-if="adapter.state =='started'">
                                             <span><i class="fa fa-check-square lh22 m-r-xs"></i> Started</span>
-                                            <button style="float:right;" title="Stop adapter" ng-click="stopAdapter(adapter)" class="btn btn-xs btn-danger" type="button"><i class="fa fa-warning m-r-xs"></i> Stop adapter</button>
+                                            <button style="float:right;" title="Stop adapter" ng-click="stopAdapter(adapter)" class="btn btn-xs btn-gray" type="button"><i class="fa fa-stop m-r-xs"></i> Stop adapter</button>
                                         </td>
                                         <td class="col-md-6" ng-if="adapter.state =='stopping'">
                                             <span><i class="fa fa-stop-circle-o lh22 m-r-xs"></i> Stopping</span>
@@ -223,7 +223,7 @@
                                             <td><span ng-show="{{receiver.hasErrorStorage}}">{{receiver.errorStorageCount}}</span></td>
                                             <td>
                                                 <span class="pull-right">
-                                                    <button title="Stop receiver" class="btn btn-danger btn-xs" ng-show="receiver.state =='started'" type="button" ng-click="stopReceiver(adapter, receiver)"><i class="fa fa-stop"></i></button>
+                                                    <button title="Stop receiver" class="btn btn-gray btn-xs" ng-show="receiver.state =='started'" type="button" ng-click="stopReceiver(adapter, receiver)"><i class="fa fa-stop"></i></button>
                                                     <button title="Start receiver" class="btn btn-primary btn-xs" ng-show="receiver.state =='stopped'" type="button" ng-click="startReceiver(adapter, receiver)"><i class="fa fa-play"></i></button>
                                                     <button title="Loading..." class="btn btn-warning btn-xs" ng-show="receiver.state !='started' && receiver.state !='stopped'" type="button"><i class="fa fa-cog fa-spin"></i></button>
                                                 </span>

--- a/webapp/src/main/webapp/iaf/gui/views/ShowConfigurationStatus.html
+++ b/webapp/src/main/webapp/iaf/gui/views/ShowConfigurationStatus.html
@@ -15,7 +15,7 @@
         <div class="col-lg-12">
             <div class="float-e-margins">
                 <div class="ibox-title" style="border:none">
-                    <h4>Adapter summary</h4>
+                    <h4>Configuration summary</h4>
                 </div>
                 <div class="ibox-content">
                     <div class="row">


### PR DESCRIPTION
- Change red 'error feeling' in showConfigurationStatus to a more neutral style
- Replace dropdown configurations list with tabbed list
- Fix when switching tabs results in switching between adapter summaries
- Change adapteroverview to a more compact style
- Change adapter summary to configuration summary