### PR TITLE
added aop around for StreamingSenderBase (err. target argument)

### DIFF
--- a/ladybug/src/main/resources/springIbisDebuggerAdvice.xml
+++ b/ladybug/src/main/resources/springIbisDebuggerAdvice.xml
@@ -103,6 +103,21 @@
 					"
 					execution(
 						*
+						nl.nn.adapterframework.stream.StreamingSenderBase.sendMessage(
+							String, String, nl.nn.adapterframework.parameters.ParameterResolutionContext, nl.nn.adapterframework.stream.MessageOutputStream
+						)
+					)
+					and
+					args(correlationId, message, parameterResolutionContext, target)
+					"
+				method="debugSenderWithParametersInputOutputAbort"
+				arg-names="correlationId, message, parameterResolutionContext"
+			/>
+			<aop:around
+				pointcut=
+					"
+					execution(
+						*
 						nl.nn.adapterframework.processors.CacheSenderWrapperProcessor.sendMessage(
 							nl.nn.adapterframework.senders.SenderWrapperBase, String, String, nl.nn.adapterframework.parameters.ParameterResolutionContext
 						)


### PR DESCRIPTION
Added an aop around of the sender base. But there is a problem with the target argument. You can read that problem in the ibis log. Here is the link that might be relevent: https://stackoverflow.com/questions/23780951/xlintinvalidabsolutetypename