### PR TITLE
Changed the web.contextpath property.

### DIFF
--- a/test/src/main/configurations/HTTP/ConfigurationHttpListenerSender.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationHttpListenerSender.xml
@@ -27,7 +27,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/HttpListener?service=LocalHttpListener"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListener"
 					inputMessageParam="request" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -62,7 +62,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/HttpListener?service=LocalHttpListenerTimeout"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListenerTimeout"
 					timeout="1000" inputMessageParam="request" />
 				<forward name="timeout" path="error_timeout" />
 				<forward name="success" path="EXIT" />

--- a/test/src/main/configurations/HTTP/ConfigurationHttpListenerSender.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationHttpListenerSender.xml
@@ -27,7 +27,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListener"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/HttpListener?service=LocalHttpListener"
 					inputMessageParam="request" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -62,7 +62,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListenerTimeout"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/HttpListener?service=LocalHttpListenerTimeout"
 					timeout="1000" inputMessageParam="request" />
 				<forward name="timeout" path="error_timeout" />
 				<forward name="success" path="EXIT" />

--- a/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
@@ -51,7 +51,7 @@
 			<pipe name="callRest"
 				className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
-					methodType="POST" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc"
+					methodType="POST" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc"
 					paramsInUrl="false" multipart="true">
 					<param name="key01" value="every cloud has a silver lining" />
 					<param name="key02" sessionKey="originalMessage" />
@@ -151,7 +151,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc" />
+					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc" />
 				<param name="docId" sessionKey="docId" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -190,7 +190,7 @@
 			<pipe name="getUrl" className="nl.nn.adapterframework.pipes.XsltPipe"
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc2" />
+					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc2" />
 				<param name="docId" xpathExpression="id" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -258,7 +258,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc3" />
+					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc3" />
 				<param name="docId" value="0" />
 				<forward name="success" path="callRest" />
 			</pipe>

--- a/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
@@ -51,7 +51,7 @@
 			<pipe name="callRest"
 				className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
-					methodType="POST" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc"
+					methodType="POST" url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc"
 					paramsInUrl="false" multipart="true">
 					<param name="key01" value="every cloud has a silver lining" />
 					<param name="key02" sessionKey="originalMessage" />
@@ -151,7 +151,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc" />
+					value="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc" />
 				<param name="docId" sessionKey="docId" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -190,7 +190,7 @@
 			<pipe name="getUrl" className="nl.nn.adapterframework.pipes.XsltPipe"
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc2" />
+					value="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc2" />
 				<param name="docId" xpathExpression="id" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -258,7 +258,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc3" />
+					value="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc3" />
 				<param name="docId" value="0" />
 				<forward name="success" path="callRest" />
 			</pipe>

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSender.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSender.xml
@@ -28,7 +28,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					soap="false"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
@@ -105,7 +105,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -127,7 +127,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_error"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" 
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -154,7 +154,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -164,7 +164,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -206,7 +206,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -216,7 +216,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -227,7 +227,7 @@
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -238,7 +238,7 @@
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -250,7 +250,7 @@
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -262,7 +262,7 @@
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -272,7 +272,7 @@
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -283,7 +283,7 @@
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -294,7 +294,7 @@
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSender.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSender.xml
@@ -28,7 +28,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					soap="false"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
@@ -105,7 +105,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -127,7 +127,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_error"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter" 
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -154,7 +154,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -164,7 +164,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -206,7 +206,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -216,7 +216,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -227,7 +227,7 @@
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -238,7 +238,7 @@
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -250,7 +250,7 @@
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -262,7 +262,7 @@
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -272,7 +272,7 @@
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -283,7 +283,7 @@
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -294,7 +294,7 @@
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAddress.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAddress.xml
@@ -64,7 +64,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -84,7 +84,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_error/address" 
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_error/address" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -110,7 +110,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -119,7 +119,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -160,7 +160,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -169,7 +169,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -179,7 +179,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -189,7 +189,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -200,7 +200,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.ForEachChildElementPipe"
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -211,7 +211,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -220,7 +220,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -230,7 +230,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -240,7 +240,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAddress.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAddress.xml
@@ -64,7 +64,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -84,7 +84,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_error/address" 
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_error/address" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -110,7 +110,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -119,7 +119,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -160,7 +160,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -169,7 +169,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -179,7 +179,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -189,7 +189,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -200,7 +200,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.ForEachChildElementPipe"
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -211,7 +211,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -220,7 +220,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -230,7 +230,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -240,7 +240,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws_timeout/address"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws_timeout/address"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
@@ -109,7 +109,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" paramsInUrl="false" inputMessageParam="file"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws/address/attachments" multipart="true"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments" multipart="true"
 					allowSelfSignedCertificates="true" verifyHostname="false" mtomEnabled="true"
 				/>
 				<param name='file' value="&lt;xml&gt;I just sent some text! :)&lt;/xml&gt;"/>
