### PR TITLE
Add method copyFile() to IBasicFileSystem

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/filesystem/AmazonS3FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/AmazonS3FileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018-2019 Integration Partners
+   Copyright 2018-2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -95,12 +95,10 @@ public class AmazonS3FileSystem implements IWritableFileSystem<S3Object> {
 			throw new ConfigurationException(" empty credential fields, please prodive aws credentials");
 
 		if (StringUtils.isEmpty(getClientRegion()) || !AVAILABLE_REGIONS.contains(getClientRegion()))
-			throw new ConfigurationException(" invalid region [" + getClientRegion()
-					+ "] please use one of the following supported regions " + AVAILABLE_REGIONS.toString());
+			throw new ConfigurationException(" invalid region [" + getClientRegion() + "] please use one of the following supported regions " + AVAILABLE_REGIONS.toString());
 
 		if (StringUtils.isEmpty(getBucketName()) || !BucketNameUtils.isValidV2BucketName(getBucketName()))
-			throw new ConfigurationException(" invalid or empty bucketName [" + getBucketName()
-					+ "] please visit AWS to see correct bucket naming");
+			throw new ConfigurationException(" invalid or empty bucketName [" + getBucketName() + "] please visit AWS to see correct bucket naming");
 	}
 
 	@Override
@@ -264,19 +262,31 @@ public class AmazonS3FileSystem implements IWritableFileSystem<S3Object> {
 	}
 
 	@Override
