### PR TITLE
Update IbisTester: change validation of resultString

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/extensions/test/IbisTester.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/test/IbisTester.java
@@ -327,7 +327,7 @@ public class IbisTester {
 					error(scenarioInfo + " failed");
 				} else {
 					if (result.resultString != null
-						&& (result.resultString.contains("passed")
+						&& result.resultString.contains("passed")
 					) {
 						debug(scenarioInfo + " passed in [" + result.duration
 								+ "] msec");

--- a/core/src/main/java/nl/nn/adapterframework/extensions/test/IbisTester.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/test/IbisTester.java
@@ -327,9 +327,8 @@ public class IbisTester {
 					error(scenarioInfo + " failed");
 				} else {
 					if (result.resultString != null
-							&& (result.resultString.endsWith("passed")
-									|| result.resultString.endsWith("passed after autosave"))
-							) {
+						&& (result.resultString.contains("passed")
+					) {
 						debug(scenarioInfo + " passed in [" + result.duration
 								+ "] msec");
 						scenariosPassed++;


### PR DESCRIPTION
When running scripted tests, the resultString contains a valid value ("All scenarios passed") which was not evaluated as true.
Instead of adding another endsWith method, changed the method endsWith to contains, so all valid scenarios are evaluated as true.