### PR TITLE
Fix mvn jetty:run for newer H2 version

### DIFF
--- a/example/pom.xml
+++ b/example/pom.xml
@@ -78,7 +78,7 @@
             </systemProperty>
             <systemProperty>
               <name>log.dir</name>
-              <value>target</value>
+              <value>./target</value>
             </systemProperty>
             <systemProperty>
               <name>log.level</name>


### PR DESCRIPTION
H2 now wants explicit declaration of current work dir usage.

Updated pom.xml for Jetty mvn plugin to pass the explicit declaration as system property.