### PR TITLE
Add Spring attribute for ibistesttool.maxMemoryUsage

### DIFF
--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -248,6 +248,8 @@ stub4testtool.configuration=false
 ibistesttool.custom=
 # maximum number of checkpoints per report
 ibistesttool.maxCheckpoints=2500
+# maximum estimated memory usage per report, in bytes
+ibistesttool.maxMemoryUsage=100000000
 # maximum character length for a report message. NOTE: Log4j messages can be capped with the 'log.lengthLogRecords' property in the log4j4ibis.properties file.
 ibistesttool.maxMessageLength=1000000
 # report transformation xslt

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -11,7 +11,7 @@
     <dependency>
       <groupId>org.ibissource</groupId>
       <artifactId>ibis-ladybug</artifactId>
-      <version>2.0.10</version>
+      <version>2.0.11</version>
     </dependency>
     <dependency>
       <groupId>org.ibissource</groupId>

--- a/ladybug/src/main/resources/springIbisTestTool.xml
+++ b/ladybug/src/main/resources/springIbisTestTool.xml
@@ -28,6 +28,10 @@
 		<constructor-arg value="${ibistesttool.maxCheckpoints}"/>
 	</bean>
 
+	<bean name="maxMemoryUsage" class="java.lang.Long">
+		<constructor-arg value="${ibistesttool.maxMemoryUsage}"/>
+	</bean>
+
 	<bean name="maxMessageLength" class="java.lang.Integer">
 		<constructor-arg value="${ibistesttool.maxMessageLength}"/>
 	</bean>
@@ -40,6 +44,7 @@
 		<property name="configName"><ref bean="configName"/></property>
 		<property name="configVersion"><ref bean="configVersion"/></property>
 		<property name="maxCheckpoints"><ref bean="maxCheckpoints"/></property>
+		<property name="maxMemoryUsage"><ref bean="maxMemoryUsage"/></property>
 		<property name="maxMessageLength"><ref bean="maxMessageLength"/></property>
 		<property name="regexFilter"><ref bean="regexFilter"/></property>
 <!--property name="loggingStorage"><ref bean="runStorage"/></property-->


### PR DESCRIPTION
Allows Frank developers to configure the maximum memory usage for Ladybug reports (as implemented in [this pull request](https://github.com/ibissource/ibis-ladybug/pull/15)) in a property file.