### PR TITLE
Let JdbcTransactionalStorage return uniform responses for all dbmses

### DIFF
--- a/test/src/test/testtool/MessageStoreSenderAndListener/common.properties
+++ b/test/src/test/testtool/MessageStoreSenderAndListener/common.properties
@@ -43,8 +43,8 @@ jdbc.selectQueue.waitBeforeRead=1000
 ignoreContentBetweenKeys1.key1=<result><rowsupdated>
 ignoreContentBetweenKeys1.key2=</rowsupdated></result>
 
-ignoreContentBetweenKeys2.key1=<results><result>16
-ignoreContentBetweenKeys2.key2=</result></results>
+ignoreContentBetweenKeys2.key1=<id>
+ignoreContentBetweenKeys2.key2=</id>
 
 ignoreContentBetweenKeys3.key1=<fielddefinition>
 ignoreContentBetweenKeys3.key2=</fielddefinition>

--- a/test/src/test/testtool/MessageStoreSenderAndListener/scenario01.properties
+++ b/test/src/test/testtool/MessageStoreSenderAndListener/scenario01.properties
@@ -2,16 +2,23 @@ scenario.description = MessageStoreSender
 			   
 include = common.properties
 
+# delete all lines from ibistore that are in related slotIds
 step1.jdbc.deleteTableIbisStore.read = scenario01/jdbc-delete.xml
+
+# make the messageStoreSender write a message
 step2.java.MessageStoreSender.write  = scenario01/in.xml
+
+# read the result of the MessageStoreSender pipeline, which is 
+# either the key of the newly inserted line in the ibisstore
+# or a message that the message to be inserted already exists
 step3.java.MessageStoreSender.read   = scenario01/out.xml
 
-# there should be no items in de errorStorage of the writer part
+# there should be no items in the errorStorage of the writer part
 step4.jdbc.selectWriteErrors.read = scenario01/out-write-errors.xml 
 # there should be one message in the write log
 step5.jdbc.selectWriteLog.read    = scenario01/out-write-log.xml 
 
-# there should be no items in de errorStorage of the read part
+# there should be no items in the errorStorage of the read part
 step6.jdbc.selectReadErrors.read  = scenario01/out-read-errors.xml 
 
 # disabled checking of read log and queue for now, because it appears to be unstable

--- a/test/src/test/testtool/MessageStoreSenderAndListener/scenario01/out.xml
+++ b/test/src/test/testtool/MessageStoreSenderAndListener/scenario01/out.xml
@@ -1,1 +1,1 @@
-<results><result>162363</result></results>
+<id>162209</id>

--- a/test/src/test/testtool/MessageStoreSenderAndListener/scenario02/out-01.xml
+++ b/test/src/test/testtool/MessageStoreSenderAndListener/scenario02/out-01.xml
@@ -1,1 +1,1 @@
-<results><result>162366</result></results>
+<id>162209</id>


### PR DESCRIPTION
Backport of changes to JdbcTransactionalStorage from master to 7.5.

storeMessageInDatabase() used to return a ratjetoe of result formats.
Now it either returns the value of the key of the newly inserted record in ibisstore, enclosed in <id/>, or a uniformly formatted message stating that a matching message already exists.