### PR TITLE
Migration of Spring Framework from 3.2.16.RELEASE to 4.3.25.RELEASE

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -11,7 +11,7 @@
 	<name>Ibis AdapterFramework core</name>
 
 	<properties>
-		<spring.version>3.2.16.RELEASE</spring.version>
+		<spring.version>4.3.25.RELEASE</spring.version>
 		<resteasy.version>3.0.12.Final</resteasy.version>
 		<j2v8.version>4.6.0</j2v8.version>
 	</properties>

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -36,7 +36,7 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-jdbc</artifactId>
-      <version>3.2.16.RELEASE</version>
+      <version>4.3.25.RELEASE</version>
     </dependency>
   </dependencies>
 </project>

--- a/ladybug/src/main/java/nl/nn/ibistesttool/tibet2/Storage.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/tibet2/Storage.java
@@ -150,7 +150,11 @@ public class Storage extends JdbcFacade implements nl.nn.testtool.storage.CrudSt
 
 	public int getSize() throws StorageException {
 		try {
-			return jdbcTemplate.queryForInt("select count(*) from " + table);
+			/* queryForInt() deprecated since version Spring 3.2.x
+			 * https://www.mkyong.com/spring/jdbctemplate-queryforint-is-deprecated/
+			 * return jdbcTemplate.queryForInt("select count(*) from " + table);
+			 */
+			return jdbcTemplate.queryForObject("select count(*) from " + table, Integer.class);			
 		} catch(DataAccessException e){
 			throw new StorageException("Could not read size", e);
 		}

--- a/larva/pom.xml
+++ b/larva/pom.xml
@@ -11,7 +11,7 @@
   <name>Ibis AdapterFramework Larva</name>
 
   <properties>
-    <spring.version>3.2.16.RELEASE</spring.version>
+    <spring.version>4.3.25.RELEASE</spring.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
In Storage.java 153 queryForInt() hqs been deprecated and replaced with queryForObject