### PR TITLE
Fix Larva test scenarios directory name not equal

### DIFF
--- a/test/src/main/tools/setupDir/setupDir.xml
+++ b/test/src/main/tools/setupDir/setupDir.xml
@@ -22,7 +22,6 @@
 		<mkdir dir="${root.dir}/rs2fs"/>
 		<mkdir dir="${root.dir}/webservices"/>
 		<mkdir dir="${root.dir}/xfeip"/>
-		<mkdir dir="${root.dir}/zip"/>
 
 		<property name="zip.name" value="folders.zip" />
 

--- a/test/src/test/testtool/RestListener/common.properties
+++ b/test/src/test/testtool/RestListener/common.properties
@@ -39,6 +39,9 @@ canonicaliseFilePathContentBetweenKeys3.key2=</filename3>
 canonicaliseFilePathContentBetweenKeys4.key1=canonicalName="
 canonicaliseFilePathContentBetweenKeys4.key2="
 
+canonicaliseFilePathContentBetweenKeys5.key1=directory name="
+canonicaliseFilePathContentBetweenKeys5.key2="
+
 ignoreContentBetweenKeys5.key1=columnDisplaySize="
 ignoreContentBetweenKeys5.key2="
 

--- a/test/src/test/testtool/Zip/ZipWriter/scenario 01.properties
+++ b/test/src/test/testtool/Zip/ZipWriter/scenario 01.properties
@@ -9,6 +9,9 @@ include = ../common.properties
 canonicaliseFilePathContentBetweenKeys1.key1=canonicalName="
 canonicaliseFilePathContentBetweenKeys1.key2="
 
+canonicaliseFilePathContentBetweenKeys2.key1=directory name="
+canonicaliseFilePathContentBetweenKeys2.key2="
+
 #step1.dir.init.write = dummy.txt
 step1.provider.java.write  = ../createDir.xml
 step2.provider.java.read   = ../createDir.xml

--- a/test/src/test/testtool/Zip/ZipWriter/scenario 02.properties
+++ b/test/src/test/testtool/Zip/ZipWriter/scenario 02.properties
@@ -9,6 +9,9 @@ include = ../common.properties
 canonicaliseFilePathContentBetweenKeys1.key1=canonicalName="
 canonicaliseFilePathContentBetweenKeys1.key2="
 
+canonicaliseFilePathContentBetweenKeys2.key1=directory name="
+canonicaliseFilePathContentBetweenKeys2.key2="
+
 #step1.dir.init.write = dummy.txt
 step1.provider.java.write  = ../createDir.xml
 step2.provider.java.read   = ../createDir.xml


### PR DESCRIPTION
Een aantal Larva scenario's gaf een verschil op directorynamen met een kleine "c" en een grote "C". Dit is nu gefixt door de canonical directorynamen met elkaar te vergelijken.
Verder gaan de Zip-scenario's fout als de directory ${testdata.dir}/zip al bestaat. Ik heb dat gefixt door deze directory niet meer aan te maken in <setupDir.xml>. Beter nog zou zijn om bij het aanmaken van de directory eerst te controleren of hij al bestaat.