### PR TITLE
Classpath issue spring spi

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/lifecycle/IbisApplicationInitializer.java
+++ b/core/src/main/java/nl/nn/adapterframework/lifecycle/IbisApplicationInitializer.java
@@ -18,12 +18,6 @@ package nl.nn.adapterframework.lifecycle;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletException;
 
-import nl.nn.adapterframework.configuration.ConfigurationWarnings;
-import nl.nn.adapterframework.util.AppConstants;
-import nl.nn.adapterframework.util.LogUtil;
-
-import org.apache.commons.lang3.StringUtils;
-import org.apache.log4j.Logger;
 import org.springframework.web.SpringServletContainerInitializer;
 import org.springframework.web.WebApplicationInitializer;
 
@@ -45,75 +39,13 @@ import org.springframework.web.WebApplicationInitializer;
  */
 public class IbisApplicationInitializer implements WebApplicationInitializer {
 
-	private ServletContext servletContext;
-	private Logger log = LogUtil.getLogger(this);
-
 	@Override
 	public void onStartup(ServletContext servletContext) throws ServletException {
 		servletContext.log("Starting IBIS Application");
-		this.servletContext = servletContext;
-
-		checkAndCorrectLegacyServerTypes();
-		determineApplicationServerType();
 
 		//TODO start the springContext from here!
-	}
-
-	/**
-	 * Log the message in System.out, the Ibis console and the Log4j logger
-	 * @param message to log
-	 */
-	private void log(String message) {
-		servletContext.log(message);
-		ConfigurationWarnings.getInstance().add(log, message);
-	}
-
-	private void checkAndCorrectLegacyServerTypes() {
-		//In case the property is explicitly set with an unsupported value, E.g. 'applName + number'
-		String applicationServerType = System.getProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY);
-		if (StringUtils.isNotEmpty(applicationServerType)) {
-			if (applicationServerType.equalsIgnoreCase("WAS5") || applicationServerType.equalsIgnoreCase("WAS6")) {
-				log("interpeting value ["+applicationServerType+"] of property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] as [WAS]");
-				System.setProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY, "WAS");
-			} else if (applicationServerType.equalsIgnoreCase("TOMCAT6")) {
-				log("interpeting value ["+applicationServerType+"] of property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] as [TOMCAT]");
-				System.setProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY, "TOMCAT");
-			}
-		}
-	}
-
-	private void determineApplicationServerType() {
-		String serverInfo = servletContext.getServerInfo();
-		String defaultApplicationServerType = null;
-		if (StringUtils.containsIgnoreCase(serverInfo, "WebSphere Liberty")) {
-			defaultApplicationServerType = "WLP";
-		} else if (StringUtils.containsIgnoreCase(serverInfo, "WebSphere")) {
-			defaultApplicationServerType = "WAS";
-		} else if (StringUtils.containsIgnoreCase(serverInfo, "Tomcat")) {
-			defaultApplicationServerType = "TOMCAT";
-		} else if (StringUtils.containsIgnoreCase(serverInfo, "JBoss")) {
-			defaultApplicationServerType = "JBOSS";
-		} else if (StringUtils.containsIgnoreCase(serverInfo, "WildFly")) {
-			defaultApplicationServerType = "JBOSS";
-		} else if (StringUtils.containsIgnoreCase(serverInfo, "jetty")) {
-			String javaHome = System.getProperty("java.home");
-			if (StringUtils.containsIgnoreCase(javaHome, "tibco")) {
-				defaultApplicationServerType = "TIBCOAMX";
-			} else {
-				defaultApplicationServerType = "JETTYMVN";
-			}
-		} else {
-			defaultApplicationServerType = "TOMCAT";
-			log("unknown server info ["+serverInfo+"] default application server type could not be determined, TOMCAT will be used as default value");
-		}
-
-		//has it explicitly been set? if not, set the property
-		String serverType = System.getProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY);
-		if (defaultApplicationServerType.equals(serverType)) { //and is it the same as the automatically detected version?
-			log("property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] already has a default value ["+defaultApplicationServerType+"]");
-		}
-		else if (StringUtils.isEmpty(serverType)) { //or has it not been set?
-			System.setProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY, defaultApplicationServerType);
-		}
+		//NM: found out that the WebApplicationInitializer has to be on the webapp's classpath
+		//putting it in core wont help, as it wont search in the webapp's dependencies
+		//for some reason it only works on eclipse+tomcat but not a standalone application server
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/lifecycle/IbisApplicationServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/lifecycle/IbisApplicationServlet.java
@@ -169,15 +169,24 @@ public class IbisApplicationServlet extends CXFServlet {
 		}
 	}
 
+	/**
+	 * Log the message in System.out, the Ibis console and the Log4j logger
+	 * @param message to log
+	 */
+	private void log2ContextAndGui(String message) {
+		servletContext.log(message);
+		ConfigurationWarnings.getInstance().add(log, message);
+	}
+
 	private void checkAndCorrectLegacyServerTypes() {
 		//In case the property is explicitly set with an unsupported value, E.g. 'applName + number'
 		String applicationServerType = System.getProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY);
 		if (StringUtils.isNotEmpty(applicationServerType)) {
 			if (applicationServerType.equalsIgnoreCase("WAS5") || applicationServerType.equalsIgnoreCase("WAS6")) {
-				log("interpeting value ["+applicationServerType+"] of property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] as [WAS]");
+				log2ContextAndGui("interpeting value ["+applicationServerType+"] of property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] as [WAS]");
 				System.setProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY, "WAS");
 			} else if (applicationServerType.equalsIgnoreCase("TOMCAT6")) {
-				log("interpeting value ["+applicationServerType+"] of property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] as [TOMCAT]");
+				log2ContextAndGui("interpeting value ["+applicationServerType+"] of property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] as [TOMCAT]");
 				System.setProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY, "TOMCAT");
 			}
 		}
@@ -205,13 +214,13 @@ public class IbisApplicationServlet extends CXFServlet {
 			}
 		} else {
 			defaultApplicationServerType = "TOMCAT";
-			log("unknown server info ["+serverInfo+"] default application server type could not be determined, TOMCAT will be used as default value");
+			log2ContextAndGui("unknown server info ["+serverInfo+"] default application server type could not be determined, TOMCAT will be used as default value");
 		}
 
 		//has it explicitly been set? if not, set the property
 		String serverType = System.getProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY);
 		if (defaultApplicationServerType.equals(serverType)) { //and is it the same as the automatically detected version?
-			log("property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] already has a default value ["+defaultApplicationServerType+"]");
+			log2ContextAndGui("property ["+AppConstants.APPLICATION_SERVER_TYPE_PROPERTY+"] already has a default value ["+defaultApplicationServerType+"]");
 		}
 		else if (StringUtils.isEmpty(serverType)) { //or has it not been set?
 			System.setProperty(AppConstants.APPLICATION_SERVER_TYPE_PROPERTY, defaultApplicationServerType);


### PR DESCRIPTION
Turns out it's a lot more complicated to start the framework through Spring's WebApplicationInitializer (SPI). The WebApplicationInitializer has to be available on the classpath of the webapp that's being ran, and not (hidden) within a dependency!

Since this file was in the core module, it worked on eclipse+tomcat, as eclipse wired all modules on the classpath. The original changes have been cleaned up (see #297) and this reverts some functions back to their previous location.