### PR TITLE
Disable streaming XSLT

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,7 +15,7 @@ Upcoming
 - Make attribute firstPipe in PipeLine optional. When empty, the first Pipe in the Pipeline configuration
   is considedred to be the first. Similarly the success forward defaults to the next Pipe in the PipeLine.
 - Enable to specify a namespace without a prefix in attribute namespaceDefs, to help simplify xpathExpressions e.g. into '/root/sub' instead of '/\*[local-name()='root']/\*[local-name()='sub'.
-- Make ForEachChildElementPipe streaming when using elementXPathExpression too; 
+- Make ForEachChildElementPipe optionally streaming when using elementXPathExpression too. N.B. This requires an XsltProcessor that properly supports streaming. The versions of Saxon and Xalan that we currently employ do not; 
   Add options 'targetElement' and 'containerElement' to ForEachChildElementPipe to enable processing of very large files, avoiding memory problems that still exist with 
   xpath expressions for very large files;
   Make Xslt streaming default for xsltVersion=1

--- a/core/src/main/java/nl/nn/adapterframework/pipes/ForEachChildElementPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/ForEachChildElementPipe.java
@@ -44,6 +44,7 @@ import nl.nn.adapterframework.stream.IThreadCreator;
 import nl.nn.adapterframework.stream.InputMessageAdapter;
 import nl.nn.adapterframework.stream.MessageOutputStream;
 import nl.nn.adapterframework.stream.ThreadLifeCycleEventListener;
+import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.ClassUtils;
 import nl.nn.adapterframework.util.StreamUtil;
 import nl.nn.adapterframework.util.TransformerErrorListener;
@@ -72,6 +73,7 @@ public class ForEachChildElementPipe extends IteratingPipe<String> implements IT
 	private String charset=StreamUtil.DEFAULT_INPUT_STREAM_ENCODING;
 	private int xsltVersion=DEFAULT_XSLT_VERSION; 
 	private boolean removeNamespaces=true;
+	private boolean streamingXslt;
 
 	private TransformerPool extractElementsTp=null;
 	private ThreadLifeCycleEventListener<Object> threadLifeCycleEventListener;
