### PR TITLE
Add various LadybugPipe improvements

### DIFF
--- a/ladybug/src/main/java/nl/nn/ibistesttool/LadybugPipe.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/LadybugPipe.java
@@ -88,8 +88,8 @@ public class LadybugPipe extends FixedForwardPipe {
 	@Override
 	public PipeRunResult doPipe(Object input, IPipeLineSession session) throws PipeRunException {
 		XmlBuilder results = new XmlBuilder("Results");
-		int errorCount = 0;
-		int notEqualCount = 0;
+		int reportsPassed = 0;
+		
 		List<Report> reports = new ArrayList<Report>();
 		try {
 			List<Integer> storageIds = testStorage.getStorageIds();
@@ -102,12 +102,13 @@ public class LadybugPipe extends FixedForwardPipe {
 				}
 			}
 		} catch (StorageException e) {
-			errorCount++;
 			addExceptionElement(results, e);
 		}
 		ReportRunner reportRunner = new ReportRunner();
 		reportRunner.setTestTool(testTool);
 		reportRunner.setSecurityContext(new IbisSecurityContext(session, checkRoles));
+		
+		long startTime = System.currentTimeMillis();
 		boolean reportGeneratorEnabledOldValue = testTool.getReportGeneratorEnabled();
 		if(enableReportGenerator) {
 			testTool.setReportGeneratorEnabled(true);
@@ -116,62 +117,76 @@ public class LadybugPipe extends FixedForwardPipe {
 		if(enableReportGenerator) {
 			testTool.setReportGeneratorEnabled(reportGeneratorEnabledOldValue);
 		}
+		long endTime = System.currentTimeMillis();
 		
 		for (Report report : reports) {
 			RunResult runResult = reportRunner.getResults().get(report.getStorageId());
+			long originalDuration = report.getEndTime() - report.getStartTime();
+			long duration = -1;
+			boolean equal = false;
+			String error = "";
+			
 			if (runResult.errorMessage != null) {
-				errorCount++;
-				results.addSubElement("Error", runResult.errorMessage);
+				error = runResult.errorMessage;
 			} else {
 				Report runResultReport = null;
 				try {
-					runResultReport = reportRunner.getRunResultReport(debugStorage, runResult.correlationId);
+					runResultReport = ReportRunner.getRunResultReport(debugStorage, runResult.correlationId);
 				} catch (StorageException e) {
-					errorCount++;
 					addExceptionElement(results, e);
 				}
+				
 				if (runResultReport == null) {
-					errorCount++;
-					results.addSubElement("Error", "Result report not found. Report generator not enabled?");
+					error = "Result report not found. Report generator not enabled?";
 				} else {
-					long originalDuration = report.getEndTime() - report.getStartTime();
-					long duration = runResultReport.getEndTime() - runResultReport.getStartTime();
-					boolean equal = false;
+					duration = runResultReport.getEndTime() - runResultReport.getStartTime();
 					report.setGlobalReportXmlTransformer(reportXmlTransformer);
 					runResultReport.setGlobalReportXmlTransformer(reportXmlTransformer);
 					runResultReport.setTransformation(report.getTransformation());
 					runResultReport.setReportXmlTransformer(report.getReportXmlTransformer());
 					if (report.toXml().equals(runResultReport.toXml())) {
 						equal = true;
-					} else {
-						notEqualCount++;
-					}
-					XmlBuilder result = new XmlBuilder("Result");
-					results.addSubElement(result);
-					result.addSubElement("Path", report.getPath());
-					result.addSubElement("Name", report.getName());
-					result.addSubElement("OriginalDuration", "" + originalDuration);
-					result.addSubElement("Duration", "" + duration);
-					result.addSubElement("Equal", "" + equal);
-					if (writeToLog || writeToSystemOut) {
-						String message;
-						message = "Path=\"" + report.getPath() + "\", "
-								+ "Name=\"" + report.getName() + "\", "
-								+ "OriginalDuration=\"" + originalDuration + "\", "
-								+ "Duration=\"" + duration + "\", "
-								+ "Equal=\"" + equal + "\"";
-						if (writeToLog) {
-							log.info(message);
-						}
-						if (writeToSystemOut) {
-							System.out.println(message);
-						}
+						reportsPassed++;
 					}
 				}
 			}
+			XmlBuilder result = new XmlBuilder("Result");
+			results.addSubElement(result);
+			result.addSubElement("Path", report.getPath());
+			result.addSubElement("Name", report.getName());
+			result.addSubElement("OriginalDuration", "" + originalDuration);
+			if(duration > -1) result.addSubElement("Duration", "" + duration);
+			result.addSubElement("Equal", "" + equal);
+			if(!error.isEmpty()) result.addSubElement("Error", error);
+			if (writeToLog || writeToSystemOut) {
+				writeToLogOrSysOut("Path=\"" + report.getPath() + "\", "
+						+ "Name=\"" + report.getName() + "\", "
+						+ "OriginalDuration=\"" + originalDuration + "\", "
+						+ ((duration > -1) ? "Duration=\"" + duration + "\", " : "")
+						+ "Equal=\"" + equal + "\""
+						+ (!error.isEmpty() ? ", Error=\"" + error + "\"" : ""));
+			}
 		}
-		PipeForward forward = (errorCount == 0 && notEqualCount == 0) ? getForward() : failureForward;
+		
+		boolean allReportsPassed = reportsPassed == reports.size();
+		if (writeToLog || writeToSystemOut) {
+			writeToLogOrSysOut("Total=\"" + reports.size() + "\", "
+					+ "Passed=\"" + reportsPassed + "\", "
+					+ "Failed=\"" + (reports.size() - reportsPassed) + "\", "
+					+ "TotalDuration=\"" + (endTime - startTime) + "\", "
+					+ "Equal=\"" + allReportsPassed + "\"");
+		}
+		PipeForward forward = allReportsPassed ? getForward() : failureForward;
 		return new PipeRunResult(forward, results.toXML());
+	}
+
+	private void writeToLogOrSysOut(String message) {
+		if (writeToLog) {
+			log.info(message);
+		}
+		if (writeToSystemOut) {
+			System.out.println(message);
+		}
 	}
 
 	private void addExceptionElement(XmlBuilder results, Exception e) {


### PR DESCRIPTION
Since most of these small changes are interdependant, I combined all of them into one pull request.

Summary:
- Passed reports are counted rather than failed ones
- Applicable metadata is logged even in the event of an error
- Error messages are now added to the report log message
- Generic writeToLogOrSysOut() method
- Concluding message that summarizes the results of all run reports