### PR TITLE
Update jaxen version and add jaxws-api dependency to the core

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -527,6 +527,13 @@
 			<artifactId>org.apache.servicemix.specs.saaj-api-1.3</artifactId>
 			<version>2.9.0</version>
 		</dependency>
+		
+		<!-- https://mvnrepository.com/artifact/org.apache.servicemix.specs/org.apache.servicemix.specs.jaxws-api-2.2 -->
+		<dependency>
+			<groupId>org.apache.servicemix.specs</groupId>
+			<artifactId>org.apache.servicemix.specs.jaxws-api-2.2</artifactId>
+			<version>2.3.0</version>
+		</dependency> 
 
 		<!-- Test scoped dependencies -->
 		<dependency>

--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -45,7 +45,7 @@
     <dependency>
       <groupId>jaxen</groupId>
       <artifactId>jaxen</artifactId>
-      <version>1.1.6</version>
+      <version>1.2.0</version>
     </dependency>
     <dependency>
 		<groupId>javax.servlet</groupId>


### PR DESCRIPTION
jaxen version has been updated from 1.1.6 to 1.2.0
org.apache.servicemix.specs.jaxws-api-2.2 dependency added to the core