### PR TITLE
Fix Larva scenarios XmlQuerySender

### DIFF
--- a/test/src/test/testtool/XmlQuerySender/common.properties
+++ b/test/src/test/testtool/XmlQuerySender/common.properties
@@ -23,3 +23,9 @@ ignoreContentBetweenKeys6.key2="
 
 ignoreContentBetweenKeys7.key1=<fielddefinition>
 ignoreContentBetweenKeys7.key2=</fielddefinition>
+
+replaceKey1.key1=<field name="TBLOB1"></field>
+replaceKey1.key2=<field name="TBLOB1" null="true"/>
+
+replaceKey2.key1=<field name="TCLOB"></field>
+replaceKey2.key2=<field name="TCLOB" null="true"/>

--- a/test/src/test/testtool/XmlQuerySender/common.properties
+++ b/test/src/test/testtool/XmlQuerySender/common.properties
@@ -24,8 +24,10 @@ ignoreContentBetweenKeys6.key2="
 ignoreContentBetweenKeys7.key1=<fielddefinition>
 ignoreContentBetweenKeys7.key2=</fielddefinition>
 
+# replace empty BLOB with null, to work around dbms incompatibilities for this test
 replaceKey1.key1=<field name="TBLOB1"></field>
 replaceKey1.key2=<field name="TBLOB1" null="true"/>
 
+# replace empty CLOB with null, to work around dbms incompatibilities for this test
 replaceKey2.key1=<field name="TCLOB"></field>
 replaceKey2.key2=<field name="TCLOB" null="true"/>


### PR DESCRIPTION
Voor de Oracle functies EMPTY_BLOB() en EMPTY_CLOB() is geen equivalent in H2. Het beste alternatief is een lege string hiervoor te gebruiken. Dit leidt tot een verschil wanneer een SELECT op zo'n BLOB- of CLOB-veld wordt gedaan. Dit pull request vervangt een lege string in de output van de BLOB- en CLOB-velden met de NULL-waarde zodat er geen verschil is wanneer het scenario met een Oracle of een H2 database gerund wordt.