@@ -149,7 +149,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" paramsInUrl="false" inputMessageParam="file"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws/address/attachments/multipart" multipart="true"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments/multipart" multipart="true"
 					allowSelfSignedCertificates="true" verifyHostname="false" mtomEnabled="true" multipartXmlSessionKey="multipart"
 				/>
 				<forward name="success" path="EXIT" />
@@ -172,7 +172,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" 
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws/address/attachments/returning"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments/returning"
 					allowSelfSignedCertificates="true" verifyHostname="false" multipartResponse="true"
 				/>
 				<forward name="success" path="WriteStream" />
@@ -205,7 +205,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" 
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/services/urn/ws/address/attachments/returning/sessionkey"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments/returning/sessionkey"
 					allowSelfSignedCertificates="true" verifyHostname="false" multipartResponse="true"
 				/>
 				<forward name="success" path="WriteStream" />

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
@@ -109,7 +109,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" paramsInUrl="false" inputMessageParam="file"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments" multipart="true"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments" multipart="true"
 					allowSelfSignedCertificates="true" verifyHostname="false" mtomEnabled="true"
 				/>
 				<param name='file' value="&lt;xml&gt;I just sent some text! :)&lt;/xml&gt;"/>
@@ -149,7 +149,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" paramsInUrl="false" inputMessageParam="file"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments/multipart" multipart="true"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments/multipart" multipart="true"
 					allowSelfSignedCertificates="true" verifyHostname="false" mtomEnabled="true" multipartXmlSessionKey="multipart"
 				/>
 				<forward name="success" path="EXIT" />
@@ -172,7 +172,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" 
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments/returning"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments/returning"
 					allowSelfSignedCertificates="true" verifyHostname="false" multipartResponse="true"
 				/>
 				<forward name="success" path="WriteStream" />
@@ -205,7 +205,7 @@
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender" 
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}services/urn/ws/address/attachments/returning/sessionkey"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments/returning/sessionkey"
 					allowSelfSignedCertificates="true" verifyHostname="false" multipartResponse="true"
 				/>
 				<forward name="success" path="WriteStream" />

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
@@ -30,7 +30,7 @@
 				<forward name="success" path="Send2WS" />
 			</pipe>
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe" name="Send2WS">
-				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
+				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
 				<forward name="success" path="EXIT" />
 			</pipe>
 		</pipeline>

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
@@ -30,7 +30,7 @@
 				<forward name="success" path="Send2WS" />
 			</pipe>
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe" name="Send2WS">
-				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
+				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
 				<forward name="success" path="EXIT" />
 			</pipe>
 		</pipeline>

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderServiceNamespaceURI.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderServiceNamespaceURI.xml
@@ -66,7 +66,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -88,7 +88,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_error:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" 
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -115,7 +115,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -125,7 +125,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -167,7 +167,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -177,7 +177,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -188,7 +188,7 @@
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -199,7 +199,7 @@
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -211,7 +211,7 @@
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -223,7 +223,7 @@
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -233,7 +233,7 @@
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -244,7 +244,7 @@
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -255,7 +255,7 @@
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderServiceNamespaceURI.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderServiceNamespaceURI.xml
@@ -66,7 +66,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -88,7 +88,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_error:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter" 
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -115,7 +115,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -125,7 +125,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -167,7 +167,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -177,7 +177,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -188,7 +188,7 @@
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -199,7 +199,7 @@
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -211,7 +211,7 @@
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -223,7 +223,7 @@
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -233,7 +233,7 @@
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -244,7 +244,7 @@
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -255,7 +255,7 @@
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout:serviceNamespaceURI"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/MainConfig/DeploymentSpecifics.properties
+++ b/test/src/main/configurations/MainConfig/DeploymentSpecifics.properties
@@ -36,7 +36,7 @@ fxf.dir=${testdata.dir}/fxf
 web.host=localhost
 web.port=80
 web.protocol=http
