### PR TITLE
Change JavascriptSender Larva test scenario

### DIFF
--- a/test/src/main/configurations/MainConfig/ConfigurationJavascript.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationJavascript.xml
@@ -90,11 +90,8 @@
 						engineName="J2V8">
 						<param name="x" type="integer" sessionKey="originalMessage"/>
 						<param name="y" type="integer" value="2"/>
-						<sender name = "file"
-							className="nl.nn.adapterframework.senders.FileSender"
-							directory= "."
-							actions= "write_append, delete"
-							fileName="WriteFile.txt">
+						<sender name = "echoFunction"
+							className="nl.nn.adapterframework.senders.EchoSender">
 						</sender>
 					</sender>
 				<forward name="success" path="EXIT" />

--- a/test/src/main/configurations/MainConfig/JavaScript/JavascriptTest.js
+++ b/test/src/main/configurations/MainConfig/JavaScript/JavascriptTest.js
@@ -14,7 +14,8 @@ function f4(x,y) {
 }
 
 function f5(x, y){
-	file("Hello World!");
-	
-	return "FileSender";
+	var a = x * y;
+	var b = echoFunction(a);
+
+	return b;
 }

--- a/test/src/test/testtool/JavascriptSender/scenario03/step02.txt
+++ b/test/src/test/testtool/JavascriptSender/scenario03/step02.txt
@@ -1,1 +1,1 @@
-FileSender
+20


### PR DESCRIPTION
Changed the JavascriptSender Callback Larva test scenario to call and use the EchoSender instead of the FileSender. This is done to simplify
the test scenario and avoid potential write permission errors.