### PR TITLE
Fix empty String handling in XML to JSON conversion

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/align/ScalarType.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/ScalarType.java
@@ -1,0 +1,21 @@
+package nl.nn.adapterframework.align;
+
+import org.apache.xerces.impl.dv.XSSimpleType;
+import org.apache.xerces.xs.XSConstants;
+
+public enum ScalarType {
+	UNKNOWN,NUMERIC,BOOLEAN,STRING;
+	
+	public static ScalarType findType(XSSimpleType simpleType) {
+		if (simpleType==null) {
+			return UNKNOWN;
+		}
+		if (simpleType.getNumeric()) {
+			return NUMERIC;
+		}
+		if (simpleType.getBuiltInKind()==XSConstants.BOOLEAN_DT) {
+			return BOOLEAN;
+		}
+		return STRING;
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/align/XmlTo.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/XmlTo.java
@@ -135,18 +135,11 @@ public class XmlTo<C extends DocumentContainer> extends XMLFilterImpl {
 	@Override
 	public void characters(char[] ch, int start, int length) throws SAXException {
 		XSSimpleType simpleType=aligner.getElementType();
-		boolean numericType=false;
-		boolean booleanType=false;
+		ScalarType scalarType=ScalarType.findType(simpleType);
 		if (simpleType!=null) {
-			if (DEBUG) log.debug("characters for SimpleType ["+new String(ch,start,length)+"]");
-			if (simpleType.getNumeric()) {
-				numericType=true;
-			}
-			if (simpleType.getBuiltInKind()==XSConstants.BOOLEAN_DT) {
-				booleanType=true;
-			}
+			if (DEBUG) log.debug("SimpleType ["+simpleType+"] ScalarType ["+scalarType+"] characters ["+new String(ch,start,length)+"]");
 		}
-		documentContainer.characters(ch, start, length, numericType, booleanType);
+		documentContainer.characters(ch, start, length);
 		super.characters(ch, start, length);
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/align/XmlTo.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/XmlTo.java
@@ -136,8 +136,8 @@ public class XmlTo<C extends DocumentContainer> extends XMLFilterImpl {
 	public void characters(char[] ch, int start, int length) throws SAXException {
 		XSSimpleType simpleType=aligner.getElementType();
 		ScalarType scalarType=ScalarType.findType(simpleType);
-		if (simpleType!=null) {
-			if (DEBUG) log.debug("SimpleType ["+simpleType+"] ScalarType ["+scalarType+"] characters ["+new String(ch,start,length)+"]");
+		if (DEBUG && simpleType!=null) {
+			log.debug("SimpleType ["+simpleType+"] ScalarType ["+scalarType+"] characters ["+new String(ch,start,length)+"]");
 		}
 		documentContainer.characters(ch, start, length);
 		super.characters(ch, start, length);

--- a/core/src/main/java/nl/nn/adapterframework/align/content/ElementContainer.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/content/ElementContainer.java
@@ -21,5 +21,5 @@ public interface ElementContainer {
 
 	public void setNull();
 	public void setAttribute(String Name, String value, XSSimpleTypeDefinition attTypeDefinition);
-	public void characters(char[] ch, int start, int length, boolean numericType, boolean booleanType);
+	public void characters(char[] ch, int start, int length);
 }

--- a/core/src/main/java/nl/nn/adapterframework/align/content/JsonDocumentContainer.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/content/JsonDocumentContainer.java
@@ -23,6 +23,7 @@ import javax.json.stream.JsonGenerator;
 
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.log4j.Logger;
+import org.apache.xerces.xs.XSTypeDefinition;
 
 /**
  * Helper class to construct JSON from XML events.
@@ -49,8 +50,8 @@ public class JsonDocumentContainer extends TreeContentContainer<JsonElementConta
 	}
 	
 	@Override
-	protected JsonElementContainer createElementContainer(String localName, boolean xmlArrayContainer, boolean repeatedElement) {
-		return new JsonElementContainer(localName, xmlArrayContainer, repeatedElement, skipArrayElementContainers, attributePrefix);
+	protected JsonElementContainer createElementContainer(String localName, boolean xmlArrayContainer, boolean repeatedElement, XSTypeDefinition typeDefinition) {
+		return new JsonElementContainer(localName, xmlArrayContainer, repeatedElement, skipArrayElementContainers, attributePrefix, typeDefinition);
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/align/content/JsonElementContainer.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/content/JsonElementContainer.java
@@ -25,7 +25,11 @@ import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
 import org.apache.commons.lang3.text.translate.EntityArrays;
 import org.apache.commons.lang3.text.translate.LookupTranslator;
 import org.apache.log4j.Logger;
+import org.apache.xerces.impl.dv.XSSimpleType;
 import org.apache.xerces.xs.XSSimpleTypeDefinition;
+import org.apache.xerces.xs.XSTypeDefinition;
+
+import nl.nn.adapterframework.align.ScalarType;
 
 /**
  * Helper class to construct JSON from XML events.
@@ -40,8 +44,7 @@ public class JsonElementContainer implements ElementContainer {
 	private boolean repeatedElement;
 	private boolean skipArrayElementContainers;
 	private boolean nil=false;
-	private boolean bool=false;
-	private boolean numeric=false;
+	private ScalarType type=ScalarType.UNKNOWN;
 	private String attributePrefix;
 
 	public String stringContent;
@@ -50,12 +53,15 @@ public class JsonElementContainer implements ElementContainer {
 	
 	private final boolean DEBUG=false;
 	
-	public JsonElementContainer(String name, boolean xmlArrayContainer, boolean repeatedElement, boolean skipArrayElementContainers, String attributePrefix) {
+	public JsonElementContainer(String name, boolean xmlArrayContainer, boolean repeatedElement, boolean skipArrayElementContainers, String attributePrefix, XSTypeDefinition typeDefinition) {
 		this.name=name;
 		this.xmlArrayContainer=xmlArrayContainer;
 		this.repeatedElement=repeatedElement;
 		this.skipArrayElementContainers=skipArrayElementContainers;
 		this.attributePrefix=attributePrefix;
+		if (typeDefinition instanceof XSSimpleType) {
+			setType(ScalarType.findType(((XSSimpleType)typeDefinition)));
+		}
 	}
 	
 	public static final CharSequenceTranslator ESCAPE_JSON = new AggregateTranslator(new CharSequenceTranslator[] {
@@ -69,22 +75,13 @@ public class JsonElementContainer implements ElementContainer {
 
 	@Override
 	public void setAttribute(String name, String value, XSSimpleTypeDefinition attTypeDefinition) {
-		JsonElementContainer attributeContainer = new JsonElementContainer(attributePrefix+name, false, false, false, attributePrefix);
-		if (attTypeDefinition.getNumeric()) {
-			attributeContainer.setNumeric(true);
-		}
+		JsonElementContainer attributeContainer = new JsonElementContainer(attributePrefix+name, false, false, false, attributePrefix, attTypeDefinition);
 		attributeContainer.setContent(value);
 		addContent(attributeContainer);
 	}
 
 	@Override
-	public void characters(char[] ch, int start, int length, boolean numericType, boolean booleanType) {
-		if (numericType) {
-			setNumeric(true);
-		}
-		if (booleanType) {
-			setBool(true);
-		}
+	public void characters(char[] ch, int start, int length) {
 		setContent(new String(ch,start,length));
 	}
 
@@ -136,8 +133,7 @@ public class JsonElementContainer implements ElementContainer {
 		if (isXmlArrayContainer() && content.isRepeatedElement() && skipArrayElementContainers) {
 			if (array==null) {
 				array=new LinkedList<Object>();
-				setNumeric(content.isNumeric());
-				setBool(content.isBool());
+				setType(content.getType());
 			} 
 			array.add(content.getContent());
 			return;
@@ -186,16 +182,17 @@ public class JsonElementContainer implements ElementContainer {
 			return null;
 		}
 		if (stringContent!=null) {
-			if (isBool()) {
+	        switch (getType()) {
+	        case BOOLEAN:
 				return stringContent;
-			}
-			if (isNumeric()) {
+	        case NUMERIC:
 				return stripLeadingZeroes(stringContent);
-			}
-			if (DEBUG) log.debug("getContent quoted stringContent ["+stringContent+"]");
+			default:
+				if (DEBUG) log.debug("getContent quoted stringContent ["+stringContent+"]");
 //				String result=StringEscapeUtils.escapeJson(stringContent.toString()); // this also converts diacritics into unicode escape sequences
-			String result=ESCAPE_JSON.translate(stringContent.toString()); 
-			return '"'+result+'"';
+				String result=ESCAPE_JSON.translate(stringContent.toString()); 
+				return '"'+result+'"';
+			}
 		}
 		if (array!=null) {
 			return array;
@@ -205,6 +202,9 @@ public class JsonElementContainer implements ElementContainer {
 		}
 		if (isXmlArrayContainer() && skipArrayElementContainers) {
 			return "[]";
+		}
+		if (getType()==ScalarType.STRING) {
+			return "\"\"";
 		}
 		return "{}";
 	}
@@ -220,19 +220,11 @@ public class JsonElementContainer implements ElementContainer {
 		return repeatedElement;
 	}
 
-	public boolean isBool() {
-		return bool;
+	public ScalarType getType() {
+		return type;
 	}
-	public void setBool(boolean bool) {
-		this.bool = bool;
-	}
-
-	public boolean isNumeric() {
-		return numeric;
-	}
-	public void setNumeric(boolean numeric) {
-		this.numeric = numeric;
+	public void setType(ScalarType type) {
+		this.type = type;
 	}
 
-	
 }

--- a/core/src/main/java/nl/nn/adapterframework/align/content/MapContentContainer.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/content/MapContentContainer.java
@@ -83,7 +83,7 @@ public class MapContentContainer<V> implements DocumentContainer {
 	}
 
 	@Override
-	public void characters(char[] ch, int start, int length, boolean numericType, boolean booleanType) {
+	public void characters(char[] ch, int start, int length) {
 		String rawValue=new String(ch,start,length);
 		if (currentName==null) {
 			if (rawValue.trim().length()>0) {

--- a/core/src/main/java/nl/nn/adapterframework/align/content/MapContentContainer.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/content/MapContentContainer.java
@@ -11,8 +11,11 @@ import org.apache.commons.lang3.text.translate.CharSequenceTranslator;
 import org.apache.commons.lang3.text.translate.EntityArrays;
 import org.apache.commons.lang3.text.translate.LookupTranslator;
 import org.apache.log4j.Logger;
+import org.apache.xerces.impl.dv.XSSimpleType;
 import org.apache.xerces.xs.XSSimpleTypeDefinition;
 import org.apache.xerces.xs.XSTypeDefinition;
+
+import nl.nn.adapterframework.align.ScalarType;
 
 public class MapContentContainer<V> implements DocumentContainer {
 	protected Logger log = Logger.getLogger(this.getClass());
@@ -25,6 +28,7 @@ public class MapContentContainer<V> implements DocumentContainer {
 	private String currentName;
 	private String currentValue;
 	boolean currentIsNull;
+	private ScalarType type=ScalarType.UNKNOWN;
 	
 	public MapContentContainer(Map<String,List<V>> data) {
 		super();
@@ -45,21 +49,27 @@ public class MapContentContainer<V> implements DocumentContainer {
 	}
 	
 	@Override
-	public void startElement(String localName, boolean xmlArrayContainer, boolean repeatedElement,
-			XSTypeDefinition typeDefinition) {
+	public void startElement(String localName, boolean xmlArrayContainer, boolean repeatedElement, XSTypeDefinition typeDefinition) {
 		currentName=localName;
 		currentValue=null;
 		currentIsNull=false;
+		if (typeDefinition instanceof XSSimpleType) {
+			type=(ScalarType.findType(((XSSimpleType)typeDefinition)));
+		}
 	}
 
 	protected void setValue(String name, V value, boolean isNull) {
-		if (value!=null || isNull) {
+		if (value!=null || isNull || type==ScalarType.STRING) {
 			List<V> entry=data.get(name);
 			if (entry==null) {
 				entry=new ArrayList<V>();
 				data.put(name, entry);
 			}
-			entry.add(value);
+			if (value==null && !isNull && type==ScalarType.STRING) {
+				entry.add(stringToValue(""));
+			} else {
+				entry.add(value);
+			}
 		}
 	}
 	
@@ -69,6 +79,7 @@ public class MapContentContainer<V> implements DocumentContainer {
 		currentValue=null;
 		currentIsNull=false;
 		currentName=null;
+		type=null;
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/align/content/TreeContentContainer.java
+++ b/core/src/main/java/nl/nn/adapterframework/align/content/TreeContentContainer.java
@@ -23,10 +23,10 @@ import org.apache.xerces.xs.XSTypeDefinition;
 public abstract class TreeContentContainer<E extends ElementContainer> implements DocumentContainer {
 
 	private Stack<E> elementStack=new Stack<E>(); 
-	private E root=createElementContainer(null, false, false);
+	private E root=createElementContainer(null, false, false, null);
 	private E elementContainer=root;
 
-	protected abstract E createElementContainer(String localName, boolean xmlArrayContainer, boolean repeatedElement);
+	protected abstract E createElementContainer(String localName, boolean xmlArrayContainer, boolean repeatedElement, XSTypeDefinition typeDefinition);
 	protected abstract void addContent(E parent, E child);
 
 	@Override
@@ -40,7 +40,7 @@ public abstract class TreeContentContainer<E extends ElementContainer> implement
 	@Override
 	public void startElement(String localName, boolean xmlArrayContainer, boolean repeatedElement, XSTypeDefinition typeDefinition) {
 		elementStack.push(elementContainer);
-		elementContainer=createElementContainer(localName, xmlArrayContainer, repeatedElement);
+		elementContainer=createElementContainer(localName, xmlArrayContainer, repeatedElement, typeDefinition);
 	}
 	@Override
 	public void endElement(String localName) {
@@ -60,8 +60,8 @@ public abstract class TreeContentContainer<E extends ElementContainer> implement
 	}
 
 	@Override
-	public void characters(char[] ch, int start, int length, boolean numericType, boolean booleanType) {
-		elementContainer.characters(ch, start, length, numericType, booleanType);
+	public void characters(char[] ch, int start, int length) {
+		elementContainer.characters(ch, start, length);
 	}
 	public E getRoot() {
 		return root;

--- a/core/src/test/resources/Align/DataTypes/Strings-compact.json
+++ b/core/src/test/resources/Align/DataTypes/Strings-compact.json
@@ -1,5 +1,7 @@
 {
   "Strings": [
-    "tja"
+    "tja",
+    "",
+    "och"
   ]
 }

--- a/core/src/test/resources/Align/DataTypes/Strings-full.json
+++ b/core/src/test/resources/Align/DataTypes/Strings-full.json
@@ -2,7 +2,9 @@
   "DataTypes": {
     "Strings": {
       "String": [
-        "tja"
+        "tja",
+        "",
+        "och"
       ]
     }
   }

--- a/core/src/test/resources/Align/DataTypes/Strings.properties
+++ b/core/src/test/resources/Align/DataTypes/Strings.properties
@@ -1,1 +1,1 @@
-String=tja
+String=tja,och

--- a/core/src/test/resources/Align/DataTypes/Strings.properties
+++ b/core/src/test/resources/Align/DataTypes/Strings.properties
@@ -1,1 +1,1 @@
-String=tja,och
+String=tja,,och

--- a/core/src/test/resources/Align/DataTypes/Strings.xml
+++ b/core/src/test/resources/Align/DataTypes/Strings.xml
@@ -2,5 +2,7 @@
 <DataTypes xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:datatypes DataTypes.xsd" xmlns="urn:datatypes">
 	<Strings>
 		<String>tja</String>
+		<String></String>
+		<String>och</String>
 	</Strings>
 </DataTypes>


### PR DESCRIPTION
Avoid empty strings being rendered as '{}', but render them as proper empty strings