### PR TITLE
Add DummyPrincipal to AllowAllSecurityHandler

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/core/AllowAllSecurityHandler.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/AllowAllSecurityHandler.java
@@ -26,7 +26,13 @@ import org.apache.commons.lang.NotImplementedException;
  * @since   4.3
  */
 public class AllowAllSecurityHandler implements ISecurityHandler {
-
+	private boolean throwException = true;
+	private DummyPrincipal dummyPrincipal = null;
+	
+	public AllowAllSecurityHandler(boolean throwException) {
+		this.throwException = throwException;
+	}
+	
 	@Override
 	public boolean isUserInRole(String role, IPipeLineSession session) {
 		return true;
@@ -34,7 +40,12 @@ public class AllowAllSecurityHandler implements ISecurityHandler {
 
 	@Override
 	public Principal getPrincipal(IPipeLineSession session) throws NotImplementedException {
-		throw new NotImplementedException("no default user available");
+		if (throwException) {
+			throw new NotImplementedException("no default user available");
+		}
+		if (dummyPrincipal == null) {
+			dummyPrincipal = new DummyPrincipal();
+		}
+		return dummyPrincipal;
 	}
-
 }

--- a/core/src/main/java/nl/nn/adapterframework/core/DummyPrincipal.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/DummyPrincipal.java
@@ -1,0 +1,26 @@
+/*
+   Copyright 2018 Nationale-Nederlanden
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+ */
+package nl.nn.adapterframework.core;
+
+import java.security.Principal;
+
+public class DummyPrincipal implements Principal {
+
+	@Override
+	public String getName() {
+		return "dummy";
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/IsAllSecurityHandlerAllowed.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/IsAllSecurityHandlerAllowed.java
@@ -1,0 +1,88 @@
+/*
+   Copyright 2018 Nationale-Nederlanden
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.pipes;
+
+
+import nl.nn.adapterframework.core.AllowAllSecurityHandler;
+import nl.nn.adapterframework.core.IPipeLineSession;
+import nl.nn.adapterframework.core.PipeForward;
+import nl.nn.adapterframework.core.PipeRunException;
+import nl.nn.adapterframework.core.PipeRunResult;
+import nl.nn.adapterframework.stream.Message;
+
+/**
+ * Selects an exitState, based on the input equals an AllowAllSecurityHandler object.
+ * 
+ * <p><b>Configuration:</b>
+ * <table border="1">
+ * <tr><th>attributes</th><th>description</th><th>default</th></tr>
+ * <tr><td>className</td><td>nl.nn.adapterframework.pipes.XmlIf</td><td>&nbsp;</td></tr>
+ * <tr><td>{@link #setName(String) name}</td><td>name of the Pipe</td><td>&nbsp;</td></tr>
+ * <tr><td>{@link #setThenForwardName(String) thenForwardName}</td><td>forward returned when 'true'</code></td><td>then</td></tr>
+ * <tr><td>{@link #setElseForwardName(String) elseForwardName}</td><td>forward returned when 'false'</td><td>else</td></tr>
+ * </table>
+ * </p>
+ *
+ * @author  Peter Leeuwenburgh
+ */
+
+public class IsAllSecurityHandlerAllowed extends AbstractPipe {
+
+	private String thenForwardName = "then";
+	private String elseForwardName = "else";
+
+
+	@Override
+	public PipeRunResult doPipe(Message message, IPipeLineSession session) throws PipeRunException {
+		String forward = "";
+		PipeForward pipeForward = null;
+
+		if (message.asObject() instanceof AllowAllSecurityHandler) {
+			forward = thenForwardName;
+		} else {
+			forward = elseForwardName;
+		}
+
+		log.debug(
+				getLogPrefix(session) + "determined forward [" + forward + "]");
+
+		pipeForward = findForward(forward);
+
+		if (pipeForward == null) {
+			throw new PipeRunException(this, getLogPrefix(null)
+					+ "cannot find forward or pipe named [" + forward + "]");
+		}
+		log.debug(getLogPrefix(session) + "resolved forward [" + forward
+				+ "] to path [" + pipeForward.getPath() + "]");
+		return new PipeRunResult(pipeForward, message);
+	}
+
+	public void setThenForwardName(String thenForwardName) {
+		this.thenForwardName = thenForwardName;
+	}
+
+	public String getThenForwardName() {
+		return thenForwardName;
+	}
+
+	public void setElseForwardName(String elseForwardName) {
+		this.elseForwardName = elseForwardName;
+	}
+
+	public String getElseForwardName() {
+		return elseForwardName;
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/pipes/PutAllowAllSecurityHandlerInSession.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/PutAllowAllSecurityHandlerInSession.java
@@ -15,7 +15,6 @@ message   Copyright 2018 Nationale-Nederlanden
 */
 package nl.nn.adapterframework.pipes;
 
-import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.AllowAllSecurityHandler;
 import nl.nn.adapterframework.core.IPipeLineSession;
 import nl.nn.adapterframework.core.PipeRunException;
@@ -35,39 +34,13 @@ import nl.nn.adapterframework.stream.Message;
  * @author  Peter Leeuwenburgh
  */
 public class PutAllowAllSecurityHandlerInSession extends FixedForwardPipe {
-	private String sessionKey = "securityHandler";
-
-	@Override
-	public void configure() throws ConfigurationException {
-		super.configure();
-
-		// check the presence of a sessionKey
-		if (getSessionKey() == null) {
-			throw new ConfigurationException(
-					getLogPrefix(null) + "has a null value for sessionKey");
-		}
-	}
 
 	public PipeRunResult doPipe(Message message, IPipeLineSession session) throws PipeRunException {
 		AllowAllSecurityHandler allowAllSecurityHandler = new AllowAllSecurityHandler(false);
-
-		session.put(this.getSessionKey(), allowAllSecurityHandler);
-
+		session.put(IPipeLineSession.securityHandlerKey, allowAllSecurityHandler);
 		if (log.isDebugEnabled()) {
-			log.debug(
-					getLogPrefix(session) + "stored [" + allowAllSecurityHandler
-							+ "] in pipeLineSession under key ["
-							+ getSessionKey() + "]");
+			log.debug(getLogPrefix(session) + "stored [" + allowAllSecurityHandler + "] in pipeLineSession under key [" + IPipeLineSession.securityHandlerKey + "]");
 		}
-
 		return new PipeRunResult(getForward(), message);
-	}
-
-	public String getSessionKey() {
-		return sessionKey;
-	}
-
-	public void setSessionKey(String newSessionKey) {
-		sessionKey = newSessionKey;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/pipes/PutAllowAllSecurityHandlerInSession.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/PutAllowAllSecurityHandlerInSession.java
@@ -1,0 +1,73 @@
+/*
+message   Copyright 2018 Nationale-Nederlanden
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.pipes;
+
+import nl.nn.adapterframework.configuration.ConfigurationException;
+import nl.nn.adapterframework.core.AllowAllSecurityHandler;
+import nl.nn.adapterframework.core.IPipeLineSession;
+import nl.nn.adapterframework.core.PipeRunException;
+import nl.nn.adapterframework.core.PipeRunResult;
+import nl.nn.adapterframework.stream.Message;
+
+/**
+ * Puts a security handler, which declares that each role is valid, under a key in the {@link nl.nn.adapterframework.core.IPipeLineSession pipeLineSession}.
+ *
+ * <p><b>Configuration:</b>
+ * <table border="1">
+ * <tr><th>attributes</th><th>description</th><th>default</th></tr>
+ * <tr><td>{@link #setName(String) name}</td><td>name of the Pipe</td><td>&nbsp;</td></tr>
+ * <tr><td>{@link #setSessionKey(String) sessionKey}</td><td>key of session variable to store result in</td><td>systemDate</td></tr>
+ * </table>
+ * </p>
+ * @author  Peter Leeuwenburgh
+ */
+public class PutAllowAllSecurityHandlerInSession extends FixedForwardPipe {
+	private String sessionKey = "securityHandler";
+
+	@Override
+	public void configure() throws ConfigurationException {
+		super.configure();
+
+		// check the presence of a sessionKey
+		if (getSessionKey() == null) {
+			throw new ConfigurationException(
+					getLogPrefix(null) + "has a null value for sessionKey");
+		}
+	}
+
+	public PipeRunResult doPipe(Message message, IPipeLineSession session) throws PipeRunException {
+		AllowAllSecurityHandler allowAllSecurityHandler = new AllowAllSecurityHandler(false);
+
+		session.put(this.getSessionKey(), allowAllSecurityHandler);
+
+		if (log.isDebugEnabled()) {
+			log.debug(
+					getLogPrefix(session) + "stored [" + allowAllSecurityHandler
+							+ "] in pipeLineSession under key ["
+							+ getSessionKey() + "]");
+		}
+
+		return new PipeRunResult(getForward(), message);
+	}
+
+	public String getSessionKey() {
+		return sessionKey;
+	}
+
+	public void setSessionKey(String newSessionKey) {
+		sessionKey = newSessionKey;
+	}
+}

--- a/test/src/main/configurations/MainConfig/Configuration.xml
+++ b/test/src/main/configurations/MainConfig/Configuration.xml
@@ -55,6 +55,7 @@
 	<!ENTITY BlockEnabledSenders SYSTEM "./ConfigurationBlockEnabledSenders.xml">
 	<!ENTITY SoapValidator SYSTEM "./ConfigurationSoapValidator.xml">
 	<!ENTITY ApiWsdlGenerator SYSTEM "./ConfigurationApiWsdlGenerator.xml">
+	<!ENTITY SecurityHandler SYSTEM "./ConfigurationSecurityHandler.xml">
 ]>
 <configuration name="MainConfig">
 	&Authentication;
@@ -113,4 +114,5 @@
 	&BlockEnabledSenders;
 	&SoapValidator;
 	&ApiWsdlGenerator;
+	&SecurityHandler;
 </configuration>

--- a/test/src/main/configurations/MainConfig/ConfigurationSecurityHandler.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationSecurityHandler.xml
@@ -1,0 +1,34 @@
+<module>
+	<adapter name="SecurityHandler">
+		<receiver className="nl.nn.adapterframework.receivers.GenericReceiver" name="GenericRestRouterPost">
+			<listener className="nl.nn.adapterframework.receivers.JavaListener" serviceName="ibis4test-securityHandler" />
+		</receiver>
+		<pipeline firstPipe="getAllowAllSecurityHandler">
+			<exits>
+				<exit state="success" path="EXIT" />
+			</exits>
+
+			<pipe name="getAllowAllSecurityHandler" className="nl.nn.adapterframework.pipes.PutAllowAllSecurityHandlerInSession">
+				<forward name="success" path="switchSecurityHandler" />
+			</pipe>
+
+			<pipe name="switchSecurityHandler" className="nl.nn.adapterframework.pipes.IsAllSecurityHandlerAllowed" getInputFromSessionKey="securityHandler">
+				<forward name="then" path="getPrincipalName" />
+				<forward name="else" path="failWithException" />
+			</pipe>
+
+			<pipe name="failWithException" className="nl.nn.adapterframework.pipes.ExceptionPipe" getInputFromFixedValue="NOT_ALL_SECURITY_HANDLER_ALLOWED">
+				<forward name="success" path="EXIT" />
+			</pipe>
+
+			<pipe name="getPrincipalName" className="nl.nn.adapterframework.pipes.GetPrincipalPipe" getInputFromFixedValue="&lt;helloWorld/&gt;">
+				<forward name="success" path="text2Xml" />
+			</pipe>
+
+			<pipe name="text2Xml" className="nl.nn.adapterframework.pipes.Text2XmlPipe" xmlTag="result" includeXmlDeclaration="false" useCdataSection="false">
+				<forward name="success" path="EXIT" />
+			</pipe>
+		</pipeline>
+	</adapter>
+
+</module>

--- a/test/src/test/testtool/SecurityHandler/common.properties
+++ b/test/src/test/testtool/SecurityHandler/common.properties
@@ -1,0 +1,6 @@
+include = ../global.properties
+
+sender.test.className = nl.nn.adapterframework.senders.IbisJavaSender
+sender.test.serviceName = ibis4test-securityHandler
+sender.test.convertExceptionToMessage=true
+

--- a/test/src/test/testtool/SecurityHandler/scenario01.properties
+++ b/test/src/test/testtool/SecurityHandler/scenario01.properties
@@ -1,0 +1,6 @@
+scenario.description = OK
+
+include = common.properties
+
+step1.sender.test.write = scenario01/Request.xml
+step2.sender.test.read  = scenario01/Result.xml

--- a/test/src/test/testtool/SecurityHandler/scenario01/Request.xml
+++ b/test/src/test/testtool/SecurityHandler/scenario01/Request.xml
@@ -1,0 +1,1 @@
+<root>startTest</root>

--- a/test/src/test/testtool/SecurityHandler/scenario01/Result.xml
+++ b/test/src/test/testtool/SecurityHandler/scenario01/Result.xml
@@ -1,0 +1,1 @@
+<result>dummy</result>


### PR DESCRIPTION
Extra functionaliteit welke in development omgevingen gebruikt kan worden om role checks van de ingelogde gebruiker te omzeilen (zodat je niet afhankelijk ben van een complete users set met de juiste rechten).