### PR TITLE
Update IbisDoc for XmlIfPipe to report the correct default XSLT version

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/pipes/XmlIf.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/XmlIf.java
@@ -195,7 +195,7 @@ public class XmlIf extends AbstractPipe {
 		return regex;
 	}
 
-	@IbisDoc({"specifies the version of xslt to use", "1"})
+	@IbisDoc({"specifies the version of xslt to use", "2"})
 	public void setXsltVersion(int xsltVersion) {
 		this.xsltVersion = xsltVersion;
 	}


### PR DESCRIPTION
IbisDoc reports version 1 while the default is version 2.