### PR TITLE
Removed the autoIncrement=true attribute in DatabaseChangelog.xml.

### DIFF
--- a/test/src/main/resources/DatabaseChangelog.xml
+++ b/test/src/main/resources/DatabaseChangelog.xml
@@ -33,7 +33,7 @@ TagDatabase
 	<changeSet id="IBISDATA" author="Robert Karajev">
 		<comment>Add IBISDATA Table</comment>
 		<createTable tableName="IBISDATA">
-			<column name="DATAKEY" type="java.sql.Types.DECIMAL(10)" autoIncrement="true">
+			<column name="DATAKEY" type="java.sql.Types.DECIMAL(10)">
 				<constraints primaryKey="true" nullable="false" primaryKeyName="PK_IBISDATA"/>
 			</column>
 			<column name="DATA" type="BLOB"/>
@@ -43,7 +43,7 @@ TagDatabase
 	<changeSet id="IBISTEMP" author="Robert Karajev">
 		<comment>Add IBISTEMP Table</comment>
 		<createTable tableName="IBISTEMP">
-			<column name="TKEY" type="java.sql.Types.DECIMAL(10)" autoIncrement="true">
+			<column name="TKEY" type="java.sql.Types.DECIMAL(10)">
 				<constraints primaryKey="true" nullable="false" primaryKeyName="PK_IBISTEMP"/>
 			</column>
 			<column name="TCHAR" type="java.sql.Types.CHAR(1)"/>


### PR DESCRIPTION
Removed the autoIncrement=true attribute for creating the tables
IBISDATA and IBISTEMP when using liquibase for Ibis4Test. This is
because this attribute is not necessary and caused an incorrect query
when running Ibis4Test with MySQL and MariaDB. Note that if you have
already run Ibis4Test before using a local database you need to drop
your Databasechangelog table before running Ibis4Test with liquibase
again.