### PR TITLE
Fix bug in XpathEvaluator-creation

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/IteratingPipe.java
@@ -519,7 +519,7 @@ public abstract class IteratingPipe<I> extends MessageSendingPipe {
 		return xpathExpression;
 	}
 
-	@IbisDoc({"3", "Namespace defintions for xpathexpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions. One entry can be without a prefix, that will define the default namespace.", ""})
+	@IbisDoc({"3", "Namespace defintions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions. For some use other cases (NOT xpathExpression), one entry can be without a prefix, that will define the default namespace.", ""})
 	public void setNamespaceDefs(String namespaceDefs) {
 		this.namespaceDefs = namespaceDefs;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/JsonXsltPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/JsonXsltPipe.java
@@ -15,7 +15,7 @@
 */
 package nl.nn.adapterframework.pipes;
 
-import nl.nn.adapterframework.doc.IbisDoc;
+import nl.nn.adapterframework.doc.IbisDocRef;
 import nl.nn.adapterframework.senders.JsonXsltSender;
 import nl.nn.adapterframework.senders.XsltSender;
 
@@ -30,19 +30,21 @@ import nl.nn.adapterframework.senders.XsltSender;
  */
 
 public class JsonXsltPipe extends XsltPipe {
-	
+
+	private final String JSONXSLTSENDER = "nl.nn.adapterframework.senders.JsonXsltSender";
+
 	@Override
 	protected XsltSender createXsltSender() {
 		return new JsonXsltSender();
 	}
 
-	@IbisDoc({"1", "When <code>true</code>, the xml result of the transformation is converted back to json", "true"})
+	@IbisDocRef({"1", JSONXSLTSENDER})
 	public void setJsonResult(boolean jsonResult) {
 		((JsonXsltSender)getSender()).setJsonResult(jsonResult);
 	}
 
 	@Override
-	@IbisDoc({"2", "Namespace defintions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions", "j=http://www.w3.org/2013/XSL/json"})
+	@IbisDocRef({"2", JSONXSLTSENDER})
 	public void setNamespaceDefs(String namespaceDefs) {
 		super.setNamespaceDefs(namespaceDefs);
 	}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
@@ -218,7 +218,7 @@ public class XmlSwitch extends AbstractPipe {
 		return xpathExpression;
 	}
 
-	@IbisDoc({"3", "namespace defintions for xpathexpression. must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions. One entry can be without a prefix, that will define the default namespace.", ""})
+	@IbisDoc({"3", "Namespace defintions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions. For some use other cases (NOT xpathExpression), one entry can be without a prefix, that will define the default namespace.", ""})
 	public void setNamespaceDefs(String namespaceDefs) {
 		this.namespaceDefs = namespaceDefs;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
@@ -333,7 +333,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 		return omitXmlDeclaration;
 	}
 
-	@IbisDoc({"6", "For xpathExpression only: namespace defintions for xpathexpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions. One entry can be without a prefix, that will define the default namespace", ""})
+	@IbisDoc({"6", "Namespace defintions for xpathExpression. Must be in the form of a comma or space separated list of <code>prefix=namespaceuri</code>-definitions. For some use other cases (NOT xpathExpression), one entry can be without a prefix, that will define the default namespace.", ""})
 	public void setNamespaceDefs(String namespaceDefs) {
 		this.namespaceDefs = namespaceDefs;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/util/XmlUtils.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/XmlUtils.java
@@ -821,12 +821,9 @@ public class XmlUtils {
 		}
 		try {
 			String xslt;
-			if (XPATH_NAMESPACE_REMOVAL_VIA_XSLT && StringUtils.isEmpty(namespaceDefs)) {
-				xslt = createXPathEvaluatorSource(namespaceDefs,xPathExpression, outputType, includeXmlDeclaration, paramNames, true, true, null, xsltVersion);
-			} else {
-				xslt = createXPathEvaluatorSource(namespaceDefs,xPathExpression, outputType, includeXmlDeclaration, paramNames);
-			}
-			return getUtilityTransformerPool(xslt,"XPath:"+xPathExpression+"|"+outputType+"|"+namespaceDefs,!includeXmlDeclaration,false,xsltVersion);
+			xslt = createXPathEvaluatorSource(namespaceDefs,xPathExpression, outputType, includeXmlDeclaration, paramNames, true, StringUtils.isEmpty(namespaceDefs), null, xsltVersion);
+			if (log.isDebugEnabled()) log.debug("xpath ["+xPathExpression+"] resulted in xslt ["+xslt+"]");
+			return getUtilityTransformerPool(xslt,"XPath:"+xPathExpression+"|"+outputType+"|"+namespaceDefs+"|"+xsltVersion,!includeXmlDeclaration,false,xsltVersion);
 		} catch (TransformerConfigurationException e) {
 			throw new ConfigurationException(e);
 		}

--- a/core/src/test/java/nl/nn/adapterframework/pipes/ForEachChildElementPipeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/ForEachChildElementPipeTest.java
@@ -722,7 +722,23 @@ public class ForEachChildElementPipeTest extends PipeTestBase<ForEachChildElemen
 
 		assertEquals(expected, actual);
 	}
-	
+
+	@Test
+	public void testNamespacedXPath() throws PipeRunException, ConfigurationException, PipeStartException, IOException {
+		pipe.setSender(getElementRenderer(null));
+		pipe.setElementXPathExpression("//x:directoryUrl");
+		pipe.setNamespaceDefs("x=http://studieData.nl/schema/edudex/directory");
+		configurePipe();
+		pipe.start();
+
+		String input = TestFileUtils.getTestFile("/ForEachChildElementPipe/NamespacedXPath/input.xml");
+		String expected = TestFileUtils.getTestFile("/ForEachChildElementPipe/NamespacedXPath/expected.xml");
+		PipeRunResult prr = pipe.doPipe(input, session);
+		String actual = prr.getResult().toString();
+
+		assertEquals(expected, actual);
+	}
+
 	
 	private class SwitchCounter {
 		public int count;

--- a/core/src/test/java/nl/nn/adapterframework/senders/XsltSenderTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/senders/XsltSenderTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.io.IOException;
 
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -99,6 +100,36 @@ public class XsltSenderTest extends SenderTestBase<XsltSender> {
 		String result = sender.sendMessage(null, input, prc);
 
 		assertEquals("2", result);
+	}
+
+	@Test
+	public void testXpathWithNamespaceXslt1() throws SenderException, TimeOutException, ConfigurationException, IOException {
+		sender.setXpathExpression("//x:directoryUrl");
+		sender.setNamespaceDefs("x=http://studieData.nl/schema/edudex/directory");
+		sender.setXsltVersion(1);
+		sender.configure();
+		sender.open();
+
+		String input = TestFileUtils.getTestFile("/Xslt/XPathWithNamespace/input.xml");
+		String expected = TestFileUtils.getTestFile("/Xslt/XPathWithNamespace/expected-xslt1.txt");
+		ParameterResolutionContext prc = new ParameterResolutionContext(input, session);
+		String result = sender.sendMessage(null, input, prc);
+
+		assertEquals(expected.trim(), result.trim());
+	}
+
+	@Test
+	public void testXpathWithNamespaceXslt2() throws SenderException, TimeOutException, ConfigurationException, IOException {
+		sender.setXpathExpression("//directoryUrl");
+		sender.configure();
+		sender.open();
+
+		String input = TestFileUtils.getTestFile("/Xslt/XPathWithNamespace/input.xml");
+		String expected = TestFileUtils.getTestFile("/Xslt/XPathWithNamespace/expected-xslt2.txt");
+		ParameterResolutionContext prc = new ParameterResolutionContext(input, session);
+		String result = sender.sendMessage(null, input, prc);
+
+		assertEquals(expected.trim(), result.trim());
 	}
 
 	@Test
@@ -222,4 +253,39 @@ public class XsltSenderTest extends SenderTestBase<XsltSender> {
 		assertEquals(expected, sender.sendMessage(null, input, prc));
 	}
 	
+	@Ignore("First have to fix this")
+	@Test
+	public void testNamespaceUnaware() throws SenderException, TimeOutException, ConfigurationException, IOException {
+		sender.setStyleSheetName("/Xslt/NamespaceUnaware/FileInfoNamespaceUnAware.xsl");
+		sender.setRemoveNamespaces(true);
+		sender.configure();
+		sender.open();
+		String input=TestFileUtils.getTestFile("/Xslt/NamespaceUnaware/in.xml");
+		log.debug("inputfile ["+input+"]");
+		String expected=TestFileUtils.getTestFile("/Xslt/NamespaceUnaware/out.xml");
+
+		ParameterResolutionContext prc = new ParameterResolutionContext(input, session);
+		String actual = sender.sendMessage(null, input, prc);
+
+		assertEquals(expected, actual);
+	}
+
+	@Ignore("First have to fix this")
+	@Test
+	public void testNamespaceAware() throws Exception {
+		sender.setStyleSheetName("/Xslt/NamespaceUnaware/FileInfoNamespaceAware.xsl");
+		sender.configure();
+		sender.open();
+		String input=TestFileUtils.getTestFile("/Xslt/NamespaceUnaware/in.xml");
+		log.debug("inputfile ["+input+"]");
+		String expected=TestFileUtils.getTestFile("/Xslt/NamespaceUnaware/out.xml");
+
+		ParameterResolutionContext prc = new ParameterResolutionContext(input, session);
+		String actual = sender.sendMessage(null, input, prc);
+
+		assertEquals(expected, actual);
+//		Diff diff = XMLUnit.compareXML(expected, actual);
+//		assertTrue(diff.toString(), diff.similar());
+	}
+
 }

--- a/core/src/test/resources/ForEachChildElementPipe/NamespacedXPath/expected.xml
+++ b/core/src/test/resources/ForEachChildElementPipe/NamespacedXPath/expected.xml
@@ -1,0 +1,27 @@
+<results>
+<result item="1">
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/tias
+</directoryUrl>
+</result>
+<result item="2">
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/baak
+</directoryUrl>
+</result>
+<result item="3">
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/zuidema
+</directoryUrl>
+</result>
+<result item="4">
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/ncoi
+</directoryUrl>
+</result>
+<result item="5">
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/nyenrode
+</directoryUrl>
+</result>
+</results>

--- a/core/src/test/resources/ForEachChildElementPipe/NamespacedXPath/input.xml
+++ b/core/src/test/resources/ForEachChildElementPipe/NamespacedXPath/input.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edudexDirectory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://studieData.nl/schema/edudex/directory">
+<editor>editor@edudex.nl</editor>
+<generator>EDU-DEX system</generator>
+<version>v0.90429</version>
+<orgUnitId>edudex</orgUnitId>
+<subDirectory>
+<orgUnitId>tias</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/tias
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>baak</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/baak
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>zuidema</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/zuidema
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>ncoi</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/ncoi
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>nyenrode</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/nyenrode
+</directoryUrl>
+</subDirectory>
+</edudexDirectory>

--- a/core/src/test/resources/Xslt/XPathWithNamespace/expected-xslt1.txt
+++ b/core/src/test/resources/Xslt/XPathWithNamespace/expected-xslt1.txt
@@ -1,0 +1,2 @@
+
+http://localhost:8080/ibis4mock/api/getmock/tias

--- a/core/src/test/resources/Xslt/XPathWithNamespace/expected-xslt2.txt
+++ b/core/src/test/resources/Xslt/XPathWithNamespace/expected-xslt2.txt
@@ -1,0 +1,10 @@
+
+http://localhost:8080/ibis4mock/api/getmock/tias
+ 
+http://localhost:8080/ibis4mock/api/getmock/baak
+ 
+http://localhost:8080/ibis4mock/api/getmock/zuidema
+ 
+http://localhost:8080/ibis4mock/api/getmock/ncoi
+ 
+http://localhost:8080/ibis4mock/api/getmock/nyenrode

--- a/core/src/test/resources/Xslt/XPathWithNamespace/input.xml
+++ b/core/src/test/resources/Xslt/XPathWithNamespace/input.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<edudexDirectory xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://studieData.nl/schema/edudex/directory">
+<editor>editor@edudex.nl</editor>
+<generator>EDU-DEX system</generator>
+<version>v0.90429</version>
+<orgUnitId>edudex</orgUnitId>
+<subDirectory>
+<orgUnitId>tias</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/tias
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>baak</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/baak
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>zuidema</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/zuidema
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>ncoi</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/ncoi
+</directoryUrl>
+</subDirectory>
+<subDirectory>
+<orgUnitId>nyenrode</orgUnitId>
+<directoryUrl>
+http://localhost:8080/ibis4mock/api/getmock/nyenrode
+</directoryUrl>
+</subDirectory>
+</edudexDirectory>


### PR DESCRIPTION
It is still not possible to create an XPath with a default namespace
specified in namespaceDefs.