-web.contextpath=iaf-test/
+web.contextpath=/iaf-test
 
 
 active.authentication=true

--- a/test/src/main/configurations/MainConfig/DeploymentSpecifics.properties
+++ b/test/src/main/configurations/MainConfig/DeploymentSpecifics.properties
@@ -36,7 +36,7 @@ fxf.dir=${testdata.dir}/fxf
 web.host=localhost
 web.port=80
 web.protocol=http
-web.contextpath=iaf-test
+web.contextpath=iaf-test/
 
 
 active.authentication=true

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationHttpListenerSender.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationHttpListenerSender.xml
@@ -27,7 +27,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/HttpListener?service=LocalHttpListener"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListener"
 					inputMessageParam="request" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -62,7 +62,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/HttpListener?service=LocalHttpListenerTimeout"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListenerTimeout"
 					timeout="1000" inputMessageParam="request" />
 				<forward name="timeout" path="error_timeout" />
 				<forward name="success" path="EXIT" />

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationHttpListenerSender.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationHttpListenerSender.xml
@@ -27,7 +27,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListener"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/HttpListener?service=LocalHttpListener"
 					inputMessageParam="request" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -62,7 +62,7 @@
 			<pipe name="LocalHttp">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}HttpListener?service=LocalHttpListenerTimeout"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/HttpListener?service=LocalHttpListenerTimeout"
 					timeout="1000" inputMessageParam="request" />
 				<forward name="timeout" path="error_timeout" />
 				<forward name="success" path="EXIT" />

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationRestListener.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationRestListener.xml
@@ -51,7 +51,7 @@
 			<pipe name="callRest"
 				className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
-					methodType="POST" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc"
+					methodType="POST" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc"
 					paramsInUrl="false" multipart="true">
 					<param name="key01" value="every cloud has a silver lining" />
 					<param name="key02" sessionKey="originalMessage" />
@@ -151,7 +151,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc" />
+					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc" />
 				<param name="docId" sessionKey="docId" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -190,7 +190,7 @@
 			<pipe name="getUrl" className="nl.nn.adapterframework.pipes.XsltPipe"
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc2" />
+					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc2" />
 				<param name="docId" xpathExpression="id" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -258,7 +258,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/doc3" />
+					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc3" />
 				<param name="docId" value="0" />
 				<forward name="success" path="callRest" />
 			</pipe>

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationRestListener.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationRestListener.xml
@@ -51,7 +51,7 @@
 			<pipe name="callRest"
 				className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe">
 				<sender className="nl.nn.adapterframework.http.HttpSender"
-					methodType="POST" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc"
+					methodType="POST" url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc"
 					paramsInUrl="false" multipart="true">
 					<param name="key01" value="every cloud has a silver lining" />
 					<param name="key02" sessionKey="originalMessage" />
@@ -151,7 +151,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc" />
+					value="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc" />
 				<param name="docId" sessionKey="docId" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -190,7 +190,7 @@
 			<pipe name="getUrl" className="nl.nn.adapterframework.pipes.XsltPipe"
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc2" />
+					value="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc2" />
 				<param name="docId" xpathExpression="id" />
 				<forward name="success" path="callRest" />
 			</pipe>
