### PR TITLE
Toggle IbisDebugger state when Ladybug ReportGenerator is changed

### DIFF
--- a/ladybug/src/main/java/nl/nn/ibistesttool/Debugger.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/Debugger.java
@@ -21,6 +21,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.context.ApplicationListener;
 
 import nl.nn.adapterframework.configuration.IbisManager;
@@ -45,7 +47,7 @@ import nl.nn.testtool.run.ReportRunner;
 /**
  * @author Jaco de Groot
  */
-public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger, ApplicationListener<DebuggerStatusChangedEvent> {
+public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger, ApplicationListener<DebuggerStatusChangedEvent>, ApplicationEventPublisherAware {
 	private static final String STUB_STRATEY_STUB_ALL_SENDERS = "Stub all senders";
 	protected static final String STUB_STRATEY_NEVER = "Never";
 	private static final String STUB_STRATEY_ALWAYS = "Always";
@@ -56,6 +58,7 @@ public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger, Applicat
 	private List<String> rerunRoles;
 
 	protected Set<String> inRerun = new HashSet<String>();
+	private ApplicationEventPublisher applicationEventPublisher;
 
 	public void setTestTool(TestTool testTool) {
 		this.testTool = testTool;
@@ -357,13 +360,31 @@ public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger, Applicat
 		return name;
 	}
 
+	// Contract for testtool state:
+	// - appconstants testtool.enabled stores global state
+	// - when the state changes:
+	//   appconstants testtool.enabled must be updated
+	//   a DebuggerStatusChangedEvent must be fired to notify others
+	// - to get notified of canges, components should listen to DebuggerStatusChangedEvents
+
 	@Override
 	public void updateReportGeneratorStatus(boolean enabled) {
 		AppConstants.getInstance().put("testtool.enabled", ""+enabled);
+		DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, enabled);
+		if (applicationEventPublisher != null) {
+			applicationEventPublisher.publishEvent(event);
+		}
 	}
 
 	@Override
 	public void onApplicationEvent(DebuggerStatusChangedEvent event) {
-		testTool.setReportGeneratorEnabled(event.isEnabled());
+		if (event.getSource()!=this) {
+			testTool.setReportGeneratorEnabled(event.isEnabled());
+		}
+	}
+	
+	@Override
+	public void setApplicationEventPublisher(ApplicationEventPublisher applicationEventPublisher) {
+		this.applicationEventPublisher = applicationEventPublisher;
 	}
 }

--- a/ladybug/src/main/java/nl/nn/ibistesttool/Debugger.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/Debugger.java
@@ -361,17 +361,14 @@ public class Debugger implements IbisDebugger, nl.nn.testtool.Debugger, Applicat
 	}
 
 	// Contract for testtool state:
-	// - appconstants testtool.enabled stores global state
-	// - when the state changes:
-	//   appconstants testtool.enabled must be updated
-	//   a DebuggerStatusChangedEvent must be fired to notify others
+	// - when the state changes a DebuggerStatusChangedEvent must be fired to notify others
 	// - to get notified of canges, components should listen to DebuggerStatusChangedEvents
+	// IbisDebuggerAdvice stores state in appconstants testtool.enabled for use by GUI
 
 	@Override
 	public void updateReportGeneratorStatus(boolean enabled) {
-		AppConstants.getInstance().put("testtool.enabled", ""+enabled);
-		DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, enabled);
 		if (applicationEventPublisher != null) {
+			DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, enabled);
 			applicationEventPublisher.publishEvent(event);
 		}
 	}

--- a/ladybug/src/main/java/nl/nn/ibistesttool/DeploymentSpecificsBeanPostProcessor.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/DeploymentSpecificsBeanPostProcessor.java
@@ -39,14 +39,11 @@ public class DeploymentSpecificsBeanPostProcessor implements BeanPostProcessor, 
 	@Override
 	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
 		if (bean instanceof TestTool) {
-			//TestTool testTool = (TestTool)bean;
 			
 			// Contract for testtool state:
-			// - appconstants testtool.enabled stores global state
-			// - when the state changes:
-			//   appconstants testtool.enabled must be updated
-			//   a DebuggerStatusChangedEvent must be fired to notify others
+			// - when the state changes a DebuggerStatusChangedEvent must be fired to notify others
 			// - to get notified of canges, components should listen to DebuggerStatusChangedEvents
+			// IbisDebuggerAdvice stores state in appconstants testtool.enabled for use by GUI
 			
 			boolean testToolEnabled=true;
 			AppConstants appConstants = AppConstants.getInstance();
@@ -60,7 +57,7 @@ public class DeploymentSpecificsBeanPostProcessor implements BeanPostProcessor, 
 				}
 				appConstants.setProperty("testtool.enabled", testToolEnabled);
 			}
