### PR TITLE
Make sure properties are set throughout all AppConstants singletons

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationDigester.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationDigester.java
@@ -224,7 +224,7 @@ public class ConfigurationDigester {
 			loadedHide = ConfigurationUtils.getUglifiedConfiguration(configuration, loadedHide);
 			loaded = ConfigurationUtils.getActivatedConfiguration(configuration, loaded);
 			loadedHide = ConfigurationUtils.getActivatedConfiguration(configuration, loadedHide);
-			if (ConfigurationUtils.stubConfiguration()) {
+			if (ConfigurationUtils.stubConfiguration(classLoader)) {
 				loaded = ConfigurationUtils.getStubbedConfiguration(configuration, loaded);
 				loadedHide = ConfigurationUtils.getStubbedConfiguration(configuration, loadedHide);
 			}

--- a/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationUtils.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationUtils.java
@@ -76,13 +76,7 @@ public class ConfigurationUtils {
 	public static String ADDITIONAL_PROPERTIES_FILE_SUFFIX = APP_CONSTANTS.getString("ADDITIONAL.PROPERTIES.FILE.SUFFIX", null);
 	public static final String DEFAULT_CONFIGURATION_FILE = "Configuration.xml";
 
-	public static boolean stubConfiguration() {
-		return stubConfiguration(null);
-	}
-	/**
-	 * TODO: make this method public and create STUB per configuration
-	 */
-	private static boolean stubConfiguration(ClassLoader classLoader) {
+	public static boolean stubConfiguration(ClassLoader classLoader) {
 		return AppConstants.getInstance(classLoader).getBoolean(STUB4TESTTOOL_CONFIGURATION_KEY, false);
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/configuration/HostnamePropertyPlaceholderConfigurer.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/HostnamePropertyPlaceholderConfigurer.java
@@ -43,7 +43,7 @@ public class HostnamePropertyPlaceholderConfigurer
 		String hostname = appConstants.getResolvedProperty(HOSTNAME_PROPERTY);
 		if (StringUtils.isEmpty(hostname)) {
 			hostname = Misc.getHostname();
-			appConstants.putPropertyPlaceholderConfigurerProperty(HOSTNAME_PROPERTY, hostname);
+			appConstants.setProperty(HOSTNAME_PROPERTY, hostname);
 			props.put(HOSTNAME_PROPERTY, hostname);
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/configuration/IbisContext.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/IbisContext.java
@@ -523,7 +523,7 @@ public class IbisContext extends IbisApplicationContext {
 	}
 
 	public String getApplicationVersion() {
-		return ConfigurationUtils.getVersion(null, "instance.version", "instance.build_id");
+		return ConfigurationUtils.getVersion(this.getClass().getClassLoader(), "instance.version", "instance.build_id");
 	}
 
 	public String getFrameworkVersion() {

--- a/core/src/main/java/nl/nn/adapterframework/configuration/LowerCasePropertyPlaceholderConfigurer.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/LowerCasePropertyPlaceholderConfigurer.java
@@ -40,7 +40,7 @@ public class LowerCasePropertyPlaceholderConfigurer
 		String instanceName = appConstants.getProperty("instance.name");
 		if (instanceName != null) {
 			String lowerCase = instanceName.toLowerCase();
-			appConstants.putPropertyPlaceholderConfigurerProperty("instance.name.lc", lowerCase);
+			appConstants.setProperty("instance.name.lc", lowerCase);
 			props.put("instance.name.lc", lowerCase);
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/configuration/OverwritePropertyPlaceholderConfigurer.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/OverwritePropertyPlaceholderConfigurer.java
@@ -39,7 +39,7 @@ public class OverwritePropertyPlaceholderConfigurer
 	@Override
 	protected void convertProperties(Properties props) {
 		AppConstants appConstants = AppConstants.getInstance();
-		appConstants.putPropertyPlaceholderConfigurerProperty(propertyName, propertyValue);
+		appConstants.setProperty(propertyName, propertyValue);
 		props.put(propertyName, propertyValue);
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/extensions/esb/EsbSoapWrapperPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/esb/EsbSoapWrapperPipe.java
@@ -340,7 +340,7 @@ public class EsbSoapWrapperPipe extends SoapWrapperPipe {
 		}
 		super.configure();
 		if (isUseFixedValues()) {
-			if (!ConfigurationUtils.stubConfiguration()) {
+			if (!ConfigurationUtils.stubConfiguration(getConfigurationClassLoader())) {
 				throw new ConfigurationException(getLogPrefix(null)+"returnFixedDate only allowed in stub mode");
 			}
 		}

--- a/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfPropertyPlaceholderConfigurer.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfPropertyPlaceholderConfigurer.java
@@ -51,7 +51,7 @@ public class FxfPropertyPlaceholderConfigurer
 			}
 		}
 		if (fxfDir != null) {
-			appConstants.putPropertyPlaceholderConfigurerProperty("fxf.dir", fxfDir);
+			appConstants.setProperty("fxf.dir", fxfDir);
 			props.put("fxf.dir", fxfDir);
 		}
 		log.debug("FxF directory: " + fxfDir);

--- a/core/src/main/java/nl/nn/adapterframework/parameters/Parameter.java
+++ b/core/src/main/java/nl/nn/adapterframework/parameters/Parameter.java
@@ -91,7 +91,7 @@ import nl.nn.adapterframework.util.XmlUtils;
  */
 public class Parameter implements INamedObject, IWithParameters {
 	protected Logger log = LogUtil.getLogger(this);
-	private ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+	private ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 
 	public final static String TYPE_XML="xml";
 	public final static String TYPE_NODE="node";
@@ -170,7 +170,7 @@ public class Parameter implements INamedObject, IWithParameters {
 			String outputType=TYPE_XML.equalsIgnoreCase(getType()) || TYPE_NODE.equalsIgnoreCase(getType()) || TYPE_DOMDOC.equalsIgnoreCase(getType())?"xml":"text";
 			boolean includeXmlDeclaration=false;
 			
-			transformerPool=TransformerPool.configureTransformer0("Parameter ["+getName()+"] ",classLoader,getNamespaceDefs(),getXpathExpression(), styleSheetName,outputType,includeXmlDeclaration,paramList,getXsltVersion());
+			transformerPool=TransformerPool.configureTransformer0("Parameter ["+getName()+"] ",configurationClassLoader,getNamespaceDefs(),getXpathExpression(), styleSheetName,outputType,includeXmlDeclaration,paramList,getXsltVersion());
 		} else {
 			if (paramList!=null && StringUtils.isEmpty(getXpathExpression())) {
 				throw new ConfigurationException("Parameter ["+getName()+"] can only have parameters itself if a styleSheetName or xpathExpression is specified");
@@ -180,7 +180,7 @@ public class Parameter implements INamedObject, IWithParameters {
 			transformerPoolRemoveNamespaces = XmlUtils.getRemoveNamespacesTransformerPool(true,false);
 		}
 		if (StringUtils.isNotEmpty(getSessionKeyXPath())) {
-			transformerPoolSessionKey = TransformerPool.configureTransformer("SessionKey for parameter ["+getName()+"] ", classLoader, getNamespaceDefs(), getSessionKeyXPath(), null,"text",false,null);
+			transformerPoolSessionKey = TransformerPool.configureTransformer("SessionKey for parameter ["+getName()+"] ", configurationClassLoader, getNamespaceDefs(), getSessionKeyXPath(), null,"text",false,null);
 		}
 		if (TYPE_DATE.equals(getType()) && StringUtils.isEmpty(getFormatString())) {
 			setFormatString(TYPE_DATE_PATTERN);
@@ -537,7 +537,7 @@ public class Parameter implements INamedObject, IWithParameters {
 			} else if ("hostname".equals(name.toLowerCase())) {
 				substitutionValue = Misc.getHostname();
 			} else if ("fixeddate".equals(name.toLowerCase())) {
-				if (!ConfigurationUtils.stubConfiguration(classLoader)) {
+				if (!ConfigurationUtils.stubConfiguration(configurationClassLoader)) {
 					throw new ParameterException("Parameter pattern [" + name + "] only allowed in stub mode");
 				}
 				Date d;
@@ -553,12 +553,12 @@ public class Parameter implements INamedObject, IWithParameters {
 				}
 				substitutionValue = d;
 			} else if ("fixeduid".equals(name.toLowerCase())) {
-				if (!ConfigurationUtils.stubConfiguration(classLoader)) {
+				if (!ConfigurationUtils.stubConfiguration(configurationClassLoader)) {
 					throw new ParameterException("Parameter pattern [" + name + "] only allowed in stub mode");
 				}
 				substitutionValue = FIXEDUID;
 			} else if ("fixedhostname".equals(name.toLowerCase())) {
-				if (!ConfigurationUtils.stubConfiguration(classLoader)) {
+				if (!ConfigurationUtils.stubConfiguration(configurationClassLoader)) {
 					throw new ParameterException("Parameter pattern [" + name + "] only allowed in stub mode");
 				}
 				substitutionValue = FIXEDHOSTNAME;

--- a/core/src/main/java/nl/nn/adapterframework/parameters/Parameter.java
+++ b/core/src/main/java/nl/nn/adapterframework/parameters/Parameter.java
@@ -537,7 +537,7 @@ public class Parameter implements INamedObject, IWithParameters {
 			} else if ("hostname".equals(name.toLowerCase())) {
 				substitutionValue = Misc.getHostname();
 			} else if ("fixeddate".equals(name.toLowerCase())) {
-				if (!ConfigurationUtils.stubConfiguration()) {
+				if (!ConfigurationUtils.stubConfiguration(classLoader)) {
 					throw new ParameterException("Parameter pattern [" + name + "] only allowed in stub mode");
 				}
 				Date d;
@@ -553,12 +553,12 @@ public class Parameter implements INamedObject, IWithParameters {
 				}
 				substitutionValue = d;
 			} else if ("fixeduid".equals(name.toLowerCase())) {
-				if (!ConfigurationUtils.stubConfiguration()) {
+				if (!ConfigurationUtils.stubConfiguration(classLoader)) {
 					throw new ParameterException("Parameter pattern [" + name + "] only allowed in stub mode");
 				}
 				substitutionValue = FIXEDUID;
 			} else if ("fixedhostname".equals(name.toLowerCase())) {
-				if (!ConfigurationUtils.stubConfiguration()) {
+				if (!ConfigurationUtils.stubConfiguration(classLoader)) {
 					throw new ParameterException("Parameter pattern [" + name + "] only allowed in stub mode");
 				}
 				substitutionValue = FIXEDHOSTNAME;

--- a/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
@@ -325,7 +325,7 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 				if (findForward(ILLEGAL_RESULT_FORWARD) == null)
 					throw new ConfigurationException(getLogPrefix(null) + "has no forward with name [illegalResult]");
 			}
-			if (!ConfigurationUtils.stubConfiguration()) {
+			if (!ConfigurationUtils.stubConfiguration(getConfigurationClassLoader())) {
 				if (StringUtils.isNotEmpty(getTimeOutOnResult())) {
 					throw new ConfigurationException(getLogPrefix(null)+"timeOutOnResult only allowed in stub mode");
 				}
@@ -786,7 +786,7 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 			if  (pipeline!=null) {
 				Adapter adapter = pipeline.getAdapter();
 				if (adapter!=null) {
-					if (getPresumedTimeOutInterval()>=0 && !ConfigurationUtils.stubConfiguration()) {
+					if (getPresumedTimeOutInterval()>=0 && !ConfigurationUtils.stubConfiguration(getConfigurationClassLoader())) {
 						long lastExitIsTimeoutDate = adapter.getLastExitIsTimeoutDate(getName());
 						if (lastExitIsTimeoutDate>0) {
 							long duration = startTime - lastExitIsTimeoutDate;
@@ -827,7 +827,7 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 			if  (pipeline!=null) {
 				Adapter adapter = pipeline.getAdapter();
 				if (adapter!=null) {
-					if (getPresumedTimeOutInterval()>=0 && !ConfigurationUtils.stubConfiguration()) {
+					if (getPresumedTimeOutInterval()>=0 && !ConfigurationUtils.stubConfiguration(getConfigurationClassLoader())) {
 						if (!PRESUMED_TIMEOUT_FORWARD.equals(exitState)) {
 							adapter.setLastExitState(getName(), System.currentTimeMillis(), exitState);
 						}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/PutSystemDateInSession.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/PutSystemDateInSession.java
@@ -68,7 +68,7 @@ public class PutSystemDateInSession extends FixedForwardPipe {
 		}
 
 		if (isReturnFixedDate()) {
-			if (!ConfigurationUtils.stubConfiguration()) {
+			if (!ConfigurationUtils.stubConfiguration(getConfigurationClassLoader())) {
 				throw new ConfigurationException(getLogPrefix(null)+"returnFixedDate only allowed in stub mode");
 			}
 		}

--- a/core/src/main/java/nl/nn/adapterframework/statistics/StatisticsKeeper.java
+++ b/core/src/main/java/nl/nn/adapterframework/statistics/StatisticsKeeper.java
@@ -84,7 +84,7 @@ public class StatisticsKeeper implements ItemList {
 	    
 	    List classBoundariesBuffer = new ArrayList();
 	
-	    StringTokenizer tok = AppConstants.getInstance().getTokenizer(boundaryConfigKey,defaultBoundaryList);
+	    StringTokenizer tok = AppConstants.getInstance().getTokenizedProperty(boundaryConfigKey,defaultBoundaryList);
 	
 	    while (tok.hasMoreTokens()) {
 	        classBoundariesBuffer.add(new Long(Long.parseLong(tok.nextToken())));

--- a/core/src/main/java/nl/nn/adapterframework/statistics/percentiles/PercentileEstimatorBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/statistics/percentiles/PercentileEstimatorBase.java
@@ -38,7 +38,7 @@ public class PercentileEstimatorBase implements PercentileEstimator {
 
 	public PercentileEstimatorBase(String configKey, String defaultPList, int valueArraySize) {
 		List pListBuffer = new ArrayList();
-		StringTokenizer tok = AppConstants.getInstance().getTokenizer(configKey,defaultPList);
+		StringTokenizer tok = AppConstants.getInstance().getTokenizedProperty(configKey,defaultPList);
 		
 		while (tok.hasMoreTokens()) {
 			pListBuffer.add(new Integer(Integer.parseInt(tok.nextToken())));

--- a/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
@@ -42,6 +42,7 @@ import nl.nn.adapterframework.configuration.classloaders.IConfigurationClassLoad
  * that file is loaded also</p>
 
  * @author Niels Meijer
+ * @version 2.0
  *
  */
 public final class AppConstants extends Properties implements Serializable {
@@ -61,6 +62,7 @@ public final class AppConstants extends Properties implements Serializable {
 
 		load(classLoader, APP_CONSTANTS_PROPERTIES_FILE, true);
 
+		//TODO Make sure this to happens only once, and store all the properties in 'additionalProperties' to be loaded for each AppConstants instance
 		Properties databaseProperties = JdbcUtil.retrieveJdbcPropertiesFromDatabase();
 		if (databaseProperties!=null) {
 			putAll(databaseProperties);
@@ -112,7 +114,7 @@ public final class AppConstants extends Properties implements Serializable {
 	public static void removeInstance(final ClassLoader cl) {
 		ClassLoader classLoader = cl;
 		if(classLoader == null) {
-			throw new IllegalStateException("calling AppConstants.getInstance without ClassLoader");
+			throw new IllegalStateException("calling AppConstants.removeInstance without ClassLoader");
 		}
 		AppConstants instance = appConstantsMap.get(classLoader);
 		if (instance != null) {
@@ -250,8 +252,9 @@ public final class AppConstants extends Properties implements Serializable {
 	}
 
 	private synchronized void load(ClassLoader classLoader, String filename, String suffix, boolean loadAdditionalPropertiesFiles) {
-		if(StringUtils.isEmpty(filename))
+		if(StringUtils.isEmpty(filename)) {
 			throw new IllegalStateException("file to load properties from cannot be null");
+		}
 
 		StringTokenizer tokenizer = new StringTokenizer(filename, ",");
 		while (tokenizer.hasMoreTokens()) {

--- a/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
@@ -182,7 +182,7 @@ public final class AppConstants extends Properties implements Serializable {
 	}
 
 	/**
-	 * Creates a tokenizer from the values of this key.  As a sepearator the "," is used.
+	 * Creates a tokenizer from the values of this key. As a separator the "," is used.
 	 * Uses the {@link #getResolvedProperty(String)} method.
 	 * Can be used to process lists of values.
 	 */
@@ -190,7 +190,7 @@ public final class AppConstants extends Properties implements Serializable {
 		return new StringTokenizer(getResolvedProperty(key), ",");
 	}
 	/**
-	 * Creates a tokenizer from the values of this key.
+	 * Creates a tokenizer from the values of this key. As a separator the "," is used.
 	 * Uses the {@link #getResolvedProperty(String)} method.
 	 * Can be used to process lists of values.
 	 */
@@ -340,15 +340,8 @@ public final class AppConstants extends Properties implements Serializable {
 	/**
 	 * Add property to global (all) AppConstants
 	 */
-	public void put(String key, String value) {
+	public synchronized void put(String key, String value) {
 		setProperty(key, value, false);
-	}
-
-	/**
-	 * Add property to a specific AppConstants instance
-	 */
-	public static void put(ClassLoader classLoader, String key, String value) {
-		getInstance(classLoader).setProperty(key, value, true);
 	}
 
 	/**

--- a/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
@@ -184,19 +184,19 @@ public final class AppConstants extends Properties implements Serializable {
 	}
 
 	/**
-	 * Creates a tokenizer from the values of this key. As a separator the "," is used.
+	 * Creates a tokenizer from the resolved value of this key. As a separator the "," is used.
 	 * Uses the {@link #getResolvedProperty(String)} method.
 	 * Can be used to process lists of values.
 	 */
-	public StringTokenizer getTokenizer(String key) {
+	public StringTokenizer getTokenizedProperty(String key) {
 		return new StringTokenizer(getResolvedProperty(key), ",");
 	}
 	/**
-	 * Creates a tokenizer from the values of this key. As a separator the "," is used.
+	 * Creates a tokenizer from the resolved value of this key. As a separator the "," is used.
 	 * Uses the {@link #getResolvedProperty(String)} method.
 	 * Can be used to process lists of values.
 	 */
-	public StringTokenizer getTokenizer(String key, String defaults) {
+	public StringTokenizer getTokenizedProperty(String key, String defaults) {
 		String list = getResolvedProperty(key);
 		if (list==null)
 			list = defaults;

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/FileViewerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/FileViewerServlet.java
@@ -98,7 +98,7 @@ public class FileViewerServlet extends HttpServlet  {
 	public static final String permissionRules = AppConstants.getInstance().getResolvedProperty("FileViewerServlet.permission.rules");
 
 	public static String makeConfiguredReplacements(String input) {
-		StringTokenizer tok=AppConstants.getInstance().getTokenizer(fvConfigKey);
+		StringTokenizer tok=AppConstants.getInstance().getTokenizedProperty(fvConfigKey);
 		while (tok.hasMoreTokens()){
 			String signal=tok.nextToken();
 			String pre=AppConstants.getInstance().getProperty(fvConfigKey+"."+signal+".pre");

--- a/core/src/test/java/nl/nn/adapterframework/configuration/ClassLoaderManagerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/configuration/ClassLoaderManagerTest.java
@@ -94,16 +94,16 @@ public class ClassLoaderManagerTest extends Mockito {
 
 		if(type.endsWith("DirectoryClassLoader")) {
 			String directory = getTestClassesLocation()+"ClassLoader/DirectoryClassLoaderRoot/";
-			appConstants.put("configurations."+configurationName+".directory", directory);
+			appConstants.put("configurations."+configurationName+".directory", (Object) directory);
 		}
 
 		if(type.endsWith("JarFileClassLoader")) {
 			URL file = this.getClass().getResource(JAR_FILE);
-			appConstants.put("configurations."+configurationName+".jar", file.getFile());
+			appConstants.put("configurations."+configurationName+".jar", (Object) file.getFile());
 		}
 
 		if(type.endsWith("ServiceClassLoader")) {
-			appConstants.put("configurations."+configurationName+".adapterName", ADAPTER_SERVICE_NAME);
+			appConstants.put("configurations."+configurationName+".adapterName", (Object) ADAPTER_SERVICE_NAME);
 		}
 	}
 
@@ -126,7 +126,7 @@ public class ClassLoaderManagerTest extends Mockito {
 			if(o[0] != null)
 				appConstants.put("configurations."+o[1]+".classLoaderType", o[0]);
 		}
-		appConstants.put("configurations.names", configurationsNames);
+		appConstants.put("configurations.names", (Object) configurationsNames);
 
 		createAdapter4ServiceClassLoader(ADAPTER_SERVICE_NAME);
 		mockDatabase();
@@ -264,11 +264,11 @@ public class ClassLoaderManagerTest extends Mockito {
 		if(skip) return; //This ClassLoader can't actually retrieve files...
 
 		String testConfiguration = "myNewClassLoader";
-		appConstants.put("configurations."+testConfiguration+".classLoaderType", "DirectoryClassLoader");
-		appConstants.put("configurations."+configurationName+".parentConfig", testConfiguration);
+		appConstants.put("configurations."+testConfiguration+".classLoaderType", (Object) "DirectoryClassLoader");
+		appConstants.put("configurations."+configurationName+".parentConfig", (Object) testConfiguration);
 		String directory = getTestClassesLocation()+"ClassLoader/";
-		appConstants.put("configurations."+testConfiguration+".directory", directory);
-		appConstants.put("configurations.names", appConstants.get("configurations.names") + ","+testConfiguration);
+		appConstants.put("configurations."+testConfiguration+".directory", (Object) directory);
+		appConstants.put((Object) "configurations.names", (Object) appConstants.get("configurations.names") + ","+testConfiguration);
 
 		String testFile = "fileOnlyOnLocalClassPath.txt";
 		ClassLoader parentClassloader = getClassLoader(testConfiguration);

--- a/core/src/test/java/nl/nn/adapterframework/configuration/ClassLoaderManagerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/configuration/ClassLoaderManagerTest.java
@@ -94,16 +94,16 @@ public class ClassLoaderManagerTest extends Mockito {
 
 		if(type.endsWith("DirectoryClassLoader")) {
 			String directory = getTestClassesLocation()+"ClassLoader/DirectoryClassLoaderRoot/";
-			appConstants.put("configurations."+configurationName+".directory", (Object) directory);
+			setLocalProperty("configurations."+configurationName+".directory", directory);
 		}
 
 		if(type.endsWith("JarFileClassLoader")) {
 			URL file = this.getClass().getResource(JAR_FILE);
-			appConstants.put("configurations."+configurationName+".jar", (Object) file.getFile());
+			setLocalProperty("configurations."+configurationName+".jar", file.getFile());
 		}
 
 		if(type.endsWith("ServiceClassLoader")) {
-			appConstants.put("configurations."+configurationName+".adapterName", (Object) ADAPTER_SERVICE_NAME);
+			setLocalProperty("configurations."+configurationName+".adapterName", ADAPTER_SERVICE_NAME);
 		}
 	}
 
@@ -123,10 +123,12 @@ public class ClassLoaderManagerTest extends Mockito {
 		String configurationsNames = "";
 		for(Object[] o: data()) {
 			configurationsNames += o[1]+",";
-			if(o[0] != null)
-				appConstants.put("configurations."+o[1]+".classLoaderType", o[0]);
+			if(o[0] != null) {
+				String value = (String) o[0];
+				setLocalProperty("configurations."+o[1]+".classLoaderType", value);
+			}
 		}
-		appConstants.put("configurations.names", (Object) configurationsNames);
+		setLocalProperty("configurations.names", configurationsNames);
 
 		createAdapter4ServiceClassLoader(ADAPTER_SERVICE_NAME);
 		mockDatabase();
@@ -264,11 +266,11 @@ public class ClassLoaderManagerTest extends Mockito {
 		if(skip) return; //This ClassLoader can't actually retrieve files...
 
 		String testConfiguration = "myNewClassLoader";
-		appConstants.put("configurations."+testConfiguration+".classLoaderType", (Object) "DirectoryClassLoader");
-		appConstants.put("configurations."+configurationName+".parentConfig", (Object) testConfiguration);
+		setLocalProperty("configurations."+testConfiguration+".classLoaderType", "DirectoryClassLoader");
+		setLocalProperty("configurations."+configurationName+".parentConfig", testConfiguration);
 		String directory = getTestClassesLocation()+"ClassLoader/";
-		appConstants.put("configurations."+testConfiguration+".directory", (Object) directory);
-		appConstants.put((Object) "configurations.names", (Object) appConstants.get("configurations.names") + ","+testConfiguration);
+		setLocalProperty("configurations."+testConfiguration+".directory", directory);
+		setLocalProperty("configurations.names", appConstants.get("configurations.names") + ","+testConfiguration);
 
 		String testFile = "fileOnlyOnLocalClassPath.txt";
 		ClassLoader parentClassloader = getClassLoader(testConfiguration);
@@ -306,5 +308,14 @@ public class ClassLoaderManagerTest extends Mockito {
 		//Make sure the manager returns the same classloader after reloading it
 		ClassLoader config2 = manager.get(configurationName);
 		assertEquals(config1.toString(), config2.toString());
+	}
+
+	/**This method makes sure the property is only set in the local AppConstants instance.
+	 * When you use the default put/setProperty it stores the property in the additionalProperties and
+	 * upon creation of a new AppConstants instance it will set all the previously set properties
+	 */
+	@SuppressWarnings("deprecation")
+	private void setLocalProperty(String key, String value) {
+		appConstants.put((Object) key, (Object) value);
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/util/AppConstantsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/AppConstantsTest.java
@@ -103,6 +103,81 @@ public class AppConstantsTest {
 		assertEquals("changed", constants.getResolvedProperty("only.in.deploymentspecifics.parent"));
 	}
 
+	@Test(expected=IllegalStateException.class)
+	public void callGetInstanceWithoutClassLoader() {
+		AppConstants.getInstance(null);
+	}
+
+	@Test(expected=IllegalStateException.class)
+	public void callRemoveInstanceWithoutClassLoader() {
+		AppConstants.removeInstance(null);
+	}
+
+	@Test
+	public void callUnresolvedProperty() {
+		assertEquals("${resolve.me}", constants.getUnresolvedProperty("unresolved.property"));
+	}
+
+	@Test
+	public void callResolvedProperty() {
+		assertEquals("123", constants.getResolvedProperty("unresolved.property"));
+	}
+
+	@Test
+	public void callNonExistingProperty() {
+		assertEquals(null, constants.getResolvedProperty("i.dont.exist"));
+	}
+
+	@Test
+	public void setRuntimePropertyThroughPut() {
+		//Remove the default instance
+		AppConstants.removeInstance();
+		//Create a new one and set a property on the newly created instance
+		AppConstants.getInstance().put("dummyConstant", "2.7");
+		//Retrieve the property through a different instance
+		assertEquals("2.7", constants.get("dummyConstant"));
+	}
+
+	@Test
+	public void setRuntimePropertyThroughSetProperty() {
+		//Remove the default instance
+		AppConstants.removeInstance();
+		//Create a new one and set a property on the newly created instance
+		AppConstants.getInstance().setProperty("dummyConstant2", "2.8");
+		//Retrieve the property through a different instance
+		assertEquals("2.8", constants.get("dummyConstant2"));
+	}
+
+	@Test
+	public void setAndGetStringProperty() {
+		constants.setProperty("property.type.string", "string");
+		assertEquals("string", constants.getString("property.type.string", ""));
+	}
+
+	@Test
+	public void setAndGetBooleanProperty() {
+		constants.setProperty("property.type.boolean", "true");
+		assertEquals(true, constants.getBoolean("property.type.boolean", false));
+	}
+
+	@Test
+	public void setAndGetIntProperty() {
+		constants.setProperty("property.type.int", "123");
+		assertEquals(123, constants.getInt("property.type.int", 0));
+	}
+
+	@Test
+	public void setAndGetLongProperty() {
+		constants.setProperty("property.type.long", "123");
+		assertEquals(123, constants.getLong("property.type.long", 0));
+	}
+
+	@Test
+	public void setAndGetDoubleProperty() {
+		constants.setProperty("property.type.double", "123.456");
+		assertEquals(123.456, constants.getDouble("property.type.double", 0.0), 0);
+	}
+
 	private class ClassLoaderMock extends ClassLoader {
 		private boolean simulateReload = false;
 

--- a/core/src/test/resources/AppConstants/AppConstants.properties
+++ b/core/src/test/resources/AppConstants/AppConstants.properties
@@ -12,3 +12,6 @@ overwrite.in.deploymentspecifics.parent=1
 
 only.in.buildinfo=1
 overwrite.in.buildinfo=1
+
+resolve.me=123
+unresolved.property=${resolve.me}


### PR DESCRIPTION
Make sure properties are set throughout all AppConstants singletons
Unify put/set methods
Disallow use of getInstance(null)
Add logging to property loading