### PR TITLE
Added parameter BROWSER_DATETIME_FORMAT to send dates in ISO format

### DIFF
--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -74,6 +74,7 @@ import org.apache.chemistry.opencmis.commons.data.PropertyData;
 import org.apache.chemistry.opencmis.commons.data.RepositoryInfo;
 import org.apache.chemistry.opencmis.commons.enums.Action;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
+import org.apache.chemistry.opencmis.commons.enums.DateTimeFormat;
 import org.apache.chemistry.opencmis.commons.enums.VersioningState;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
 import org.apache.commons.codec.binary.Base64;
@@ -932,6 +933,8 @@ public class CmisSender extends SenderWithParametersBase {
 		} else if (getBindingType().equalsIgnoreCase("browser")) {
 			parameterMap.setBrowserBindingUrl(getUrl());
 			parameterMap.setBasicAuthentication();
+			//Add parameter dateTimeFormat to send dates in ISO format instead of milliseconds.
+			parameterMap.put(SessionParameter.BROWSER_DATETIME_FORMAT, DateTimeFormat.EXTENDED.value());			
 		} else {
 			parameterMap.setUsernameTokenAuthentication(false);
 			// OpenCMIS requires an entrypoint url (wsdl), if this url has been secured and is not publicly accessible,


### PR DESCRIPTION
By default datetime fields are send as a value in milleseconds. This leads to differences in time if the client is in a different timezone than the server. To fix this problem, the datetime fields have to be send in ISO format. This is done by setting the BROWSER_DATETIME_FORMAT to EXTENDED.