### PR TITLE
Set jdbc.convertFieldnamesToUppercase default to true

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -59,6 +59,7 @@ Upcoming
   fileListForcedAfter, outputFilenamePattern, passWithoutDirectory, numberOfBackups, overwrite and random.
 - Remove attribute 'count' from result of iterating pipes like ForEachChildElementPipe, to enable streaming output.
 - The MailSender displayName element no longer exist, please use attribute `name` on the from/to elements instead.
+- jdbc.convertFieldnamesToUppercase has been set to true by default
 
 
 

--- a/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/AppConstants.java
@@ -71,7 +71,12 @@ public final class AppConstants extends Properties implements Serializable {
 		//Add all ibis properties
 		putAll(additionalProperties);
 
-		log.info("created new AppConstants instance for classloader ["+classLoader+"]");
+		if(log.isInfoEnabled() && classLoader instanceof IConfigurationClassLoader) {
+			log.info("created new AppConstants instance for classloader ["+classLoader+"]");
+		}
+		else {
+			log.info("created new AppConstants instance for root classloader");
+		}
 	}
 
 	/**

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -111,7 +111,7 @@ jdbc.storage.checkIndices=true
 jdbc.dateFormat=yyyy-MM-dd
 jdbc.timestampFormat=yyyy-MM-dd HH:mm:ss
 
-jdbc.convertFieldnamesToUppercase=false
+jdbc.convertFieldnamesToUppercase=true
 
 # the path where the logging can be found, respectively the wildcard for log-files
 logging.path=${log.dir}


### PR DESCRIPTION
Table names in a database might be upper-, lower- or random-case. This converts the tablenames in the rowset results to uppercase.