### PR TITLE
Added postgres database connectivity to iaf-test

### DIFF
--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -17,6 +17,7 @@ jdbc.datasource.oracle_docker=jdbc/${instance.name.lc}-oracle-docker
 jdbc.datasource.mssql.microsoft=jdbc/${instance.name.lc}-mssql-microsoft
 jdbc.datasource.mssql.microsoft-xa=jdbc/${instance.name.lc}-mssql-microsoft-xa
 jdbc.datasource.mssql.jtds=jdbc/${instance.name.lc}-mssql-jtds
+jdbc.datasource.postgres=jdbc/${instance.name.lc}-postgres
 jdbc.datasource.default=${jdbc.datasource.h2}
 
 manageDatabase.active=true

--- a/test/src/main/tools/setupDB/Postgresql/create_user.sql
+++ b/test/src/main/tools/setupDB/Postgresql/create_user.sql
@@ -1,0 +1,14 @@
+--Prevent all connections to existing database
+--Otherwise it cannot be dropped
+REVOKE CONNECT ON DATABASE wearefrank_db FROM public;
+SELECT pg_terminate_backend(pg_stat_activity.pid)
+FROM pg_stat_activity
+WHERE pg_stat_activity.datname = 'wearefrank_db'
+AND pid <> pg_backend_pid();
+--Drop database and user
+DROP DATABASE IF EXISTS wearefrank_db;
+DROP ROLE IF EXISTS testiaf_user;
+--Create new database and user
+CREATE DATABASE wearefrank_db;
+CREATE USER testiaf_user WITH PASSWORD 'testiaf_pass01';
+GRANT ALL PRIVILEGES ON DATABASE wearefrank_db TO testiaf_user;

--- a/test/src/main/tools/setupDB/Postgresql/create_user.xml
+++ b/test/src/main/tools/setupDB/Postgresql/create_user.xml
@@ -1,0 +1,11 @@
+<project default="create.user">
+	<target name="create.user">
+		<property name="PGPASSWORD" value="system"/>
+		<exec executable="psql">
+			<arg value="-U"/>
+			<arg value="postgres"/>
+			<arg value="-f"/>
+			<arg value="create_user.sql"/>
+		</exec>
+	</target>
+</project>

--- a/test/src/main/webapp/META-INF/context.xml
+++ b/test/src/main/webapp/META-INF/context.xml
@@ -81,6 +81,19 @@
 		validationQuery="select 1"
 	/>
 
+ 	<Resource 
+			name="jdbc/ibis4test-postgres" 
+			auth="Container"
+			type="javax.sql.DataSource" 
+			driverClassName="org.postgresql.Driver"
+			url="jdbc:postgresql://localhost:5432/wearefrank_db"
+			username="testiaf_user" 
+			password="testiaf_pass01" 
+			maxActive="20" 
+			maxIdle="10" 
+			maxWait="-1"
+		/>
+
 	<Resource
 		name="jms/qcf_tibco_esb_ff"
 		factory="org.apache.naming.factory.BeanFactory"
@@ -107,4 +120,5 @@
 		SSLTrace="false"
 		SSLDebugTrace="false"
 	/>
+	
 </Context>


### PR DESCRIPTION
The test scenarios in the framework's test adapter will have to work on a postgres database.
This commit enables iaf to create a user and database via ant build.
And subsequently create the tables via liquibase in the postgres database