### PR TITLE
Solve several cmis issues

### DIFF
--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisSender.java
@@ -738,8 +738,10 @@ public class CmisSender extends SenderWithParametersBase {
 					processProperties(propertiesElement, props);
 				}
 
+				ObjectId folderId = null;
 				String folderIdstr = XmlUtils.getChildTagAsString(requestElement, "folderId");
-				ObjectId folderId = session.createObjectId(folderIdstr);
+				if(StringUtils.isNotEmpty(folderIdstr))
+					folderId = session.createObjectId(folderIdstr);
 
 				String versioningStatestr = XmlUtils.getChildTagAsString(requestElement, "versioningState");
 				VersioningState state = VersioningState.valueOf(versioningStatestr);

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/CmisEventDispatcher.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/CmisEventDispatcher.java
@@ -28,6 +28,7 @@ import nl.nn.adapterframework.core.ListenerException;
 import nl.nn.adapterframework.core.PipeLineSessionBase;
 import nl.nn.adapterframework.core.PipeRunException;
 import nl.nn.adapterframework.extensions.cmis.CmisEventListener;
+import nl.nn.adapterframework.extensions.cmis.CmisUtils;
 import nl.nn.adapterframework.util.DomBuilderException;
 import nl.nn.adapterframework.util.XmlUtils;
 
