### PR TITLE
Enable setting additional recipients for errors in the test module

### DIFF
--- a/test/src/main/configurations/UTIL/ConfigurationLarva.xml
+++ b/test/src/main/configurations/UTIL/ConfigurationLarva.xml
@@ -60,6 +60,7 @@
 				<param name="hostname" value="${hostname}" />
 				<param name="message" sessionKey="message" />
 				<param name="mailaddresses" value="${errorreport.mailaddresses}" />
+				<param name="mailaddressesError" value="${errorreport.mailaddresses.error}" />
 				
 				<forward name="success" path="SendMail" />
 			</pipe>

--- a/test/src/main/configurations/UTIL/ConfigurationLarva.xml
+++ b/test/src/main/configurations/UTIL/ConfigurationLarva.xml
@@ -30,6 +30,23 @@
 				storeResultInSessionKey="message"
 				logLevel="scenario failed"
 				>
+				<forward name="success" path="StoreSuccessState" />
+				<forward name="fail" path="StoreFailState" />
+			</pipe>
+			<pipe 
+				name="StoreSuccessState"
+				className="nl.nn.adapterframework.pipes.PutParametersInSession"
+				>
+				<param name="result" value="SUCCESS"/>
+				<param name="mailaddresses" value="${errorreport.mailaddresses.pass}" />
+				<forward name="success" path="SwitchMethod" />
+			</pipe>
+			<pipe 
+				name="StoreFailState"
+				className="nl.nn.adapterframework.pipes.PutParametersInSession"
+				>
+				<param name="result" value="FAILED"/>
+				<param name="mailaddresses" value="${errorreport.mailaddresses.fail}" />
 				<forward name="success" path="SwitchMethod" />
 			</pipe>
 			<pipe
@@ -54,14 +71,12 @@
 				name="CreateMail"
 				className="nl.nn.adapterframework.pipes.XsltPipe"
 				styleSheetName="/Larva/xsl/CreateMail.xsl"
-				xslt2="true"
 				getInputFromFixedValue="&lt;dummy/&gt;"
 				>
 				<param name="hostname" value="${hostname}" />
 				<param name="message" sessionKey="message" />
-				<param name="mailaddresses" value="${errorreport.mailaddresses}" />
-				<param name="mailaddressesError" value="${errorreport.mailaddresses.error}" />
-				
+				<param name="mailaddresses" sessionKey="mailaddresses" />
+				<param name="result" sessionKey="result" />
 				<forward name="success" path="SendMail" />
 			</pipe>
 			<pipe
@@ -87,6 +102,7 @@
 			</exits>
 		</pipeline>
 	</adapter>
+	
 	<scheduler>
 		<job
 			name="Larva"

--- a/test/src/main/configurations/UTIL/Larva/xsl/CreateMail.xsl
+++ b/test/src/main/configurations/UTIL/Larva/xsl/CreateMail.xsl
@@ -5,6 +5,8 @@
 	<xsl:param name="hostname"/>
 	<xsl:param name="message"/>
 	<xsl:param name="mailaddresses"/>
+	<xsl:param name="mailaddressesError"/>
+	
 	<xsl:variable name="from" select="$hostname"/>
 	<xsl:variable name="to" select="tokenize($mailaddresses,',')[1]"/>
 	<xsl:variable name="cc" select="substring-after($mailaddresses,',')"/>
@@ -16,11 +18,18 @@
 		</xsl:choose>
 	</xsl:variable>
 
+	<xsl:variable name="ccList">
+		<xsl:choose>
+			<xsl:when test="contains($message, 'All scenarios passed')"><xsl:value-of select="$cc"/></xsl:when>
+			<xsl:otherwise><xsl:value-of select="concat($cc, ',', $mailaddressesError)"/></xsl:otherwise>
+		</xsl:choose>
+	</xsl:variable>
+
 	<xsl:template match="/">
 		<email>
 			<recipients>
 				<recipient type="to"><xsl:value-of select="$to"/></recipient>
-				<xsl:for-each select="tokenize($cc,',')">
+				<xsl:for-each select="tokenize($ccList,',')">
 					<recipient type="cc"><xsl:value-of select="."/></recipient>
 				</xsl:for-each>
 			</recipients>

--- a/test/src/main/configurations/UTIL/Larva/xsl/CreateMail.xsl
+++ b/test/src/main/configurations/UTIL/Larva/xsl/CreateMail.xsl
@@ -5,38 +5,24 @@
 	<xsl:param name="hostname"/>
 	<xsl:param name="message"/>
 	<xsl:param name="mailaddresses"/>
-	<xsl:param name="mailaddressesError"/>
+	<xsl:param name="result" />
 	
 	<xsl:variable name="from" select="$hostname"/>
 	<xsl:variable name="to" select="tokenize($mailaddresses,',')[1]"/>
 	<xsl:variable name="cc" select="substring-after($mailaddresses,',')"/>
-
-	<xsl:variable name="passed">
-		<xsl:choose>
-			<xsl:when test="contains($message, 'All scenarios passed')"></xsl:when>
-			<xsl:otherwise>FAILED </xsl:otherwise>
-		</xsl:choose>
-	</xsl:variable>
-
-	<xsl:variable name="ccList">
-		<xsl:choose>
-			<xsl:when test="contains($message, 'All scenarios passed')"><xsl:value-of select="$cc"/></xsl:when>
-			<xsl:otherwise><xsl:value-of select="concat($cc, ',', $mailaddressesError)"/></xsl:otherwise>
-		</xsl:choose>
-	</xsl:variable>
-
+	
 	<xsl:template match="/">
 		<email>
 			<recipients>
 				<recipient type="to"><xsl:value-of select="$to"/></recipient>
-				<xsl:for-each select="tokenize($ccList,',')">
+				<xsl:for-each select="tokenize($cc,',')">
 					<recipient type="cc"><xsl:value-of select="."/></recipient>
 				</xsl:for-each>
 			</recipients>
 			<from><xsl:value-of select="$from"/></from>
 			<subject>
-				<xsl:value-of select="$passed"/>
-				<xsl:value-of select="concat('Larva run results on ', $hostname, ' (')"/>
+				<xsl:value-of select="$result"/>
+				<xsl:value-of select="concat(' Larva run results on ', $hostname, ' (')"/>
 				<xsl:value-of select="tokenize($message, '\n')[last() - 1]"/>
 				<xsl:value-of select="')'"/>
 			</subject>

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -106,6 +106,5 @@ jdbc.querylistener.key=260873
 MemoryLeak.active=false
 
 #needs a comma separated list with mailaddresses for the larva adapter
-#people in the .error-list are only mailed when tests fail
-errorreport.mailaddresses=
-errorreport.mailaddresses.error=
+errorreport.mailaddresses.pass=
+errorreport.mailaddresses.fail=

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -106,4 +106,6 @@ jdbc.querylistener.key=260873
 MemoryLeak.active=false
 
 #needs a comma separated list with mailaddresses for the larva adapter
+#people in the .error-list are only mailed when tests fail
 errorreport.mailaddresses=
+errorreport.mailaddresses.error=


### PR DESCRIPTION
Extends https://github.com/ibissource/iaf/pull/526 to allow setting additional recipients that will only get the e-mail when tests fail.