### PR TITLE
Added mailaddresses property to test module

### DIFF
--- a/test/src/main/configurations/UTIL/ConfigurationLarva.xml
+++ b/test/src/main/configurations/UTIL/ConfigurationLarva.xml
@@ -59,6 +59,8 @@
 				>
 				<param name="hostname" value="${hostname}" />
 				<param name="message" sessionKey="message" />
+				<param name="mailaddresses" value="${mailaddresses}" />
+				
 				<forward name="success" path="SendMail" />
 			</pipe>
 			<pipe

--- a/test/src/main/configurations/UTIL/ConfigurationLarva.xml
+++ b/test/src/main/configurations/UTIL/ConfigurationLarva.xml
@@ -59,7 +59,7 @@
 				>
 				<param name="hostname" value="${hostname}" />
 				<param name="message" sessionKey="message" />
-				<param name="mailaddresses" value="${mailaddresses}" />
+				<param name="mailaddresses" value="${errorreport.mailaddresses}" />
 				
 				<forward name="success" path="SendMail" />
 			</pipe>

--- a/test/src/main/configurations/UTIL/Larva/xsl/CreateMail.xsl
+++ b/test/src/main/configurations/UTIL/Larva/xsl/CreateMail.xsl
@@ -4,10 +4,10 @@
 
 	<xsl:param name="hostname"/>
 	<xsl:param name="message"/>
-	
-	<xsl:variable name="from" select="'dummy@dummy.com'"/>
-	<xsl:variable name="to" select="'dummy@dummy.com'"/>
-	<xsl:variable name="cc" select="'dummy@dummy.com,dummy@dummy.com,dummy@dummy.com'"/>
+	<xsl:param name="mailaddresses"/>
+	<xsl:variable name="from" select="$hostname"/>
+	<xsl:variable name="to" select="tokenize($mailaddresses,',')[1]"/>
+	<xsl:variable name="cc" select="substring-after($mailaddresses,',')"/>
 
 	<xsl:variable name="passed">
 		<xsl:choose>

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -104,3 +104,6 @@ active.soap12=false
 
 jdbc.querylistener.key=260873
 MemoryLeak.active=false
+
+#needs a comma separated list with mailaddresses for the larva adapter
+errorreport.mailaddresses=


### PR DESCRIPTION
In Ibis4TestIAF wordt altijd automatisch begonnen met een testrun. Dit gaat via de Larva-adapter. De resultaten hiervan dienen onmiddelijk bij de relevante personen worden gemeld zodat zij op de hoogte zijn van de gezondheid van de geteste versie van het framework. Zoals het er stond moesten de geaddresseerden hard gecodeerd worden neergezet. De voorgestelde oplossing laat de mailadressen binnen de applicatie geformuleerd worden.

Heb in /test/src/main/configurations/UTIL de ConfigurationLarva.xml en de bijbehorende CreateMail.xsl aangepast. ConfigurationLarva pakt de property "mailaddresses" op die geformuleerd staat in deploymentspecifics als een comma-separated list. Het eerst item in deze lijst wordt het "To"-veld, de rest van de lijst komt indien aanwezig in het "CC" veld. 
![Capture](https://user-images.githubusercontent.com/6153602/77174101-d2231100-6ac0-11ea-83d8-20b5b29e098f.PNG)