-			// enable/disable testtool via two switches, until one of the switches has become deprecated
+			// notify other components of status of debugger
 			DebuggerStatusChangedEvent event = new DebuggerStatusChangedEvent(this, testToolEnabled);
 			if (applicationEventPublisher != null) {
 				applicationEventPublisher.publishEvent(event);

--- a/ladybug/src/main/java/nl/nn/ibistesttool/DeploymentSpecificsBeanPostProcessor.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/DeploymentSpecificsBeanPostProcessor.java
@@ -39,7 +39,15 @@ public class DeploymentSpecificsBeanPostProcessor implements BeanPostProcessor, 
 	@Override
 	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
 		if (bean instanceof TestTool) {
-			TestTool testTool = (TestTool)bean;
+			//TestTool testTool = (TestTool)bean;
+			
+			// Contract for testtool state:
+			// - appconstants testtool.enabled stores global state
+			// - when the state changes:
+			//   appconstants testtool.enabled must be updated
+			//   a DebuggerStatusChangedEvent must be fired to notify others
+			// - to get notified of canges, components should listen to DebuggerStatusChangedEvents
+			
 			boolean testToolEnabled=true;
 			AppConstants appConstants = AppConstants.getInstance();
 			String testToolEnabledProperty=appConstants.getProperty("testtool.enabled");

--- a/ladybug/src/main/java/nl/nn/ibistesttool/IbisDebuggerAdvice.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/IbisDebuggerAdvice.java
@@ -61,6 +61,12 @@ import nl.nn.adapterframework.webcontrol.api.DebuggerStatusChangedEvent;
 public class IbisDebuggerAdvice implements ThreadLifeCycleEventListener<Object>, ApplicationListener<DebuggerStatusChangedEvent> {
 	protected Logger log = LogUtil.getLogger(this);
 
+	// Contract for testtool state:
+	// - appconstants testtool.enabled stores global state
+	// - when the state changes:
+	//   appconstants testtool.enabled must be updated
+	//   a DebuggerStatusChangedEvent must be fired to notify others
+	// - to get notified of canges, components should listen to DebuggerStatusChangedEvents
 	private IbisDebugger ibisDebugger;
 	private static boolean enabled=true;
 	

--- a/ladybug/src/main/java/nl/nn/ibistesttool/IbisDebuggerAdvice.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/IbisDebuggerAdvice.java
@@ -52,6 +52,7 @@ import nl.nn.adapterframework.stream.IStreamingSender;
 import nl.nn.adapterframework.stream.Message;
 import nl.nn.adapterframework.stream.ThreadConnector;
 import nl.nn.adapterframework.stream.ThreadLifeCycleEventListener;
+import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.webcontrol.api.DebuggerStatusChangedEvent;
 
@@ -62,11 +63,9 @@ public class IbisDebuggerAdvice implements ThreadLifeCycleEventListener<Object>,
 	protected Logger log = LogUtil.getLogger(this);
 
 	// Contract for testtool state:
-	// - appconstants testtool.enabled stores global state
-	// - when the state changes:
-	//   appconstants testtool.enabled must be updated
-	//   a DebuggerStatusChangedEvent must be fired to notify others
+	// - when the state changes a DebuggerStatusChangedEvent must be fired to notify others
 	// - to get notified of canges, components should listen to DebuggerStatusChangedEvents
+	// IbisDebuggerAdvice stores state in appconstants testtool.enabled for use by GUI
 	private IbisDebugger ibisDebugger;
 	private static boolean enabled=true;
 	
@@ -442,8 +441,9 @@ public class IbisDebuggerAdvice implements ThreadLifeCycleEventListener<Object>,
 
 	}
 
-	public static void setEnabled(boolean enable) {
+	public void setEnabled(boolean enable) {
 		enabled = enable;
+		AppConstants.getInstance().put("testtool.enabled", ""+enable);
 	}
 	public boolean isEnabled() {
 		return enabled;


### PR DESCRIPTION
With this change, an event is fired when the Ladybug report generator is switched off. 
This event is used to switch off the ibisdebugger completely. 