### PR TITLE
IbisDoc for IMS transaction code was not shown

### DIFF
--- a/ibm/src/main/java/nl/nn/adapterframework/extensions/ibm/IMSSender.java
+++ b/ibm/src/main/java/nl/nn/adapterframework/extensions/ibm/IMSSender.java
@@ -80,11 +80,11 @@ public class IMSSender extends MQSender {
 	 * The transaction code that should be added in the header, must be 8 characters
 	 */
 	@IbisDoc({"transaction code that should be added to the header, must be 8 characters", ""})
-	public String getTransactionCode() {
-		return transactionCode;
-	}
 	public void setTransactionCode(String transactionCode) {
 		this.transactionCode = transactionCode;
+	}
+	public String getTransactionCode() {
+		return transactionCode;
 	}
 
 	@Override


### PR DESCRIPTION
IbisDoc did not contain documentation for the transaction code as the IbisDoc annotation was above the getter. Switched around getter and setter, so that the IbisDoc annotation is above the setter, resulting in it being shown in the IbisDoc.