### PR TITLE
Removed zip dir from setupDir

### DIFF
--- a/test/src/main/tools/setupDir/setupDir.xml
+++ b/test/src/main/tools/setupDir/setupDir.xml
@@ -22,7 +22,6 @@
 		<mkdir dir="${root.dir}/rs2fs"/>
 		<mkdir dir="${root.dir}/webservices"/>
 		<mkdir dir="${root.dir}/xfeip"/>
-		<mkdir dir="${root.dir}/zip"/>
 
 		<property name="zip.name" value="folders.zip" />
 


### PR DESCRIPTION
The setupDir caused larva scenario's to crash due to zip dir being created when it shouldn't.