### PR TITLE
Add ability to set character encoding on the response header

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
@@ -56,6 +56,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 
 	private ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private String messageIdHeader = AppConstants.getInstance(configurationClassLoader).getString("apiListener.messageIdHeader", "Message-Id");
+	private String charset = null; //Don't use any special character encoding unless explicitly specified!
 
 	public enum AuthenticationMethods {
 		NONE, COOKIE, HEADER, AUTHROLE;
@@ -78,6 +79,9 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		if(!methods.contains(getMethod()))
 			throw new ConfigurationException("Method ["+method+"] not yet implemented, supported methods are "+methods.toString()+"");
 
+		if(StringUtils.isNotEmpty(charset)) {
+			produces.withCharset(charset);
+		}
 	}
 
 	@Override
@@ -184,7 +188,15 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		return produces.name();
 	}
 
-	@IbisDoc({"5", "automatically generate and validate etags", "true"})
+	@IbisDoc({"5", "sets the specified character encoding on the response contentType header", ""})
+	public void setCharacterEncoding(String charset) {
+		this.charset = charset;
+	}
+	public String getCharacterEncoding() {
+		return charset;
+	}
+
+	@IbisDoc({"6", "automatically generate and validate etags", "true"})
 	public void setUpdateEtag(boolean updateEtag) {
 		this.updateEtag = updateEtag;
 	}
@@ -194,7 +206,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 
 	//TODO add authenticationType
 
