### PR TITLE
Move integration tests to /it folder

### DIFF
--- a/core/src/it/java/nl/nn/adapterframework/filesystems/AmazonS3FileSystemTest.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/AmazonS3FileSystemTest.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import java.util.UUID;
 

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/AmazonS3FileSystemTestHelper.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/AmazonS3FileSystemTestHelper.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import java.io.BufferedOutputStream;
 import java.io.File;

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/AmazonS3SenderTest.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/AmazonS3SenderTest.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/BasicFileSystemTestBase.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/BasicFileSystemTestBase.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/ExchangeFileSystemTest.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/ExchangeFileSystemTest.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import org.junit.Test;
 

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/FtpFileSystemSenderTest.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/FtpFileSystemSenderTest.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import org.apache.commons.net.ftp.FTPFile;
 

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/FtpFileSystemTest.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/FtpFileSystemTest.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import org.apache.commons.net.ftp.FTPFile;
 

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/FtpFileSystemTestHelper.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/FtpFileSystemTestHelper.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import java.io.FilterOutputStream;
 import java.io.IOException;

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/Samba1FileSystemTest.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/Samba1FileSystemTest.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import jcifs.smb.SmbFile;
 import nl.nn.adapterframework.filesystem.FileSystemTest;

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/SambaFileSystemSenderTest.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/SambaFileSystemSenderTest.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import jcifs.smb.SmbFile;
 import nl.nn.adapterframework.filesystem.FileSystemSenderTest;

--- a/core/src/it/java/nl/nn/adapterframework/filesystems/SambaFileSystemTestHelper.java
+++ b/core/src/it/java/nl/nn/adapterframework/filesystems/SambaFileSystemTestHelper.java
@@ -1,4 +1,4 @@
-package it.nl.nn.adapterframework.senders;
+package nl.nn.adapterframework.filesystems;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;


### PR DESCRIPTION
It did not work to move the integration tests to iaf-test, because the integration tests have
iaf-core/src/test/java as a dependency.
Therefor integration tests are moved to iaf-core/src/it/java