@@ -59,6 +60,8 @@ public class CmisEventDispatcher {
 	}
 
 	public Element trigger(CmisEvent event, String message, IPipeLineSession messageContext) {
+		CmisUtils.populateCmisAttributes(messageContext);
+
 		if(!eventListeners.containsKey(event))
 			throw new CmisRuntimeException("event ["+event.toString()+"] not found");
 

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/CmisSecurityHandler.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/CmisSecurityHandler.java
@@ -1,0 +1,64 @@
+/*
+   Copyright 2019 Nationale-Nederlanden
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package nl.nn.adapterframework.extensions.cmis.server;
+
+import java.security.Principal;
+
+import org.apache.chemistry.opencmis.commons.server.CallContext;
+import org.apache.commons.lang.NotImplementedException;
+
+import nl.nn.adapterframework.core.IPipeLineSession;
+import nl.nn.adapterframework.core.ISecurityHandler;
+import nl.nn.adapterframework.util.CredentialFactory;
+
+/**
+ * Wraps the CMIS SecurityContext in an ISecurityHandler.
+ * 
+ * @author Niels Meijer
+ *
+ */
+public class CmisSecurityHandler implements ISecurityHandler {
+
+	private CredentialFactory credentials = null;
+
+	public CmisSecurityHandler(CallContext callContext) {
+		this.credentials = new CredentialFactory(null, callContext.getUsername(), callContext.getPassword());
+	}
+
+	@Override
+	public boolean isUserInRole(String role, IPipeLineSession session) throws NotImplementedException {
+		return false;
+	}
+
+	@Override
+	public Principal getPrincipal(IPipeLineSession session) throws NotImplementedException {
+
+		return new Principal() {
+			@Override
+			public String getName() {
+				return getCredentials().getUsername();
+			}
+		};
+	}
+
+	/**
+	 * Can be used to authenticate the user against another system or pass the authentication context through.
+	 * @return the user's credentials wrapped in a {@link CredentialFactory}
+	 */
+	public CredentialFactory getCredentials() {
+		return credentials;
+	}
+}

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/HttpSessionCmisService.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/HttpSessionCmisService.java
@@ -44,6 +44,7 @@ public class HttpSessionCmisService extends CachedBindingCmisService {
 
 	private static final long serialVersionUID = 1L;
 	private final Logger log = LogUtil.getLogger(this);
+	public static ThreadLocal<CallContext> callContext = new ThreadLocal<CallContext>();
 
 	/** Key in the HTTP session. **/
 	public static final String CMIS_BINDING = "org.apache.chemistry.opencmis.bridge.binding";
@@ -52,8 +53,7 @@ public class HttpSessionCmisService extends CachedBindingCmisService {
 
 	public HttpSessionCmisService(CallContext context) {
 		setCallContext(context);
-//		context.getUsername();
-//		context.getPassword();
+		callContext.set(context);
 	}
 
 	@Override
@@ -123,7 +123,7 @@ public class HttpSessionCmisService extends CachedBindingCmisService {
 
 			//Only always grab the first value because we explicitly check method.getParameterTypes().length != 1
 			Object castValue = getCastValue(method.getParameterTypes()[0], value);
-			log.debug("trying to set property ["+PROPERTY_PREFIX+setter+"] with value ["+value+"] of type ["+castValue.getClass().getCanonicalName()+"] on ["+sessionBuilder.toString()+"]");
+			log.debug("trying to set property ["+PROPERTY_PREFIX+setter+"] with value ["+value+"] of type ["+castValue.getClass().getCanonicalName()+"] on ["+sessionBuilder+"]");
 
 			try {
 				method.invoke(sessionBuilder, castValue);
@@ -163,7 +163,7 @@ public class HttpSessionCmisService extends CachedBindingCmisService {
 
 	@Override
 	public RepositoryService getRepositoryService() {
-		return new IbisRepositoryService(super.getRepositoryService(), getCallContext().getCmisVersion());
+		return new IbisRepositoryService(super.getRepositoryService());
 	}
 
 	@Override

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/impl/IbisDiscoveryService.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/impl/IbisDiscoveryService.java
@@ -68,8 +68,8 @@ public class IbisDiscoveryService implements DiscoveryService {
 			Holder<String> changeLogToken, Boolean includeProperties,
 			String filter, Boolean includePolicyIds, Boolean includeAcl,
 			BigInteger maxItems, ExtensionsData extension) {
-		// TODO Auto-generated method stub
-		return null;
+
+		return discoveryService.getContentChanges(repositoryId, changeLogToken, includeProperties, filter, includePolicyIds, includeAcl, maxItems, extension);
 	}
 	
 }

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/impl/IbisRepositoryService.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/server/impl/IbisRepositoryService.java
@@ -22,6 +22,7 @@ import java.util.List;
 import nl.nn.adapterframework.extensions.cmis.CmisUtils;
 import nl.nn.adapterframework.extensions.cmis.server.CmisEvent;
 import nl.nn.adapterframework.extensions.cmis.server.CmisEventDispatcher;
+import nl.nn.adapterframework.extensions.cmis.server.HttpSessionCmisService;
 import nl.nn.adapterframework.util.XmlBuilder;
 import nl.nn.adapterframework.util.XmlUtils;
 
@@ -31,6 +32,7 @@ import org.apache.chemistry.opencmis.commons.definitions.TypeDefinition;
 import org.apache.chemistry.opencmis.commons.definitions.TypeDefinitionContainer;
 import org.apache.chemistry.opencmis.commons.definitions.TypeDefinitionList;
 import org.apache.chemistry.opencmis.commons.enums.CmisVersion;
+import org.apache.chemistry.opencmis.commons.server.CallContext;
 import org.apache.chemistry.opencmis.commons.spi.RepositoryService;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
@@ -39,15 +41,18 @@ public class IbisRepositoryService implements RepositoryService {
 
 	private RepositoryService repositoryService;
 	private CmisEventDispatcher eventDispatcher = CmisEventDispatcher.getInstance();
-	private CmisVersion cmisVersion = CmisVersion.CMIS_1_1;
 
 	public IbisRepositoryService(RepositoryService repositoryService) {
 		this.repositoryService = repositoryService;
 	}
 
-	public IbisRepositoryService(RepositoryService repositoryService, CmisVersion cmisVersion) {
-		this.repositoryService = repositoryService;
-		this.cmisVersion = cmisVersion;
+	private CmisVersion getCmisVersion() {
+		CallContext context = HttpSessionCmisService.callContext.get();
+		if(context != null) {
+			return HttpSessionCmisService.callContext.get().getCmisVersion();
+		}
+
+		return CmisVersion.CMIS_1_1;
 	}
 
 	private XmlBuilder buildXml(String name, Object value) {
@@ -120,7 +125,7 @@ public class IbisRepositoryService implements RepositoryService {
 			Element cmisResult = eventDispatcher.trigger(CmisEvent.GET_TYPE_DESCENDANTS, cmisXml.toXML());
 			Element typesXml = XmlUtils.getFirstChildTag(cmisResult, "typeDescendants");
 
-			return CmisUtils.xml2TypeDescendants(typesXml, cmisVersion);
+			return CmisUtils.xml2TypeDescendants(typesXml, getCmisVersion());
 		}
 	}
 
@@ -139,7 +144,7 @@ public class IbisRepositoryService implements RepositoryService {
 
 			Element typesXml = XmlUtils.getFirstChildTag(cmisResult, "typeDefinitions");
 
-			return CmisUtils.xml2TypeDefinition(XmlUtils.getFirstChildTag(typesXml, "typeDefinition"), cmisVersion);
+			return CmisUtils.xml2TypeDefinition(XmlUtils.getFirstChildTag(typesXml, "typeDefinition"), getCmisVersion());
 		}
 	}
 

--- a/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/CmisTestObject.java
+++ b/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/CmisTestObject.java
@@ -34,6 +34,7 @@ import org.apache.chemistry.opencmis.commons.enums.AclPropagation;
 import org.apache.chemistry.opencmis.commons.enums.Action;
 import org.apache.chemistry.opencmis.commons.enums.BaseTypeId;
 import org.apache.chemistry.opencmis.commons.enums.ExtensionLevel;
+import org.apache.chemistry.opencmis.commons.enums.PropertyType;
 import org.apache.chemistry.opencmis.commons.enums.VersioningState;
 import org.mockito.Mockito;
 
@@ -51,20 +52,24 @@ public class CmisTestObject extends Mockito implements Document {
 		Property<String> pName = mock(Property.class);
 		when(pName.getId()).thenReturn("cmis:name");
 		when(pName.getFirstValue()).thenReturn("dummy");
+		when(pName.getType()).thenReturn(PropertyType.ID);
 		list.add(pName);
 		
 		Property<BigInteger> pProjectNumber = mock(Property.class);
+		when(pProjectNumber.getType()).thenReturn(PropertyType.INTEGER);
 		when(pProjectNumber.getId()).thenReturn("project:number");
 		when(pProjectNumber.getFirstValue()).thenReturn(new BigInteger("123456789"));
 		list.add(pProjectNumber);
 		
 		Property<GregorianCalendar> pLastModified = mock(Property.class);
+		when(pLastModified.getType()).thenReturn(PropertyType.DATETIME);
 		when(pLastModified.getId()).thenReturn("project:lastModified");
 		when(pLastModified.getFirstValue()).thenReturn(new GregorianCalendar(2019, 1, 26, 16, 31, 15));
 		list.add(pLastModified);
 		
 		Property<Boolean> pOnTime = mock(Property.class);
 		when(pOnTime.getId()).thenReturn("project:onTime");
+		when(pOnTime.getType()).thenReturn(PropertyType.BOOLEAN);
 		when(pOnTime.getFirstValue()).thenReturn(true);
 		list.add(pOnTime);
 		

--- a/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/TestBindingTypes.java
+++ b/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/TestBindingTypes.java
@@ -59,7 +59,7 @@ public class TestBindingTypes extends SenderBase<CmisSender>{
 			"	<includeAcl>true</includeAcl> </query>";
 	private final static String FIND_RESULT = "<cmis totalNumItems=\"0\">  <rowset /></cmis>";
 	private final static String FETCH_RESULT = "<cmis>  <properties>    "
-			+ "<property name=\"cmis:name\">dummy</property>    "
+			+ "<property name=\"cmis:name\" type=\"id\">dummy</property>    "
 			+ "<property name=\"project:number\" type=\"integer\">123456789</property>    "
 			+ "<property name=\"project:lastModified\" type=\"datetime\">2019-02-26T16:31:15</property>    "
 			+ "<property name=\"project:onTime\" type=\"boolean\">true</property>  "

--- a/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/TestGetAction.java
+++ b/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/TestGetAction.java
@@ -50,7 +50,7 @@ public class TestGetAction extends SenderBase<CmisSender>{
 	private final static String GET_RESULT_TO_SERVLET= "";
 
 	private final static String GET_RESULT_FOR_GET_PROPERTIES = "<cmis><properties>"
-			+ "<property name=\"cmis:name\">dummy</property>"
+			+ "<property name=\"cmis:name\" type=\"id\">dummy</property>"
 			+ "<property name=\"project:number\" type=\"integer\">123456789</property>"
 			+ "<property name=\"project:lastModified\" type=\"datetime\">2019-02-26T16:31:15</property>"
 			+ "<property name=\"project:onTime\" type=\"boolean\">true</property></properties></cmis>";


### PR DESCRIPTION
Add CmisSecurityHandler available to the pipeline

Implement DiscoveryService.getContentChanges
Return property types when no value has been supplied
Remove some unnecessarily logging

Bugfix make folder optional when creating new document
Bugfix NPE when cmis object has no baseTypeId
Bugfix display,local and query where not returned in cmis properties