@@ -258,7 +258,7 @@
 				styleSheetName="RestListener/xsl/GetUrl.xsl" sessionKey="url"
 				getInputFromFixedValue="&lt;dummy/&gt;">
 				<param name="baseUrl"
-					value="${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/doc3" />
+					value="${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/doc3" />
 				<param name="docId" value="0" />
 				<forward name="success" path="callRest" />
 			</pipe>

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSender.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSender.xml
@@ -61,7 +61,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -83,7 +83,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_error"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter" 
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -110,7 +110,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -120,7 +120,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -162,7 +162,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -172,7 +172,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -183,7 +183,7 @@
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -194,7 +194,7 @@
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -206,7 +206,7 @@
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -218,7 +218,7 @@
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -228,7 +228,7 @@
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -239,7 +239,7 @@
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -250,7 +250,7 @@
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSender.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSender.xml
@@ -61,7 +61,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					namespaceDefs="ns1=${web.protocol}://www.ing.com/namespace1 ns2=${web.protocol}://www.ing.com/namespace2"
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -83,7 +83,7 @@
 				name="Send2WS">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_error"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" 
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
 			</pipe>
@@ -110,7 +110,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -120,7 +120,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -162,7 +162,7 @@
 				name="send2ws_no_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false"/>
 				<forward name="success" path="EXIT" />
@@ -172,7 +172,7 @@
 				name="send2ws_forward_timeout">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -183,7 +183,7 @@
 				name="send2ws_forward_exception">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000"
 					allowSelfSignedCertificates="true" verifyHostname="false"  />
 				<forward name="exception" path="error_exception" />
@@ -194,7 +194,7 @@
 				name="send2ws_with_forwards">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -206,7 +206,7 @@
 				name="send2ws_multiple_with_forwards" removeXmlDeclarationInResults="true">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -218,7 +218,7 @@
 				name="send2ws_no_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="success" path="EXIT" />
@@ -228,7 +228,7 @@
 				name="send2ws_forward_timeout_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />
@@ -239,7 +239,7 @@
 				name="send2ws_forward_exception_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="exception" path="error_exception" />
@@ -250,7 +250,7 @@
 				name="send2ws_with_forwards_resultOnTimeOut" resultOnTimeOut="&lt;receiver_timed_out/&gt;">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
 					serviceNamespace="urn:ws_timeout"
-					url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter"
 					timeout="1000" 
 					allowSelfSignedCertificates="true" verifyHostname="false" />
 				<forward name="timeout" path="error_timeout" />

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
@@ -30,7 +30,7 @@
 				<forward name="success" path="Send2WS" />
 			</pipe>
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe" name="Send2WS">
-				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
+				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
 				<forward name="success" path="EXIT" />
 			</pipe>
 		</pipeline>

--- a/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
+++ b/test/src/main/configurations/WSS_HTTP/ConfigurationWebServiceListenerSenderNoSoap.xml
@@ -30,7 +30,7 @@
 				<forward name="success" path="Send2WS" />
 			</pipe>
 			<pipe className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe" name="Send2WS">
-				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
+				<sender className="nl.nn.adapterframework.http.WebServiceSender" soap="false" url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter" namespaceDefs="ns1=http://www.ing.com/namespace1 ns2=http://www.ing.com/namespace2" />
 				<forward name="success" path="EXIT" />
 			</pipe>
 		</pipeline>

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -40,7 +40,7 @@ fxf.dir=${testdata.dir}
 web.host=localhost
 web.port=80
 web.protocol=http
-web.contextpath=iaf-test
+web.contextpath=iaf-test/
 #web.contextpath=${instance.name.lc}
 
 active.authentication=true

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -40,7 +40,7 @@ fxf.dir=${testdata.dir}
 web.host=localhost
 web.port=80
 web.protocol=http
-web.contextpath=iaf-test/
+web.contextpath=/iaf-test
 #web.contextpath=${instance.name.lc}
 
 active.authentication=true

