### PR TITLE
Sync Ladybug's enable toggle with GUI 3.0's

### DIFF
--- a/ladybug/src/main/java/nl/nn/ibistesttool/Debugger.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/Debugger.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.context.ApplicationEventPublisher;
+
 import nl.nn.adapterframework.configuration.IbisManager;
 import nl.nn.adapterframework.core.IAdapter;
 import nl.nn.adapterframework.core.IListener;
@@ -31,6 +33,7 @@ import nl.nn.adapterframework.core.ISender;
 import nl.nn.adapterframework.core.PipeLine;
 import nl.nn.adapterframework.core.PipeLineSessionBase;
 import nl.nn.adapterframework.parameters.Parameter;
+import nl.nn.adapterframework.webcontrol.api.DebuggerStatusChangedEvent;
 import nl.nn.testtool.Checkpoint;
 import nl.nn.testtool.Report;
 import nl.nn.testtool.SecurityContext;
@@ -322,5 +325,13 @@ public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger {
 		}
 		return name;
 	}
-
+	
+	@Override
+	public void setEnabled(boolean enabled) {
+		DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, enabled);
+		ApplicationEventPublisher applicationEventPublisher = ibisManager.getApplicationEventPublisher();
+		if (applicationEventPublisher!=null) {
+			applicationEventPublisher.publishEvent(event);
+		}
+	}
 }

--- a/ladybug/src/main/java/nl/nn/ibistesttool/tibet2/Debugger.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/tibet2/Debugger.java
@@ -18,10 +18,13 @@ package nl.nn.ibistesttool.tibet2;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.context.ApplicationEventPublisher;
+
 import nl.nn.adapterframework.core.IAdapter;
 import nl.nn.adapterframework.core.IPipeLineSession;
 import nl.nn.adapterframework.core.PipeLineResult;
 import nl.nn.adapterframework.core.PipeLineSessionBase;
+import nl.nn.adapterframework.webcontrol.api.DebuggerStatusChangedEvent;
 import nl.nn.testtool.Checkpoint;
 import nl.nn.testtool.Report;
 import nl.nn.testtool.SecurityContext;
@@ -78,5 +81,13 @@ public class Debugger extends nl.nn.ibistesttool.Debugger {
 		}
 		return errorMessage;
 	}
-
+	
+	@Override
+	public void setEnabled(boolean enabled) {
+		DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, enabled);
+		ApplicationEventPublisher applicationEventPublisher = ibisManager.getApplicationEventPublisher();
+		if (applicationEventPublisher!=null) {
+			applicationEventPublisher.publishEvent(event);
+		}
+	}
 }


### PR DESCRIPTION
Has a dependency on [this pull request](https://github.com/ibissource/ibis-ladybug/pull/20). This pull request needs a Travis rerun after that one has been accepted.

TODO: toggling the setting within Ladybug does not yet adjust the checkbox found in GUI 3.0's Environment Variables. A link needs to be made between the Debugger implementations' setEnabled() methods and the corresponding JS function.