### PR TITLE
Add 'from dual' (required for Oracle, not H2)

### DIFF
--- a/test/src/test/testtool/XmlBuilderThreadSafety/scenario01/in.txt
+++ b/test/src/test/testtool/XmlBuilderThreadSafety/scenario01/in.txt
@@ -1,1 +1,1 @@
-select 'X' as DUMMY
+select 'X' as DUMMY from dual


### PR DESCRIPTION
H2 blijkt toch ook met de default Oracle tabel DUAL om te kunnen gaan. Waarschijnlijk omdat MODE=Oracle wordt gebruikt.