-	@IbisDoc({"6", "enables security for this listener, must be one of [NONE, COOKIE, HEADER, AUTHROLE]. If you wish to use the application servers authorisation roles [AUTHROLE], you need to enable them globally for all ApiListeners with the `servlet.ApiListenerServlet.securityroles=ibistester,ibiswebservice` property", "NONE"})
+	@IbisDoc({"7", "enables security for this listener, must be one of [NONE, COOKIE, HEADER, AUTHROLE]. If you wish to use the application servers authorisation roles [AUTHROLE], you need to enable them globally for all ApiListeners with the `servlet.ApiListenerServlet.securityroles=ibistester,ibiswebservice` property", "NONE"})
 	public void setAuthenticationMethod(String authenticationMethod) throws ConfigurationException {
 		try {
 			this.authenticationMethod = AuthenticationMethods.valueOf(authenticationMethod);
@@ -212,7 +224,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		return this.authenticationMethod;
 	}
 
-	@IbisDoc({"6", "only active when AuthenticationMethod=AUTHROLE. comma separated list of authorization roles which are granted for this service, eq. ibistester,ibisobserver", ""})
+	@IbisDoc({"8", "only active when AuthenticationMethod=AUTHROLE. comma separated list of authorization roles which are granted for this service, eq. ibistester,ibisobserver", ""})
 	public void setAuthenticationRoles(String authRoles) {
 		List<String> roles = new ArrayList<String>();
 		if (StringUtils.isNotEmpty(authRoles)) {
@@ -230,7 +242,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		return authenticationRoles;
 	}
 
-	@IbisDoc({"7", "specify the form-part you wish to enter the pipeline", "name of the first form-part"})
+	@IbisDoc({"9", "specify the form-part you wish to enter the pipeline", "name of the first form-part"})
 	public void setMultipartBodyName(String multipartBodyName) {
 		this.multipartBodyName = multipartBodyName;
 	}
@@ -241,7 +253,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		return null;
 	}
 
-	@IbisDoc({"8", "name of the header which contains the message-id", "message-id"})
+	@IbisDoc({"10", "name of the header which contains the message-id", "message-id"})
 	public void setMessageIdHeader(String messageIdHeader) {
 		this.messageIdHeader = messageIdHeader;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
@@ -31,6 +31,7 @@ import nl.nn.adapterframework.doc.IbisDoc;
 import nl.nn.adapterframework.http.PushingListenerAdapter;
 import nl.nn.adapterframework.receivers.ReceiverAware;
 import nl.nn.adapterframework.util.AppConstants;
+import nl.nn.adapterframework.util.Misc;
 
 /**
  * 
@@ -57,7 +58,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 
 	private ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private String messageIdHeader = AppConstants.getInstance(configurationClassLoader).getString("apiListener.messageIdHeader", "Message-Id");
-	private String charset = null; //Use system default or UTF-8?
+	private String charset = null;
 
 	public enum AuthenticationMethods {
 		NONE, COOKIE, HEADER, AUTHROLE;
@@ -81,7 +82,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 			throw new ConfigurationException("Method ["+method+"] not yet implemented, supported methods are "+methods.toString()+"");
 
 		producedContentType = new ContentType(produces);
-		if(StringUtils.isNotEmpty(charset)) {
+		if(charset != null) {
 			producedContentType.setCharset(charset);
 		}
 	}
@@ -190,9 +191,11 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		return produces.name();
 	}
 
-	@IbisDoc({"5", "sets the specified character encoding on the response contentType header", ""})
+	@IbisDoc({"5", "sets the specified character encoding on the response contentType header", "UTF-8"})
 	public void setCharacterEncoding(String charset) {
-		this.charset = charset;
+		if(StringUtils.isNotEmpty(charset)) {
+			this.charset = charset;
+		}
 	}
 	public String getCharacterEncoding() {
 		return charset;

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
@@ -31,7 +31,6 @@ import nl.nn.adapterframework.doc.IbisDoc;
 import nl.nn.adapterframework.http.PushingListenerAdapter;
 import nl.nn.adapterframework.receivers.ReceiverAware;
 import nl.nn.adapterframework.util.AppConstants;
-import nl.nn.adapterframework.util.Misc;
 
 /**
  * 
@@ -139,8 +138,18 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		return pattern.replaceAll("\\{.*?}", "*");
 	}
 
+	/**
+	 * Match request ContentType to consumes enum to see if the listener accepts the message
+	 */
 	public boolean isConsumable(String contentType) {
 		return consumes.isConsumable(contentType);
+	}
+
+	/**
+	 * Match accept header to produces enum to see if the client accepts the message
+	 */
+	public boolean accepts(String acceptHeader) {
+		return produces.equals(MediaTypes.ANY) || acceptHeader.contains("*/*") || acceptHeader.contains(produces.getContentType());
 	}
 
 	public String getContentType() {

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
@@ -50,13 +50,14 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 
 	private MediaTypes consumes = MediaTypes.ANY;
 	private MediaTypes produces = MediaTypes.ANY;
+	private ContentType producedContentType;
 	private String multipartBodyName = null;
 
 	private IReceiver receiver;
 
 	private ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private String messageIdHeader = AppConstants.getInstance(configurationClassLoader).getString("apiListener.messageIdHeader", "Message-Id");
-	private String charset = null; //Don't use any special character encoding unless explicitly specified!
+	private String charset = null; //Use system default or UTF-8?
 
 	public enum AuthenticationMethods {
 		NONE, COOKIE, HEADER, AUTHROLE;
@@ -79,8 +80,9 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		if(!methods.contains(getMethod()))
 			throw new ConfigurationException("Method ["+method+"] not yet implemented, supported methods are "+methods.toString()+"");
 
+		producedContentType = new ContentType(produces);
 		if(StringUtils.isNotEmpty(charset)) {
-			produces.withCharset(charset);
+			producedContentType.setCharset(charset);
 		}
 	}
 
@@ -141,7 +143,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 	}
 
 	public String getContentType() {
-		return produces.getContentType();
+		return producedContentType.getContentType();
 	}
 
 	@IbisDoc({"1", "HTTP method eq. GET POST PUT DELETE", ""})
@@ -269,7 +271,7 @@ public class ApiListener extends PushingListenerAdapter<String> implements HasPh
 		builder.append(" uriPattern["+getUriPattern()+"]");
 		builder.append(" produces["+getProduces()+"]");
 		builder.append(" consumes["+getConsumes()+"]");
-		builder.append(" contentType["+getContentType()+"]");
+		builder.append(" messageIdHeader["+getMessageIdHeader()+"]");
 		builder.append(" updateEtag["+getUpdateEtag()+"]");
 		return builder.toString();
 	}

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -62,7 +62,6 @@ public class ApiListenerServlet extends HttpServletBase {
 
 	private static final long serialVersionUID = 1L;
 
-	private final String CHARSET="UTF-8";
 	private List<String> IGNORE_HEADERS = Arrays.asList("connection", "transfer-encoding", "content-type", "authorization");
 
 	protected Logger log = LogUtil.getLogger(this);
@@ -369,7 +368,6 @@ public class ApiListenerServlet extends HttpServletBase {
 			if (ServletFileUpload.isMultipartContent(request)) {
 				DiskFileItemFactory diskFileItemFactory = new DiskFileItemFactory();
 				ServletFileUpload servletFileUpload = new ServletFileUpload(diskFileItemFactory);
-				servletFileUpload.setHeaderEncoding(CHARSET);
 				List<FileItem> items = servletFileUpload.parseRequest(request);
 				XmlBuilder attachments = new XmlBuilder("parts");
 				int i = 0;
@@ -486,7 +484,7 @@ public class ApiListenerServlet extends HttpServletBase {
 			 */
 			response.addHeader("Allow", (String) messageContext.get("allowedMethods"));
 
-			String contentType = listener.getContentType() + ";charset="+CHARSET;
+			String contentType = listener.getContentType();
 			if(listener.getProduces().equals("ANY")) {
 				contentType = messageContext.get("contentType", contentType);
 			}

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -256,12 +256,12 @@ public class ApiListenerServlet extends HttpServletBase {
 			/**
 			 * Evaluate preconditions
 			 */
-			String accept = request.getHeader("Accept");
-			if(accept != null && !accept.isEmpty() && !accept.equals("*/*")) {
-				if(!listener.getProduces().equals("ANY") && !accept.contains(listener.getContentType())) {
+			String acceptHeader = request.getHeader("Accept");
+			if(StringUtils.isNotEmpty(acceptHeader)) { //If an Accept header is present, make sure we comply to it!
+				if(!listener.accepts(acceptHeader)) {
 					response.setStatus(406);
-					response.getWriter().print("It appears you expected the MediaType ["+accept+"] but I only support the MediaType ["+listener.getContentType()+"] :)");
-					if(log.isTraceEnabled()) log.trace("Aborting request with status [406], client expects ["+accept+"] got ["+listener.getContentType()+"] instead");
+					response.getWriter().print("It appears you expected the MediaType ["+acceptHeader+"] but I only support the MediaType ["+listener.getContentType()+"] :)");
+					if(log.isTraceEnabled()) log.trace("Aborting request with status [406], client expects ["+acceptHeader+"] got ["+listener.getContentType()+"] instead");
 					return;
 				}
 			}

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiServiceDispatcher.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiServiceDispatcher.java
@@ -153,7 +153,10 @@ public class ApiServiceDispatcher {
 					IAdapter adapter = listener.getReceiver().getAdapter();
 					methodBuilder.add("summary", adapter.getDescription());
 					methodBuilder.add("operationId", adapter.getName());
-					methodBuilder.add("responses", mapResponses(adapter, listener.getContentType(), schemas));
+
+					//ContentType may have more parameters such as charset and formdata-boundry
+					MediaTypes produces = MediaTypes.valueOf(listener.getProduces());
+					methodBuilder.add("responses", mapResponses(adapter, produces, schemas));
 				}
 
 				methods.add(method.toLowerCase(), methodBuilder);
@@ -177,7 +180,7 @@ public class ApiServiceDispatcher {
 		return null;
 	}
 
-	private JsonObjectBuilder mapResponses(IAdapter adapter, String contentType, JsonObjectBuilder schemas) {
+	private JsonObjectBuilder mapResponses(IAdapter adapter, MediaTypes contentType, JsonObjectBuilder schemas) {
 		JsonObjectBuilder responses = Json.createObjectBuilder();
 
 		PipeLine pipeline = adapter.getPipeLine();
@@ -210,9 +213,9 @@ public class ApiServiceDispatcher {
 			if(!ple.getEmptyResult()) {
 				JsonObjectBuilder content = Json.createObjectBuilder();
 				if(schema == null) {
-					content.addNull(contentType);
+					content.addNull(contentType.getContentType());
 				} else {
-					content.add(contentType, schema);
+					content.add(contentType.getContentType(), schema);
 				}
 				exit.add("content", content);
 			}

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ContentType.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ContentType.java
@@ -15,23 +15,31 @@ limitations under the License.
 */
 package nl.nn.adapterframework.http.rest;
 
+import java.nio.charset.Charset;
+import java.nio.charset.UnsupportedCharsetException;
+
 import org.apache.commons.lang3.StringUtils;
 
 public class ContentType {
 	public static final String CHARSET_PARAMETER = "charset";
 	private MediaTypes mediaType;
-	private String charset;
+	private Charset charset;
 
 	public ContentType(MediaTypes mediaType) {
 		this.mediaType = mediaType;
+		this.charset = mediaType.getCharset(); // when charset = NULL it means setting it is disallowed
 	}
 
 	public void setCharset(String charset) {
+		if(charset == null) {
+			throw new UnsupportedCharsetException("provided mediatype does not support setting charset");
+		}
+
 		if(StringUtils.isNotEmpty(charset)) {
-			this.charset = charset.toUpperCase();
+			this.charset = Charset.forName(charset);
 		}
 	}
-	public String getCharset() {
+	public Charset getCharset() {
 		return charset;
 	}
 
@@ -41,7 +49,7 @@ public class ContentType {
 			string.append(";");
 			string.append(CHARSET_PARAMETER);
 			string.append("=");
-			string.append(charset);
+			string.append(charset.name());
 		}
 
 		return string.toString();

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ContentType.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ContentType.java
@@ -27,11 +27,11 @@ public class ContentType {
 
 	public ContentType(MediaTypes mediaType) {
 		this.mediaType = mediaType;
-		this.charset = mediaType.getCharset(); // when charset = NULL it means setting it is disallowed
+		this.charset = mediaType.getDefaultCharset(); // when charset = NULL it means setting it is disallowed
 	}
 
 	public void setCharset(String charset) {
-		if(charset == null) {
+		if(this.charset == null) {
 			throw new UnsupportedCharsetException("provided mediatype does not support setting charset");
 		}
 

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ContentType.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ContentType.java
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 WeAreFrank!
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nl.nn.adapterframework.http.rest;
+
+import org.apache.commons.lang3.StringUtils;
+
+public class ContentType {
+	public static final String CHARSET_PARAMETER = "charset";
+	private MediaTypes mediaType;
+	private String charset;
+
+	public ContentType(MediaTypes mediaType) {
+		this.mediaType = mediaType;
+	}
+
+	public void setCharset(String charset) {
+		if(StringUtils.isNotEmpty(charset)) {
+			this.charset = charset.toUpperCase();
+		}
+	}
+	public String getCharset() {
+		return charset;
+	}
+
+	public String getContentType() {
+		StringBuilder string = new StringBuilder(mediaType.getContentType());
+		if(charset != null) {
+			string.append(";");
+			string.append(CHARSET_PARAMETER);
+			string.append("=");
+			string.append(charset);
+		}
+
+		return string.toString();
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 WeAreFrank!
+Copyright 2019-2020 WeAreFrank!
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,8 +15,6 @@ limitations under the License.
 */
 package nl.nn.adapterframework.http.rest;
 
-import org.apache.commons.lang3.StringUtils;
-
 public enum MediaTypes {
 
 	ANY("*/*"),
@@ -28,43 +26,14 @@ public enum MediaTypes {
 	MULTIPART_FORMDATA("multipart/form-data"),
 	MULTIPART("multipart/*");
 
-	public static final String CHARSET_PARAMETER = "charset";
-
-	private String mediaType;
-	private String charset;
+	private final String mediaType;
 
 	private MediaTypes(String mediaType) {
-		this(mediaType, null);
-	}
-	private MediaTypes(String mediaType, String charset) {
 		this.mediaType = mediaType;
-		this.charset = charset;
-	}
-
-	/**
-	 * Getter for primary type.
-	 */
-	public String getType() {
-		return mediaType;
-	}
-
-	/**
-	 * Getter for primary type.
-	 */
-	public String getCharset() {
-		return charset;
 	}
 
 	public String getContentType() {
-		StringBuilder string = new StringBuilder(mediaType);
-		if(charset != null) {
-			string.append(";");
-			string.append(CHARSET_PARAMETER);
-			string.append("=");
-			string.append(charset);
-		}
-
-		return string.toString();
+		return mediaType;
 	}
 
 	public boolean isConsumable(String contentType) {
@@ -89,12 +58,5 @@ public enum MediaTypes {
 			}
 		}
 		throw new IllegalArgumentException(v);
-	}
-
-	public MediaTypes withCharset(String charset) {
-		if(StringUtils.isNotEmpty(charset)) {
-			this.charset = charset.toUpperCase();
-		}
-		return this;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
@@ -17,6 +17,8 @@ package nl.nn.adapterframework.http.rest;
 
 import java.nio.charset.Charset;
 
+import nl.nn.adapterframework.util.StreamUtil;
+
 public enum MediaTypes {
 
 	ANY("*/*", null),
@@ -30,28 +32,29 @@ public enum MediaTypes {
 	MULTIPART("multipart/*");
 
 	private final String mediaType;
-	private final Charset charset;
+	private final Charset defaultCharset;
 
 	/**
 	 * Creates a new MediaType with the default charset (UTF-8)
 	 */
 	private MediaTypes(String mediaType) {
-		this(mediaType, Charset.forName("utf-8"));
+		this(mediaType, Charset.forName(StreamUtil.DEFAULT_INPUT_STREAM_ENCODING));
 	}
 
 	/**
-	 * Creates a new MediaType with the given charset
+	 * Creates a new MediaType with the given charset.
+	 * `null` means no charset!
 	 */
 	private MediaTypes(String mediaType, Charset charset) {
 		this.mediaType = mediaType;
-		this.charset = charset;
+		this.defaultCharset = charset;
 	}
 
 	/**
 	 * returns the default charset for the given mediatype or null when non is allowed
 	 */
-	public Charset getCharset() {
-		return charset;
+	public Charset getDefaultCharset() {
+		return defaultCharset;
 	}
 
 	public String getContentType() {

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
@@ -15,21 +15,43 @@ limitations under the License.
 */
 package nl.nn.adapterframework.http.rest;
 
+import java.nio.charset.Charset;
+
 public enum MediaTypes {
 
-	ANY("*/*"),
+	ANY("*/*", null),
 	TEXT("text/plain"),
 	XML("application/xml"),
 	JSON("application/json"),
-	PDF("application/pdf"),
+	PDF("application/pdf", null), //raw binary formats do not have a charset
+	OCTET("application/octet-stream", null), //raw binary formats do not have a charset
 	MULTIPART_RELATED("multipart/related"),
 	MULTIPART_FORMDATA("multipart/form-data"),
 	MULTIPART("multipart/*");
 
 	private final String mediaType;
+	private final Charset charset;
 
+	/**
+	 * Creates a new MediaType with the default charset (UTF-8)
+	 */
 	private MediaTypes(String mediaType) {
+		this(mediaType, Charset.forName("utf-8"));
+	}
+
+	/**
+	 * Creates a new MediaType with the given charset
+	 */
+	private MediaTypes(String mediaType, Charset charset) {
 		this.mediaType = mediaType;
+		this.charset = charset;
+	}
+
+	/**
+	 * returns the default charset for the given mediatype or null when non is allowed
+	 */
+	public Charset getCharset() {
+		return charset;
 	}
 
 	public String getContentType() {

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
@@ -1,5 +1,5 @@
 /*
-Copyright 2019 Integration Partners B.V.
+Copyright 2019 WeAreFrank!
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -15,6 +15,8 @@ limitations under the License.
 */
 package nl.nn.adapterframework.http.rest;
 
+import org.apache.commons.lang3.StringUtils;
+
 public enum MediaTypes {
 
 	ANY("*/*"),
@@ -26,14 +28,43 @@ public enum MediaTypes {
 	MULTIPART_FORMDATA("multipart/form-data"),
 	MULTIPART("multipart/*");
 
-	private final String mediaType;
+	public static final String CHARSET_PARAMETER = "charset";
+
+	private String mediaType;
+	private String charset;
 
 	private MediaTypes(String mediaType) {
+		this(mediaType, null);
+	}
+	private MediaTypes(String mediaType, String charset) {
 		this.mediaType = mediaType;
+		this.charset = charset;
+	}
+
+	/**
+	 * Getter for primary type.
+	 */
+	public String getType() {
+		return mediaType;
+	}
+
+	/**
+	 * Getter for primary type.
+	 */
+	public String getCharset() {
+		return charset;
 	}
 
 	public String getContentType() {
-		return mediaType;
+		StringBuilder string = new StringBuilder(mediaType);
+		if(charset != null) {
+			string.append(";");
+			string.append(CHARSET_PARAMETER);
+			string.append("=");
+			string.append(charset);
+		}
+
+		return string.toString();
 	}
 
 	public boolean isConsumable(String contentType) {
@@ -58,5 +89,12 @@ public enum MediaTypes {
 			}
 		}
 		throw new IllegalArgumentException(v);
+	}
+
+	public MediaTypes withCharset(String charset) {
+		if(StringUtils.isNotEmpty(charset)) {
+			this.charset = charset.toUpperCase();
+		}
+		return this;
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
@@ -155,6 +155,42 @@ public class ApiListenerTest {
 		}
 	}
 
+	@Test
+	public void listenerAcceptsAll() throws ConfigurationException {
+		String contentType = "application/octet-stream";
+		String acceptHeader = contentType + "; type=text/html; q=0.7, "+contentType+"; level=2; q=0.4";
+
+		listener.setProduces("ANY");
+		assertTrue("accepts anything", listener.accepts(acceptHeader));
+	}
+
+	@Test
+	public void clientAcceptsAll() throws ConfigurationException {
+		String contentType = "application/xhtml+xml, application/xml";
+		String acceptHeader = contentType + "; type=text/html; q=0.7, */*; level=2; q=0.4";
+
+		listener.setProduces("JSON");
+		assertTrue("accepts anything", listener.accepts(acceptHeader));
+	}
+
+	@Test
+	public void doesNotAcceptOctetStreamWhenJSON() throws ConfigurationException {
+		String contentType = "application/octet-stream";
+		String acceptHeader = contentType + "; type=text/html; q=0.7, "+contentType+"; level=2; q=0.4";
+
+		listener.setProduces("JSON");
+		assertFalse("does not accept an octet-stream when set to JSON", listener.accepts(acceptHeader));
+	}
+
+	@Test
+	public void acceptsJson() throws ConfigurationException {
+		String contentType = "application/json";
+		String acceptHeader = contentType + "; type=text/html; q=0.7, "+contentType+"; level=2; q=0.4";
+
+		listener.setProduces("JSON");
+		assertTrue("accepts JSON", listener.accepts(acceptHeader));
+	}
+
 	@Test(expected = ConfigurationException.class)
 	public void testFaultyAuthMethod() throws ConfigurationException {
 		try{

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
@@ -56,6 +56,16 @@ public class ApiListenerTest {
 		assertEquals("XML", listener.getProduces());
 	}
 
+	@Test
+	public void testProducesPdfWithCharset() throws ConfigurationException {
+		listener.setProduces("PDF");
+		listener.setCharacterEncoding("utf-8");
+		listener.configure();
+
+		assertEquals("PDF", listener.getProduces());
+		assertEquals("application/pdf;charset=UTF-8", listener.getContentType());
+	}
+
 	@Test(expected=IllegalArgumentException.class)
 	public void testUnknownProduces() throws ConfigurationException {
 		listener.setProduces("unknown");

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
@@ -57,13 +57,13 @@ public class ApiListenerTest {
 	}
 
 	@Test
-	public void testProducesPdfWithCharset() throws ConfigurationException {
-		listener.setProduces("PDF");
+	public void testProducesTextWithCharset() throws ConfigurationException {
+		listener.setProduces("TEXT");
 		listener.setCharacterEncoding("utf-8");
 		listener.configure();
 
-		assertEquals("PDF", listener.getProduces());
-		assertEquals("application/pdf;charset=UTF-8", listener.getContentType());
+		assertEquals("TEXT", listener.getProduces());
+		assertEquals("text/plain;charset=UTF-8", listener.getContentType());
 	}
 
 	@Test(expected=IllegalArgumentException.class)
@@ -98,7 +98,7 @@ public class ApiListenerTest {
 			listener.setProduces(type.name());
 			listener.configure(); //Check if the mediatype passes the configure checks
 
-			assertEquals(type.getContentType(), listener.getContentType());
+			assertTrue(listener.getContentType().startsWith(type.getContentType()));
 		}
 
 		//Check empty produces

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ContentTypeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ContentTypeTest.java
@@ -1,0 +1,41 @@
+/*
+Copyright 2020 WeAreFrank!
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package nl.nn.adapterframework.http.rest;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+public class ContentTypeTest {
+
+	@Test
+	public void defaultTest() {
+		ContentType contenType = new ContentType(MediaTypes.ANY);
+		assertNull("MediaType should not have a charset by default", contenType.getCharset());
+		assertEquals("ContentType should be */* without charset", "*/*", contenType.getContentType());
+	}
+
+	@Test
+	public void withCharset() {
+		ContentType contenType = new ContentType(MediaTypes.PDF);
+		assertNull("ContentType should not have a charset by default", contenType.getCharset());
+		assertEquals("ContentType should be application/pdf without charset", "application/pdf", contenType.getContentType());
+
+		contenType.setCharset("Utf-8");
+		assertEquals("application/pdf;charset=UTF-8", contenType.getContentType());
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ContentTypeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ContentTypeTest.java
@@ -18,24 +18,43 @@ package nl.nn.adapterframework.http.rest;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.nio.charset.UnsupportedCharsetException;
+
 import org.junit.Test;
 
 public class ContentTypeTest {
 
 	@Test
 	public void defaultTest() {
-		ContentType contenType = new ContentType(MediaTypes.ANY);
-		assertNull("MediaType should not have a charset by default", contenType.getCharset());
-		assertEquals("ContentType should be */* without charset", "*/*", contenType.getContentType());
+		ContentType contentType = new ContentType(MediaTypes.ANY);
+		assertNull("MediaType should not have a charset by default", contentType.getCharset());
+		assertEquals("ContentType should be */* without charset", "*/*", contentType.getContentType());
 	}
 
 	@Test
-	public void withCharset() {
-		ContentType contenType = new ContentType(MediaTypes.PDF);
-		assertNull("ContentType should not have a charset by default", contenType.getCharset());
-		assertEquals("ContentType should be application/pdf without charset", "application/pdf", contenType.getContentType());
+	public void utf8Charset() {
+		ContentType contentType = new ContentType(MediaTypes.TEXT);
+		assertEquals("ContentType should have a charset UTF-8", "UTF-8", contentType.getCharset().name());
+		assertEquals("ContentType should be application/pdf with utf-8 charset", "text/plain;charset=UTF-8", contentType.getContentType());
+	}
 
-		contenType.setCharset("Utf-8");
-		assertEquals("application/pdf;charset=UTF-8", contenType.getContentType());
+	@Test
+	public void isoCharset() {
+		ContentType contentType = new ContentType(MediaTypes.TEXT);
+		contentType.setCharset("ISO-8859-1");
+		assertEquals("text/plain;charset=ISO-8859-1", contentType.getContentType());
+	}
+
+	@Test
+	public void asciiCharset() {
+		ContentType contentType = new ContentType(MediaTypes.TEXT);
+		contentType.setCharset("US-ASCII");
+		assertEquals("text/plain;charset=US-ASCII", contentType.getContentType());
+	}
+
+	@Test(expected=UnsupportedCharsetException.class)
+	public void faultyCharset() {
+		ContentType contentType = new ContentType(MediaTypes.TEXT);
+		contentType.setCharset("ISO-1234");
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
@@ -79,4 +79,13 @@ public class MediaTypeTest {
 			assertTrue("can parse ["+header+"]", MediaTypes.MULTIPART.isConsumable(acceptHeader));
 		}
 	}
+
+	@Test
+	public void addCharset() {
+		MediaTypes type = MediaTypes.PDF;
+		assertEquals("application/pdf", type.getContentType());
+
+		type.withCharset("Utf-8");
+		assertEquals("application/pdf;charset=UTF-8", type.getContentType());
+	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
@@ -83,12 +83,12 @@ public class MediaTypeTest {
 
 	@Test
 	public void defaultJsonCharsetUtf8() {
-		assertEquals("json should not have utf-8 charset", "UTF-8", MediaTypes.JSON.getCharset().name());
+		assertEquals("json should not have utf-8 charset", "UTF-8", MediaTypes.JSON.getDefaultCharset().name());
 	}
 
 	@Test
 	public void noCharsetOnOctetstreams() {
-		assertNull("octet-stream should not have a charset", MediaTypes.OCTET.getCharset());
-		assertNull("pdf should not have a charset", MediaTypes.PDF.getCharset());
+		assertNull("octet-stream should not have a charset", MediaTypes.OCTET.getDefaultCharset());
+		assertNull("pdf should not have a charset", MediaTypes.PDF.getDefaultCharset());
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
@@ -17,6 +17,7 @@ package nl.nn.adapterframework.http.rest;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
@@ -78,5 +79,16 @@ public class MediaTypeTest {
 
 			assertTrue("can parse ["+header+"]", MediaTypes.MULTIPART.isConsumable(acceptHeader));
 		}
+	}
+
+	@Test
+	public void defaultJsonCharsetUtf8() {
+		assertEquals("json should not have utf-8 charset", "UTF-8", MediaTypes.JSON.getCharset().name());
+	}
+
+	@Test
+	public void noCharsetOnOctetstreams() {
+		assertNull("octet-stream should not have a charset", MediaTypes.OCTET.getCharset());
+		assertNull("pdf should not have a charset", MediaTypes.PDF.getCharset());
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
@@ -79,13 +79,4 @@ public class MediaTypeTest {
 			assertTrue("can parse ["+header+"]", MediaTypes.MULTIPART.isConsumable(acceptHeader));
 		}
 	}
-
-	@Test
-	public void addCharset() {
-		MediaTypes type = MediaTypes.PDF;
-		assertEquals("application/pdf", type.getContentType());
-
-		type.withCharset("Utf-8");
-		assertEquals("application/pdf;charset=UTF-8", type.getContentType());
-	}
 }


### PR DESCRIPTION
Revert 88ead735ee4c673d67eeb14e3d77066977b04f6e
Add ability to set Character Encoding on response ContentType header (a508918f2b3172f2397d14154b9b30f26f180762)
No charset is set by default