### PR TITLE
Impl #1005 Option to ignore larva test step response

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
@@ -585,7 +585,7 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 	}
 
 
-	@IbisDoc({"6", "for action="+ACTION_APPEND+": when set to a positive number, the file is rotated each day, and this number of files is kept", "0"})
+	@IbisDoc({"6", "for action="+ACTION_APPEND+": when set to a positive number, the file is rotated each day, and this number of files is kept. The inputFolder must point to the directory where the file resides", "0"})
 	public void setRotateDays(int rotateDays) {
 		this.rotateDays = rotateDays;
 	}
@@ -593,7 +593,7 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 		return rotateDays;
 	}
 
-	@IbisDoc({"7", "for action="+ACTION_APPEND+": when set to a positive number, the file is rotated when it has reached the specified size, and the number of files specified in numberOfBackups is kept", "0"})
+	@IbisDoc({"7", "for action="+ACTION_APPEND+": when set to a positive number, the file is rotated when it has reached the specified size, and the number of files specified in numberOfBackups is kept. Size is specified in plain bytes, suffixes like 'K', 'M' or 'G' are not recognized. The inputFolder must point to the directory where the file resides", "0"})
 	public void setRotateSize(int rotateSize) {
 		this.rotateSize = rotateSize;
 	}
@@ -601,7 +601,7 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 		return rotateSize;
 	}
 
-	@IbisDoc({"8", "for action="+ACTION_WRITE1+", and for action="+ACTION_APPEND+" with rotateSize>0: the number of backup files that is kept", "0"})
+	@IbisDoc({"8", "for action="+ACTION_WRITE1+", and for action="+ACTION_APPEND+" with rotateSize>0: the number of backup files that is kept. The inputFolder must point to the directory where the file resides", "0"})
 	public void setNumberOfBackups(int numberOfBackups) {
 		this.numberOfBackups = numberOfBackups;
 	}

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/TestTool.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/TestTool.java
@@ -2857,8 +2857,13 @@ public class TestTool {
 		if ("".equals(fileName)) {
 			errorMessage("No file specified for step '" + step + "'", writers);
 		} else {
-			debugMessage("Read file " + fileName, writers);
-			fileContent = readFile(fileNameAbsolutePath, writers);
+			if (fileName.endsWith("ignore")) {
+				debugMessage("creating dummy expected file for filename '"+fileName+"'", writers);
+				fileContent = "ignore";
+			} else {
+				debugMessage("Read file " + fileName, writers);
+				fileContent = readFile(fileNameAbsolutePath, writers);
+			}
 			if (fileContent == null) {
 				errorMessage("Could not read file '" + fileName + "'", writers);
 			} else {
@@ -3072,6 +3077,10 @@ public class TestTool {
 	}
 
 	public static int compareResult(String step, String stepDisplayName, String fileName, String expectedResult, String actualResult, Properties properties, Map<String, Object> writers, String queueName) {
+		if (fileName.endsWith("ignore")) {
+			debugMessage("ignoring compare for filename '"+fileName+"'", writers);
+			return RESULT_OK;
+		}
 		int ok = RESULT_ERROR;
 		String printableExpectedResult = XmlUtils.replaceNonValidXmlCharacters(expectedResult);
 		String printableActualResult = XmlUtils.replaceNonValidXmlCharacters(actualResult);


### PR DESCRIPTION
If in any larva .read step the filename is specified as 'ignore', then the result of the test step is not compared to any expected value, but just accepted