--- a/test/src/test/testtool/CorrelationMessageId/common.properties
+++ b/test/src/test/testtool/CorrelationMessageId/common.properties
@@ -7,7 +7,7 @@ java.CorrelationMessageIdXPath.className=nl.nn.adapterframework.senders.IbisJava
 java.CorrelationMessageIdXPath.serviceName=ibis4test-CorrelationMessageIdXPath
 
 ws.CorrelationMessageIdXPath.className=nl.nn.adapterframework.http.WebServiceSender
-ws.CorrelationMessageIdXPath.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/servlet/rpcrouter
+ws.CorrelationMessageIdXPath.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter
 ws.CorrelationMessageIdXPath.serviceNamespace=CorrelationMessageIdXPath2
 
 manage.db.className=nl.nn.adapterframework.senders.IbisJavaSender

--- a/test/src/test/testtool/CorrelationMessageId/common.properties
+++ b/test/src/test/testtool/CorrelationMessageId/common.properties
@@ -7,7 +7,7 @@ java.CorrelationMessageIdXPath.className=nl.nn.adapterframework.senders.IbisJava
 java.CorrelationMessageIdXPath.serviceName=ibis4test-CorrelationMessageIdXPath
 
 ws.CorrelationMessageIdXPath.className=nl.nn.adapterframework.http.WebServiceSender
-ws.CorrelationMessageIdXPath.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}servlet/rpcrouter
+ws.CorrelationMessageIdXPath.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/servlet/rpcrouter
 ws.CorrelationMessageIdXPath.serviceNamespace=CorrelationMessageIdXPath2
 
 manage.db.className=nl.nn.adapterframework.senders.IbisJavaSender

--- a/test/src/test/testtool/HttpListenerSender/common.properties
+++ b/test/src/test/testtool/HttpListenerSender/common.properties
@@ -16,7 +16,7 @@ ignoreContentBetweenKeys3.key1=<details>
 ignoreContentBetweenKeys3.key2=</details>
 
 ignoreContentBetweenKeys4.key1=${web.protocol}:
-ignoreContentBetweenKeys4.key2=/${web.contextpath}
+ignoreContentBetweenKeys4.key2=${web.contextpath}
 
 ignoreContentBetweenKeys5.key1=&lt;stackTrace&gt;
 ignoreContentBetweenKeys5.key2=&lt;/stackTrace&gt;

--- a/test/src/test/testtool/IbisConsole/showConfiguration.properties
+++ b/test/src/test/testtool/IbisConsole/showConfiguration.properties
@@ -3,7 +3,7 @@ include = common.properties
 scenario.description = IbisConsole - ShowConfiguration
 
 http.ShowConfiguration.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfiguration.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfiguration
+http.ShowConfiguration.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/showConfiguration
 http.ShowConfiguration.xhtml=true
 http.ShowConfiguration.styleSheetName=showConfiguration/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfiguration.properties
+++ b/test/src/test/testtool/IbisConsole/showConfiguration.properties
@@ -3,7 +3,7 @@ include = common.properties
 scenario.description = IbisConsole - ShowConfiguration
 
 http.ShowConfiguration.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfiguration.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/showConfiguration
+http.ShowConfiguration.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfiguration
 http.ShowConfiguration.xhtml=true
 http.ShowConfiguration.styleSheetName=showConfiguration/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatBTM.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatBTM.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.tomcatBTM}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_TomCatBTM/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatBTM.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatBTM.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.tomcatBTM}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_TomCatBTM/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatSpringDSTA.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatSpringDSTA.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.tomcatSpringDSTA}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_TomCatSpringDSTA/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatSpringDSTA.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_TomCatSpringDSTA.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.tomcatSpringDSTA}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_TomCatSpringDSTA/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_WAS.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_WAS.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.was}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_WAS/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_WAS.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_WAS.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.was}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_WAS/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_WLP.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_WLP.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.wlp}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_WLP/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showConfigurationStatus_WLP.properties
