### PR TITLE
Bugfix (un)loading configs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,6 +19,7 @@ Upcoming
 
 - Make ForEachChildElementPipe streaming when using elementXPathExpression too
   Make Xslt streaming default for xsltVersion=1
+- Bugfix (un)loading configs in JmxMbeanHelper
 
 ### Non backwards compatible changes
 


### PR DESCRIPTION
When configs are loaded, unloaded or reloaded a lot of warnings and errors occur. This is caused by the class JmxMBeanHelper which can not handle configs and a bug in retrieving the ObjectName which differs from the real one which is registered.