@@ -85,6 +87,7 @@ public class ForEachChildElementPipe extends IteratingPipe<String> implements IT
 		super.configure();
 		try {
 			if (StringUtils.isNotEmpty(getElementXPathExpression())) {
+				streamingXslt = AppConstants.getInstance(getConfigurationClassLoader()).getBoolean("xslt.streaming.default", false);
 				if (getXsltVersion()==0) {
 					setXsltVersion(DEFAULT_XSLT_VERSION);
 				}
@@ -382,7 +385,7 @@ public class ForEachChildElementPipe extends IteratingPipe<String> implements IT
 			
 			if (getExtractElementsTp()!=null) {
 				log.debug("transforming input to obtain list of elements using xpath ["+getElementXPathExpression()+"]");
-				TransformerFilter transformerFilter = getExtractElementsTp().getTransformerFilter(this, threadLifeCycleEventListener, correlationID);
+				TransformerFilter transformerFilter = getExtractElementsTp().getTransformerFilter(this, threadLifeCycleEventListener, correlationID, streamingXslt);
 				transformerFilter.setContentHandler(inputHandler);
 				inputHandler=transformerFilter;
 				ErrorListener errorListener = transformerFilter.getTransformer().getErrorListener();

--- a/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
@@ -44,6 +44,7 @@ import nl.nn.adapterframework.stream.MessageOutputStreamCap;
 import nl.nn.adapterframework.stream.StreamingException;
 import nl.nn.adapterframework.stream.StreamingSenderBase;
 import nl.nn.adapterframework.stream.ThreadLifeCycleEventListener;
+import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.ClassUtils;
 import nl.nn.adapterframework.util.DomBuilderException;
 import nl.nn.adapterframework.util.TransformerPool;
@@ -85,6 +86,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 	private int transformerPoolMapSize = 100;
 
 	private ThreadLifeCycleEventListener<Object> threadLifeCycleEventListener;
+	private boolean streamingXslt;
 
 
 	/**
@@ -95,6 +97,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 	public void configure() throws ConfigurationException {
 		super.configure();
 		
+		streamingXslt = AppConstants.getInstance(getConfigurationClassLoader()).getBoolean("xslt.streaming.default", false);
 		dynamicTransformerPoolMap = Collections.synchronizedMap(new LRUMap(transformerPoolMapSize));
 		
 		if(StringUtils.isNotEmpty(getXpathExpression()) && getOutputType()==null) {
@@ -245,7 +248,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 			}
 			
 
-			TransformerFilter mainFilter = poolToUse.getTransformerFilter(this, threadLifeCycleEventListener, correlationID);
+			TransformerFilter mainFilter = poolToUse.getTransformerFilter(this, threadLifeCycleEventListener, correlationID, streamingXslt);
 			XmlUtils.setTransformerParameters(mainFilter.getTransformer(),parametervalues);
 			mainFilter.setContentHandler(handler);
 			handler=mainFilter;

--- a/core/src/main/java/nl/nn/adapterframework/util/TransformerPool.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/TransformerPool.java
@@ -465,8 +465,8 @@ public class TransformerPool {
 	}
 
 	
-	public TransformerFilter getTransformerFilter(INamedObject owner, ThreadLifeCycleEventListener<Object> threadLifeCycleEventListener, String correlationID) throws TransformerConfigurationException {
-		return new TransformerFilter(owner, getTransformerHandler(), threadLifeCycleEventListener, correlationID);
+	public TransformerFilter getTransformerFilter(INamedObject owner, ThreadLifeCycleEventListener<Object> threadLifeCycleEventListener, String correlationID, boolean expectChildThreads) throws TransformerConfigurationException {
+		return new TransformerFilter(owner, getTransformerHandler(), threadLifeCycleEventListener, correlationID, expectChildThreads);
 	}
 	
 	public static List<String> getTransformerPoolsKeys() {

--- a/core/src/main/java/nl/nn/adapterframework/xml/TransformerFilter.java
+++ b/core/src/main/java/nl/nn/adapterframework/xml/TransformerFilter.java
@@ -24,20 +24,22 @@ import org.xml.sax.ext.LexicalHandler;
 
 import nl.nn.adapterframework.core.INamedObject;
 import nl.nn.adapterframework.stream.ThreadLifeCycleEventListener;
-import nl.nn.adapterframework.util.TransformerErrorListener;
 
 public class TransformerFilter extends FullXmlFilter {
 
 	private FullXmlFilter lastFilter;
 	private TransformerHandler transformerHandler;
 	
-	public TransformerFilter(INamedObject owner, TransformerHandler transformerHandler, ThreadLifeCycleEventListener<Object> threadLifeCycleEventListener, String correlationID) {
+	public TransformerFilter(INamedObject owner, TransformerHandler transformerHandler, ThreadLifeCycleEventListener<Object> threadLifeCycleEventListener, String correlationID, boolean expectChildThreads) {
 		super();
-		ThreadConnectingFilter threadConnectingFilter = new ThreadConnectingFilter(owner, threadLifeCycleEventListener, correlationID);
-		lastFilter=threadConnectingFilter;
+		if (expectChildThreads) {
+			lastFilter = new ThreadConnectingFilter(owner, threadLifeCycleEventListener, correlationID);
+		} else {
+			lastFilter = new FullXmlFilter();
+		}
 		SAXResult transformedStream = new SAXResult();
-		transformedStream.setHandler(threadConnectingFilter);
-		transformedStream.setLexicalHandler((LexicalHandler)threadConnectingFilter);
+		transformedStream.setHandler(lastFilter);
+		transformedStream.setLexicalHandler((LexicalHandler)lastFilter);
 		this.transformerHandler=transformerHandler;
 		transformerHandler.setResult(transformedStream);
 		super.setContentHandler(transformerHandler);

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -147,7 +147,10 @@ recover.adapters.interval=300000
 checkReload.interval=60000
 
 xml.namespaceAware.default=false
-xslt.streaming.default=true
+# set xslt.streaming.default=true to use streaming Xslt. 
+# N.B. 2019-11-25 this appears to cause NullPointerExceptions in Xalans TransformerHandlerImpl, therefor we disabled this setting
+# (also because it is using more memory than expected, e.g. ForEachChildElementPipe with elementXPathExpression still goes out of memory on large files)
+xslt.streaming.default=false
 xslt.auto.reload=false
 xslt.bufsize=4096
 

--- a/core/src/test/java/nl/nn/adapterframework/pipes/ForEachChildElementPipeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/ForEachChildElementPipeTest.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.hamcrest.Matchers;
-import org.junit.Assume;
 import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;

--- a/core/src/test/java/nl/nn/adapterframework/pipes/ForEachChildElementPipeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/ForEachChildElementPipeTest.java
@@ -3,6 +3,7 @@ package nl.nn.adapterframework.pipes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.ByteArrayInputStream;
 import java.io.FilterInputStream;
@@ -12,6 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.hamcrest.Matchers;
+import org.junit.Assume;
 import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -28,6 +30,7 @@ import nl.nn.adapterframework.core.SenderException;
 import nl.nn.adapterframework.core.TimeOutException;
 import nl.nn.adapterframework.parameters.ParameterResolutionContext;
 import nl.nn.adapterframework.senders.EchoSender;
+import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.xml.FullXmlFilter;
 
 public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElementPipe> {
@@ -215,6 +218,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
         String actual=prr.getResult().toString();
         
         assertEquals(expectedBasicNoNS, actual);
+		assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		assertTrue("streaming failure: switch count ["+sc.count+"] should be larger than 2",sc.count>2);
     }
 
@@ -234,6 +238,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
         String actual=prr.getResult().toString();
         
         assertEquals(expectedBasicNoNS, actual);
+		assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		assertTrue("streaming failure: switch count ["+sc.count+"] should be larger than 2",sc.count>2);
     }
 
@@ -253,6 +258,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
         String actual=prr.getResult().toString();
         
         assertEquals(expectedBasicNoNS, actual);
+		assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		assertTrue("streaming failure: switch count ["+sc.count+"] should be larger than 2",sc.count>2);
     }
 
@@ -271,6 +277,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
         String actual=prr.getResult().toString();
         
         assertEquals(expectedBasicNS1, actual);
+		assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		assertTrue("streaming failure: switch count ["+sc.count+"] should be larger than 2",sc.count>2);
     }
     
@@ -289,6 +296,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
         String actual=prr.getResult().toString();
         
         assertEquals(expectedBasicNS2, actual);
+		assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		assertTrue("streaming failure: switch count ["+sc.count+"] should be larger than 2",sc.count>2);
     }
     
@@ -307,6 +315,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
         String actual=prr.getResult().toString();
         
         assertEquals(expectedBasicNS1, actual);
+		assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		assertTrue("streaming failure: switch count ["+sc.count+"] should be larger than 2",sc.count>2);
     }
     
@@ -324,6 +333,7 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
         String actual=prr.getResult().toString();
         
         assertEquals(expectedBasicNoNSFirstTwoElements, actual);
+		assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		assertTrue("streaming failure: switch count ["+sc.count+"] should be larger than 2",sc.count>2);
     }
  

--- a/core/src/test/java/nl/nn/adapterframework/util/XsltStreamingTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/XsltStreamingTest.java
@@ -12,6 +12,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamSource;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.xml.sax.Attributes;
 import org.xml.sax.ContentHandler;
@@ -187,7 +188,7 @@ public class XsltStreamingTest {
 		 * receive SAX destination events
 		 * received events and source events should be mixed
 		 */
-		
+		Assume.assumeTrue("Streaming XSLT switched off", AppConstants.getInstance().getBoolean("xslt.streaming.default", true));
 		SwitchCounter sc = new SwitchCounter();
 		
 		String xpath="/root/a";

--- a/core/src/test/java/nl/nn/adapterframework/xslt/XsltErrorTestBase.java
+++ b/core/src/test/java/nl/nn/adapterframework/xslt/XsltErrorTestBase.java
@@ -192,7 +192,7 @@ public abstract class XsltErrorTestBase<P extends StreamingPipe> extends XsltTes
 		String errorMessage = null;
 		try {
 			doPipe(pipe, input, session);
-		} catch (PipeRunException e) {
+		} catch (Exception e) {
 			errorMessage = e.getMessage();
 			//System.out.println("ErrorMessage: "+errorMessage);
 			assertThat(errorMessage,containsString(FILE_NOT_FOUND_EXCEPTION));


### PR DESCRIPTION
This appeared to cause NullPointerExceptions in Xalans
TransformerHandlerImpl, therefor we disabled this setting.
Also because it is using more memory than expected, e.g.
ForEachChildElementPipe with elementXPathExpression still goes out of
memory on large files