### PR TITLE
Fix bug in link to ibisdoc

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/doc/IbisDocPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/IbisDocPipe.java
@@ -322,7 +322,7 @@ public class IbisDocPipe extends FixedForwardPipe {
 					+ "  <a href=\"ibisdoc/ibisdoc.xsd\">ibisdoc.xsd</a><br/>\n"
 					+ "  <a href=\"ibisdoc/uglify_lookup.xml\">uglify_lookup.xml</a><br/>\n"
 					+ "  <a href=\"ibisdoc/ibisdoc.json\">ibisdoc.json</a><br/>\n"
-					+ "  <a href=\"../../iaf/ibisdoc\">The new ibisdoc application</a><br/>\n"
+					+ "  <a href=\"../iaf/ibisdoc\">The new ibisdoc application</a><br/>\n"
 					+ "</html>";
 		} else if ("/ibisdoc/ibisdoc.html".equals(uri)) {
 			result = "<html>\n"


### PR DESCRIPTION
The link of the new ibisdoc application went to http://localhost:8080/iaf/ibisdoc when clicking on it instead of http://localhost:8080/iaf-example/iaf/ibisdoc which resulted in a 404. This has now been fixed