-	public S3Object renameFile(S3Object f, String newName, boolean force) throws FileSystemException {
-		if(s3Client.doesObjectExist(bucketName, newName))
+	public S3Object renameFile(S3Object f, String destinationFile, boolean force) throws FileSystemException {
+		if(s3Client.doesObjectExist(bucketName, destinationFile)) {
 			throw new FileSystemException("Cannot rename file. Destination file already exists.");
-		s3Client.copyObject(bucketName, f.getKey(), bucketName, newName);
+		}
+		s3Client.copyObject(bucketName, f.getKey(), bucketName, destinationFile);
 		s3Client.deleteObject(bucketName, f.getKey());
-		return toFile(newName);
+		return toFile(destinationFile);
 	}
 
 	@Override
-	public S3Object moveFile(S3Object f, String destination, boolean createFolder) throws FileSystemException {
-		return renameFile(f,destination+"/"+f.getKey(), false);
+	public S3Object copyFile(S3Object f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		String destinationFile = destinationFolder+"/"+f.getKey();
+		if(s3Client.doesObjectExist(bucketName, destinationFile)) {
+			throw new FileSystemException("Cannot copy file. Destination file already exists.");
+		}
+		s3Client.copyObject(bucketName, f.getKey(), bucketName, destinationFile);
+		return toFile(destinationFile);
 	}
-	
+
+	@Override
+	public S3Object moveFile(S3Object f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		return renameFile(f,destinationFolder+"/"+f.getKey(), false);
+	}
+
+
 	@Override
 	public Map<String, Object> getAdditionalFileProperties(S3Object f) {
 		Map<String, Object> attributes = new HashMap<String, Object>();

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Integration Partners
+   Copyright 2019, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -360,6 +360,18 @@ public class ExchangeFileSystem implements IWithAttachments<Item,Attachment> {
 		try {
 			emailMessage = EmailMessage.bind(exchangeService, f.getId());
 			emailMessage = (EmailMessage) emailMessage.move(getFolderIdByFolderName(destinationFolder));
+			return emailMessage;
+		} catch (Exception e) {
+			throw new FileSystemException(e);
+		}
+	}
+
+	@Override
+	public Item copyFile(Item f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		EmailMessage emailMessage;
+		try {
+			emailMessage = EmailMessage.bind(exchangeService, f.getId());
+			emailMessage = (EmailMessage) emailMessage.copy(getFolderIdByFolderName(destinationFolder));
 			return emailMessage;
 		} catch (Exception e) {
 			throw new FileSystemException(e);

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
@@ -222,7 +222,7 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 			return getFilename();
 		}
 		if (pvl!=null && pvl.containsKey(PARAMETER_FILENAME)) {
-			return pvl.getParameterValue(PARAMETER_FILENAME).asStringValue("");
+			return pvl.getParameterValue(PARAMETER_FILENAME).asStringValue(null);
 		}
 		try {
 			return input.asString();
@@ -236,7 +236,7 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 			return getDestination();
 		}
 		if (pvl!=null && pvl.containsKey(PARAMETER_DESTINATION)) {
-			return pvl.getParameterValue(PARAMETER_DESTINATION).asStringValue("");
+			return pvl.getParameterValue(PARAMETER_DESTINATION).asStringValue(null);
 		}
 		return null;
 	}
@@ -251,7 +251,7 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 			return getInputFolder();
 		}
 		if (pvl!=null && pvl.containsKey(PARAMETER_INPUTFOLDER)) {
-			return pvl.getParameterValue(PARAMETER_INPUTFOLDER).asStringValue("");
+			return pvl.getParameterValue(PARAMETER_INPUTFOLDER).asStringValue(null);
 		}
 		try {
 			if (input==null || StringUtils.isEmpty(input.asString())) {

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019, 2020 Integration Partners
+   Copyright 2019, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -43,7 +43,8 @@ import nl.nn.adapterframework.stream.StreamingPipe;
  * <tr><th>Action</th><th>Description</th><th>Configuration</th></tr>
  * <tr><td>list</td><td>list files in a folder/directory</td><td>folder, taken from first available of:<ol><li>attribute <code>inputFolder</code></li><li>parameter <code>inputFolder</code></li><li>root folder</li></ol></td></tr>
  * <tr><td>read</td><td>read a file, returns an InputStream</td><td>filename: taken from parameter <code>filename</code> or input message</td><td>&nbsp;</td></tr>
- * <tr><td>move</td><td>move a file to another folder</td><td>filename: taken from parameter <code>filename</code> or input message<br/>parameter <code>destination</code></td></tr>
+ * <tr><td>move</td><td>move a file to another folder</td><td>filename: taken from parameter <code>filename</code> or input message<br/>destination: taken from attribute <code>destination</code> or parameter <code>destination</code></td></tr>
+ * <tr><td>copy</td><td>copy a file to another folder</td><td>filename: taken from parameter <code>filename</code> or input message<br/>destination: taken from attribute <code>destination</code> or parameter <code>destination</code></td></tr>
  * <tr><td>delete</td><td>delete a file</td><td>filename: taken from parameter <code>filename</code> or input message</td><td>&nbsp;</td></tr>
  * <tr><td>mkdir</td><td>create a folder/directory</td><td>folder: taken from parameter <code>foldername</code> or input message</td><td>&nbsp;</td></tr>
  * <tr><td>rmdir</td><td>remove a folder/directory</td><td>folder: taken from parameter <code>foldername</code> or input message</td><td>&nbsp;</td></tr>
@@ -61,7 +62,7 @@ import nl.nn.adapterframework.stream.StreamingPipe;
  *  The missing parameter defaults to the input message.<br/>
  *  For streaming operation, the parameter <code>filename</code> must be specified.
  *  </td><td>&nbsp;</td></tr>
- * <tr><td>rename</td><td>change the name of a file</td><td>filename: taken from parameter <code>filename</code> or input message<br/>parameter <code>destination</code></td></tr>
+ * <tr><td>rename</td><td>change the name of a file</td><td>filename: taken from parameter <code>filename</code> or input message<br/>destination: taken from attribute <code>destination</code> or parameter <code>destination</code></td></tr>
  * <table>
  * 
  * @author Gerrit van Brakel
@@ -177,6 +178,11 @@ public class FileSystemPipe<F, FS extends IBasicFileSystem<F>> extends Streaming
 	@IbisDocRef({"2", FILESYSTEMACTOR})
 	public void setFilename(String filename) {
 		actor.setFilename(filename);
+	}
+
+	@IbisDocRef({"2", FILESYSTEMACTOR})
+	public void setDestination(String destination) {
+		actor.setDestination(destination);
 	}
 
 	@IbisDocRef({"3", FILESYSTEMACTOR})

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemSender.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Integration Partners
+   Copyright 2019, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -39,7 +39,8 @@ import nl.nn.adapterframework.stream.StreamingSenderBase;
  * <tr><th>Action</th><th>Description</th><th>Configuration</th></tr>
  * <tr><td>list</td><td>list files in a folder/directory</td><td>folder, taken from first available of:<ol><li>attribute <code>inputFolder</code></li><li>parameter <code>inputFolder</code></li><li>root folder</li></ol></td></tr>
  * <tr><td>read</td><td>read a file, returns an InputStream</td><td>filename: taken from parameter <code>filename</code> or input message</td><td>&nbsp;</td></tr>
- * <tr><td>move</td><td>move a file to another folder</td><td>filename: taken from parameter <code>filename</code> or input message<br/>parameter <code>destination</code></td></tr>
+ * <tr><td>move</td><td>move a file to another folder</td><td>filename: taken from parameter <code>filename</code> or input message<br/>destination: taken from attribute <code>destination</code> or parameter <code>destination</code></td></tr>
+ * <tr><td>copy</td><td>copy a file to another folder</td><td>filename: taken from parameter <code>filename</code> or input message<br/>destination: taken from attribute <code>destination</code> or parameter <code>destination</code></td></tr>
  * <tr><td>delete</td><td>delete a file</td><td>filename: taken from parameter <code>filename</code> or input message</td><td>&nbsp;</td></tr>
  * <tr><td>mkdir</td><td>create a folder/directory</td><td>folder: taken from parameter <code>foldername</code> or input message</td><td>&nbsp;</td></tr>
  * <tr><td>rmdir</td><td>remove a folder/directory</td><td>folder: taken from parameter <code>foldername</code> or input message</td><td>&nbsp;</td></tr>
@@ -57,7 +58,7 @@ import nl.nn.adapterframework.stream.StreamingSenderBase;
  *  The missing parameter defaults to the input message.<br/>
  *  For streaming operation, the parameter <code>filename</code> must be specified.
  *  </td><td>&nbsp;</td></tr>
- * <tr><td>rename</td><td>change the name of a file</td><td>filename: taken from parameter <code>filename</code> or input message<br/>parameter <code>destination</code></td></tr>
+ * <tr><td>rename</td><td>change the name of a file</td><td>filename: taken from parameter <code>filename</code> or input message<br/>destination: taken from attribute <code>destination</code> or parameter <code>destination</code></td></tr>
  * <table>
  * 
  * @author Gerrit van Brakel
@@ -158,6 +159,11 @@ public class FileSystemSender<F, FS extends IBasicFileSystem<F>> extends Streami
 	@IbisDocRef({"2", FILESYSTEMACTOR})
 	public void setFilename(String filename) {
 		actor.setFilename(filename);
+	}
+
+	@IbisDocRef({"2", FILESYSTEMACTOR})
+	public void setDestination(String destination) {
+		actor.setDestination(destination);
 	}
 
 	@IbisDocRef({"3", FILESYSTEMACTOR})

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FtpFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FtpFileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Nationale-Nederlanden
+   Copyright 2019, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.commons.net.ftp.FTPFile;
 import org.apache.commons.net.ftp.FTPReply;
 import org.apache.log4j.Logger;
@@ -192,21 +193,30 @@ public class FtpFileSystem extends FtpSession implements IWritableFileSystem<FTP
 		return toFile(newName);
 	}
 
-	@Override
-	public FTPFile moveFile(FTPFile f, String destinationFolder, boolean createFolder) throws FileSystemException {
+	protected String getDestinationFilename(FTPFile f, String destinationFolder, boolean createFolder, String action) throws FileSystemException {
 		if(!folderExists(destinationFolder)) {
 			if(createFolder) {
 				createFolder(destinationFolder);
 			}
-			throw new FileSystemException("Cannot move file. Destination folder ["+destinationFolder+"] does not exist.");
+			throw new FileSystemException("Cannot "+action+" file. Destination folder ["+destinationFolder+"] does not exist.");
 		}
-		String destinationFilename=destinationFolder+"/"+f.getName();
+		return destinationFolder+"/"+f.getName();
+	}
+
+	@Override
+	public FTPFile moveFile(FTPFile f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		String destinationFilename = getDestinationFilename(f, destinationFolder, createFolder, "move");
 		try {
 			ftpClient.rename(f.getName(), destinationFilename);
 		} catch (IOException e) {
 			throw new FileSystemException(e);
 		}
 		return toFile(destinationFilename);
+	}
+	
+	@Override
+	public FTPFile copyFile(FTPFile f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		throw new NotImplementedException("CopyFile not implemented for FtpFileSystem");
 	}
 	
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/IBasicFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/IBasicFileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Integration Partners
+   Copyright 2019, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -63,6 +63,7 @@ public interface IBasicFileSystem<F> extends HasPhysicalDestination{
 	public InputStream readFile(F f) throws FileSystemException, IOException;
 	public void deleteFile(F f) throws FileSystemException;
 	public F moveFile(F f, String destinationFolder, boolean createFolder) throws FileSystemException;
+	public F copyFile(F f, String destinationFolder, boolean createFolder) throws FileSystemException;
 
 	public void createFolder(String folder) throws FileSystemException;
 	public void removeFolder(String folder) throws FileSystemException;

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/Samba1FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/Samba1FileSystem.java
@@ -15,7 +15,6 @@
 */
 package nl.nn.adapterframework.filesystem;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/Samba1FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/Samba1FileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018 Nationale-Nederlanden
+   Copyright 2018 Nationale-Nederlanden, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
 */
 package nl.nn.adapterframework.filesystem;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -231,18 +232,41 @@ public class Samba1FileSystem implements IWritableFileSystem<SmbFile> {
 		}
 	}
 
-	@Override
-	public SmbFile moveFile(SmbFile f, String destinationFolder, boolean createFolder) throws FileSystemException {
+	protected SmbFile getDestinationFile(SmbFile f, String destinationFolder, boolean createFolder, String action) throws FileSystemException {
 		SmbFile dest;
 		try {
 			dest = new SmbFile(smbContext, destinationFolder+"/"+f.getName());
 			if (!exists(dest)) {
-				throw new FileSystemException("Cannot move file. Destination folder ["+destinationFolder+"] does not exists.");
+				// should createFolder if createFolder==true
+				throw new FileSystemException("Cannot "+action+" file. Destination ["+destinationFolder+"] does not exists.");
 			}
 			if (!isFolder(dest)) {
-				throw new FileSystemException("Cannot move file. Destination folder ["+destinationFolder+"] is not a folder.");
+				throw new FileSystemException("Cannot "+action+" file. Destination folder ["+destinationFolder+"] is not a folder.");
 			}
+			return dest;
+		} catch (FileSystemException e) {
+			throw e;
+		} catch (Exception e) {
+			throw new FileSystemException(e);
+		}
+	}
+
+	@Override
+	public SmbFile moveFile(SmbFile f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		SmbFile dest = getDestinationFile(f, destinationFolder, createFolder, "move");
+		try {
 			f.renameTo(dest);
+			return dest;
+		} catch (Exception e) {
+			throw new FileSystemException(e);
+		}
+	}
+
+	@Override
+	public SmbFile copyFile(SmbFile f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		SmbFile dest = getDestinationFile(f, destinationFolder, createFolder, "copy");
+		try {
+			f.copyTo(dest);
 			return dest;
 		} catch (Exception e) {
 			throw new FileSystemException(e);

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
@@ -65,7 +65,6 @@ import com.hierynomus.smbj.share.Directory;
 import com.hierynomus.smbj.share.DiskShare;
 import com.hierynomus.smbj.share.File;
 
-import jcifs.smb.SmbFile;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.doc.IbisDoc;
 import nl.nn.adapterframework.util.CredentialFactory;

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019 Integration Partners
+   Copyright 2019, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -54,6 +54,8 @@ import com.hierynomus.mssmb2.SMB2CreateOptions;
 import com.hierynomus.mssmb2.SMB2ShareAccess;
 import com.hierynomus.mssmb2.SMBApiException;
 import com.hierynomus.protocol.commons.EnumWithValue;
+import com.hierynomus.protocol.commons.buffer.Buffer.BufferException;
+import com.hierynomus.protocol.transport.TransportException;
 import com.hierynomus.smbj.SMBClient;
 import com.hierynomus.smbj.auth.AuthenticationContext;
 import com.hierynomus.smbj.auth.GSSAuthenticationContext;
@@ -63,6 +65,7 @@ import com.hierynomus.smbj.share.Directory;
 import com.hierynomus.smbj.share.DiskShare;
 import com.hierynomus.smbj.share.File;
 
+import jcifs.smb.SmbFile;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.doc.IbisDoc;
 import nl.nn.adapterframework.util.CredentialFactory;
@@ -316,22 +319,39 @@ public class Samba2FileSystem implements IWritableFileSystem<String> {
 		return newName;
 	}
 
-	@Override
-	public String moveFile(String f, String to, boolean createFolder) throws FileSystemException {
-		try (File file = getFile(f, AccessMask.GENERIC_ALL, SMB2CreateDisposition.FILE_OPEN)) {
-			if (exists(to)) {
-				if (!isFolder(to)) {
-					throw new FileSystemException("Cannot move file. Destination file ["+to+"] is not a folder.");
-				}
-			} else {
-				if (createFolder) {
-					createFolder(to);
-				} else {
-					throw new FileSystemException("Cannot move file. Destination folder ["+to+"] does not exist.");
-				}
+	protected String getDestinationFile(String f, String destinationFolder, boolean createFolder, String action) throws FileSystemException {
+		if (exists(destinationFolder)) {
+			if (!isFolder(destinationFolder)) {
+				throw new FileSystemException("Cannot "+action+" file. Destination ["+destinationFolder+"] is not a folder.");
 			}
-			String destination = to+"\\"+f;
-			file.rename(destination, createFolder);
+		} else {
+			if (createFolder) {
+				createFolder(destinationFolder);
+			} else {
+				throw new FileSystemException("Cannot "+action+" file. Destination folder ["+destinationFolder+"] does not exist.");
+			}
+		}
+		return destinationFolder+"\\"+f;
+	}
+
+	@Override
+	public String moveFile(String f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		try (File file = getFile(f, AccessMask.GENERIC_ALL, SMB2CreateDisposition.FILE_OPEN)) {
+			String destination = getDestinationFile(f, destinationFolder, createFolder, "move");
+			file.rename(destination, false);
+			return destination;
+		}
+	}
+
+	@Override
+	public String copyFile(String f, String destinationFolder, boolean createFolder) throws FileSystemException {
+		try (File file = getFile(f, AccessMask.GENERIC_ALL, SMB2CreateDisposition.FILE_OPEN)) {
+			String destination = getDestinationFile(f, destinationFolder, createFolder, "copy");
+			try (File destinationFile = getFile(f, AccessMask.GENERIC_ALL, SMB2CreateDisposition.FILE_OVERWRITE)) {
+				file.remoteCopyTo(destinationFile);
+			} catch (TransportException | BufferException e) {
+				throw new FileSystemException("cannot copy file ["+f+"] to ["+destinationFolder+"]",e);
+			}
 			return destination;
 		}
 	}

--- a/core/src/test/java/nl/nn/adapterframework/filesystem/BasicFileSystemTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/filesystem/BasicFileSystemTest.java
@@ -207,6 +207,37 @@ public abstract class BasicFileSystemTest<F, FS extends IBasicFileSystem<F>> ext
 		assertFalse("Origin must have disappeared",_fileExists(fileName));
 	}
 
+	@Test
+	public void basicFileSystemTestCopyFile() throws Exception {
+		String fileName = "fileTobeMoved.txt";
+		
+		fileSystem.configure();
+		fileSystem.open();
+
+		createFile(null,fileName, "tja");
+		waitForActionToFinish();
+		
+		assertTrue(_fileExists(fileName));
+		
+		String destinationFolder = "destinationFolder";
+		_createFolder(destinationFolder);
+		waitForActionToFinish();
+
+		assertTrue(_fileExists(fileName));
+		assertTrue(_folderExists(destinationFolder));
+
+		F f = fileSystem.toFile(fileName);
+		F movedFile =fileSystem.copyFile(f, destinationFolder, false);
+		waitForActionToFinish();
+		
+		
+		assertTrue("Destination folder must exist",_folderExists(destinationFolder));
+		assertTrue("Destination must exist ["+fileSystem.getName(movedFile)+"]",fileSystem.exists(movedFile));
+		//TODO: test that contents of file has remained the same
+		//TODO: test that file timestamp has not changed
+		assertTrue("Origin must still exist",_fileExists(fileName));
+	}
+
 
 
 	

--- a/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemActorTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemActorTest.java
@@ -612,7 +612,7 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 	@Test()
 	public void fileSystemActorMoveActionTestForDestinationParameter() throws Exception {
 		actor.setAction("move");
-		thrown.expectMessage("the move action requires the parameter [destination] to be present");
+		thrown.expectMessage("the move action requires the parameter [destination] or the attribute [destination] to be present");
 		actor.configure(fileSystem,null,owner);
 	}
 	
@@ -686,6 +686,51 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 //		fileSystemSenderMoveActionTest("folder1","folder2");
 //	}
 
+	public void fileSystemActorCopyActionTest(String folder1, String folder2, boolean folderExists, boolean setCreateFolderAttribute) throws Exception {
+		String filename = "sendermove" + FILE1;
+		String contents = "Tekst om te lezen";
+		
+		if (folder1!=null) {
+			_createFolder(folder1);
+		}
+		if (folderExists && folder2!=null) {
+			_createFolder(folder2);
+		}
+		createFile(folder1, filename, contents);
+//		deleteFile(folder2, filename);
+		waitForActionToFinish();
+
+		actor.setAction("copy");
+		actor.setDestination(folder2);
+		ParameterList params = new ParameterList();
+		if (setCreateFolderAttribute) {
+			actor.setCreateFolder(true);
+		}
+		params.configure();
+		actor.configure(fileSystem,params,owner);
+		actor.open();
+		
+		Message message = new Message(filename);
+		ParameterValueList pvl = params.getValues(message, session);
+		Object result = actor.doAction(message, pvl, session);
+		
+		// test
+		// result should be name of the moved file
+		assertNotNull(result);
+		
+		// TODO: result should point to new location of file
+		// TODO: contents of result should be contents of original file
+		
+		// assertTrue("file should exist in destination folder ["+folder2+"]", _fileExists(folder2, filename)); // does not have to be this way. filename may have changed.
+		assertTrue("file should still exist anymore in original folder ["+folder1+"]", _fileExists(folder1, filename));
+	}
+
+	@Test
+	public void fileSystemActorCopyActionTestRootToFolder() throws Exception {
+		fileSystemActorCopyActionTest(null,"folder",true,false);
+	}
+
+	
 	@Test
 	public void fileSystemActorMkdirActionTest() throws Exception {
 		String folder = "mkdir" + DIR1;

--- a/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemListenerTest.java
@@ -132,6 +132,15 @@ public abstract class FileSystemListenerTest<F, FS extends IBasicFileSystem<F>> 
 		fileSystemListener.configure();
 		fileSystemListener.open();
 	}
+
+	@Test
+	public void fileListenerTestCreateLogFolder() throws Exception {
+		fileSystemListener.setLogFolder(fileAndFolderPrefix+"xxx");
+		fileSystemListener.setCreateInputDirectory(true);
+		fileSystemListener.configure();
+		fileSystemListener.open();
+	}
+	
 	/*
 	 * vary this on: 
 	 *   inputFolder
@@ -197,6 +206,32 @@ public abstract class FileSystemListenerTest<F, FS extends IBasicFileSystem<F>> 
 		
 		String message=fileSystemListener.getStringFromRawMessage(rawMessage, threadContext);
 		assertThat(message,CoreMatchers.containsString(filename));
+	}
+
+	@Test
+	public void fileListenerTestGetStringFromRawMessageLogFile() throws Exception {
+		String filename="rawMessageFile";
+		String contents="Test Message Contents";
+		String logFolder="log";
+		
+		fileSystemListener.setMinStableTime(0);
+		fileSystemListener.setLogFolder(logFolder);
+		fileSystemListener.setCreateFolders(true);
+		fileSystemListener.configure();
+		fileSystemListener.open();
+		
+		createFile(null, filename, contents);
+
+		F rawMessage=fileSystemListener.getRawMessage(threadContext);
+		assertNotNull(rawMessage);
+		
+		String message=fileSystemListener.getStringFromRawMessage(rawMessage, threadContext);
+		assertThat(message,CoreMatchers.containsString(filename));
+
+		
+		assertThat(message,CoreMatchers.containsString(filename));
+		assertTrue("Log folder must exist",_folderExists(logFolder));
+		assertTrue("File must exist in log folder",_fileExists(logFolder, filename));
 	}
 
 	@Test

--- a/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemListenerTest.java
@@ -111,32 +111,32 @@ public abstract class FileSystemListenerTest<F, FS extends IBasicFileSystem<F>> 
 	
 	@Test
 	public void fileListenerTestCreateInputFolder() throws Exception {
-		fileSystemListener.setInputFolder(fileAndFolderPrefix+"xxx");
-		fileSystemListener.setCreateInputDirectory(true);
+		fileSystemListener.setInputFolder(fileAndFolderPrefix+"xxx1");
+		fileSystemListener.setCreateFolders(true);
 		fileSystemListener.configure();
 		fileSystemListener.open();
 	}
 	
 	@Test
 	public void fileListenerTestCreateInProcessFolder() throws Exception {
-		fileSystemListener.setInProcessFolder(fileAndFolderPrefix+"xxx");
-		fileSystemListener.setCreateInputDirectory(true);
+		fileSystemListener.setInProcessFolder(fileAndFolderPrefix+"xxx2");
+		fileSystemListener.setCreateFolders(true);
 		fileSystemListener.configure();
 		fileSystemListener.open();
 	}
 	
 	@Test
 	public void fileListenerTestCreateProcessedFolder() throws Exception {
-		fileSystemListener.setProcessedFolder(fileAndFolderPrefix+"xxx");
-		fileSystemListener.setCreateInputDirectory(true);
+		fileSystemListener.setProcessedFolder(fileAndFolderPrefix+"xxx3");
+		fileSystemListener.setCreateFolders(true);
 		fileSystemListener.configure();
 		fileSystemListener.open();
 	}
 
 	@Test
 	public void fileListenerTestCreateLogFolder() throws Exception {
-		fileSystemListener.setLogFolder(fileAndFolderPrefix+"xxx");
-		fileSystemListener.setCreateInputDirectory(true);
+		fileSystemListener.setLogFolder(fileAndFolderPrefix+"xxx4");
+		fileSystemListener.setCreateFolders(true);
 		fileSystemListener.configure();
 		fileSystemListener.open();
 	}
@@ -186,7 +186,9 @@ public abstract class FileSystemListenerTest<F, FS extends IBasicFileSystem<F>> 
 	
 	@Test
 	public void fileListenerTestGetRawMessageWithInProcess() throws Exception {
-		fileListenerTestGetRawMessage(null,"inProcessFolder");
+		String folderName = "inProcessFolder";
+		_createFolder(folderName);
+		fileListenerTestGetRawMessage(null,folderName);
 	}
 
 
@@ -212,10 +214,10 @@ public abstract class FileSystemListenerTest<F, FS extends IBasicFileSystem<F>> 
 	public void fileListenerTestGetStringFromRawMessageLogFile() throws Exception {
 		String filename="rawMessageFile";
 		String contents="Test Message Contents";
-		String logFolder="log";
+		String logFolder="logFolder";
 		
 		fileSystemListener.setMinStableTime(0);
-		fileSystemListener.setLogFolder(logFolder);
+		fileSystemListener.setLogFolder(fileAndFolderPrefix+logFolder);
 		fileSystemListener.setCreateFolders(true);
 		fileSystemListener.configure();
 		fileSystemListener.open();

--- a/core/src/test/java/nl/nn/adapterframework/filesystem/MockFileSystem.java
+++ b/core/src/test/java/nl/nn/adapterframework/filesystem/MockFileSystem.java
@@ -3,7 +3,9 @@ package nl.nn.adapterframework.filesystem;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Arrays;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
@@ -175,6 +177,30 @@ public class MockFileSystem<M extends MockFile> extends MockFolder implements IW
 			getFolders().put(destinationFolderName,destFolder);
 		}
 		destFolder.getFiles().put(f.getName(), f.getOwner().getFiles().remove(f.getName()));
+		f.setOwner(destFolder);
+		return f;
+	}
+
+	@Override
+	public M copyFile(M f, String destinationFolderName, boolean createFolder) throws FileSystemException {
+		//checkOpenAndExists(f.getOwner().getName(),f);
+		MockFolder destFolder= destinationFolderName==null?this:getFolders().get(destinationFolderName);
+		if (destFolder==null) {
+			if (!createFolder) {
+				throw new FileSystemException("folder ["+destinationFolderName+"] does not exist");
+			} 
+			destFolder = new MockFolder(destinationFolderName,this);
+			getFolders().put(destinationFolderName,destFolder);
+		}
+		MockFile fileDuplicate = new MockFile(f.getName(), destFolder);
+		fileDuplicate.setContents(Arrays.copyOf(f.getContents(),f.getContents().length));
+		if (f.getAdditionalProperties()!=null) {
+			Map<String,Object> propDup = new HashMap<String,Object>();
+			propDup.putAll(f.getAdditionalProperties());
+			fileDuplicate.setAdditionalProperties(propDup);
+		}
+		fileDuplicate.setLastModified(f.getLastModified());
+		destFolder.getFiles().put(fileDuplicate.getName(), fileDuplicate);
 		f.setOwner(destFolder);
 		return f;
 	}


### PR DESCRIPTION
- Implement copyFile() method in all known FileSystems, except for ftp
- Add action 'copy' to FileSystemActor (and FileSystemPipe and -Sender)
- Add attribute 'logFolder' to FileSystemListener