+++ b/test/src/test/testtool/IbisConsole/showConfigurationStatus_WLP.properties
@@ -2,7 +2,7 @@ scenario.description = IbisConsole - ShowConfigurationStatus
 scenario.active=${active.wlp}
 
 http.ShowConfigurationStatus.className=nl.nn.adapterframework.http.HttpSender
-http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/showConfigurationStatus
+http.ShowConfigurationStatus.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/showConfigurationStatus
 http.ShowConfigurationStatus.xhtml=true
 http.ShowConfigurationStatus.styleSheetName=showConfigurationStatus_WLP/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showLogging.properties
+++ b/test/src/test/testtool/IbisConsole/showLogging.properties
@@ -3,7 +3,7 @@ include = common.properties
 scenario.description = IbisConsole - ShowLogging
 
 http.ShowLogging.className=nl.nn.adapterframework.http.HttpSender
-http.ShowLogging.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}showLogging.do
+http.ShowLogging.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/showLogging.do
 http.ShowLogging.xhtml=true
 http.ShowLogging.styleSheetName=showLogging/transformXhtml.xsl
 

--- a/test/src/test/testtool/IbisConsole/showLogging.properties
+++ b/test/src/test/testtool/IbisConsole/showLogging.properties
@@ -3,7 +3,7 @@ include = common.properties
 scenario.description = IbisConsole - ShowLogging
 
 http.ShowLogging.className=nl.nn.adapterframework.http.HttpSender
-http.ShowLogging.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/showLogging.do
+http.ShowLogging.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}showLogging.do
 http.ShowLogging.xhtml=true
 http.ShowLogging.styleSheetName=showLogging/transformXhtml.xsl
 

--- a/test/src/test/testtool/WsdlGenerator/common.properties
+++ b/test/src/test/testtool/WsdlGenerator/common.properties
@@ -1,16 +1,16 @@
 include = ../global.properties
 
 http.WsdlGenerator.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator.wsdl
+http.WsdlGenerator.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/webservices/WsdlGenerator.wsdl
 
 http.WsdlGenerator2.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator2.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator2.wsdl
+http.WsdlGenerator2.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/webservices/WsdlGenerator2.wsdl
 
 http.WsdlGenerator3.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator3.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator3.wsdl
+http.WsdlGenerator3.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/webservices/WsdlGenerator3.wsdl
 
 http.WsdlGenerator4.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator4.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator4.wsdl
+http.WsdlGenerator4.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/rest/webservices/WsdlGenerator4.wsdl
 
 ignoreContentBetweenKeys1.key1=<wsdl:documentation>
 ignoreContentBetweenKeys1.key2=</wsdl:documentation>

--- a/test/src/test/testtool/WsdlGenerator/common.properties
+++ b/test/src/test/testtool/WsdlGenerator/common.properties
@@ -1,16 +1,16 @@
 include = ../global.properties
 
 http.WsdlGenerator.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/webservices/WsdlGenerator.wsdl
+http.WsdlGenerator.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator.wsdl
 
 http.WsdlGenerator2.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator2.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/webservices/WsdlGenerator2.wsdl
+http.WsdlGenerator2.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator2.wsdl
 
 http.WsdlGenerator3.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator3.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/webservices/WsdlGenerator3.wsdl
+http.WsdlGenerator3.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator3.wsdl
 
 http.WsdlGenerator4.className=nl.nn.adapterframework.http.HttpSender
-http.WsdlGenerator4.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}/rest/webservices/WsdlGenerator4.wsdl
+http.WsdlGenerator4.url=${web.protocol}://${web.host}:${web.port}/${web.contextpath}rest/webservices/WsdlGenerator4.wsdl
 
 ignoreContentBetweenKeys1.key1=<wsdl:documentation>
 ignoreContentBetweenKeys1.key2=</wsdl:documentation>


### PR DESCRIPTION
The web.contextpath property can now be empty without causing a double forward slash in the url
where this property is used. The forward slash after using the variable
has been removed and the contextpath should now be given ending with a
forward slash, e.g. now use "iaf-test/" instead of "iaf-test".