### PR TITLE
Upgrade to latest Ladybug version

### DIFF
--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -16,7 +16,7 @@
 		<dependency>
 			<groupId>org.ibissource</groupId>
 			<artifactId>ibis-ladybug</artifactId>
-			<version>2.0.15-20200814.171944</version>
+			<version>2.0.15-20200925.161114</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ibissource</groupId>


### PR DESCRIPTION
Ladybug RELEASES.md between 2.0.15-20200814.171944 and 2.0.15-20200925.161114:
- Fix report filter for positive matching (report almost empty)
- Add tool tip to report filter text field
- Only log once when max checkpoints or max memory usage is exceeded