### PR TITLE
Make trim optional for execute query

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ExecuteJdbcQuery.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ExecuteJdbcQuery.java
@@ -95,7 +95,7 @@ public final class ExecuteJdbcQuery extends Base {
 	public Response execute(LinkedHashMap<String, Object> json) throws ApiException {
 
 		String datasource = null, resultType = null, query = null, queryType = null, result = "", returnType = MediaType.APPLICATION_XML;
-		boolean avoidLocking = false;
+		boolean avoidLocking = false, trimSpaces=false;
 		for (Entry<String, Object> entry : json.entrySet()) {
 			String key = entry.getKey();
 			if(key.equalsIgnoreCase("datasource")) {
@@ -112,6 +112,9 @@ public final class ExecuteJdbcQuery extends Base {
 			}
 			if(key.equalsIgnoreCase("avoidLocking")) {
 				avoidLocking = Boolean.parseBoolean(entry.getValue().toString());
+			}
+			if(key.equalsIgnoreCase("trimSpaces")) {
+				trimSpaces = Boolean.parseBoolean(entry.getValue().toString());
 			}
 			if(key.equalsIgnoreCase("query")) {
 				query = entry.getValue().toString();
@@ -149,6 +152,7 @@ public final class ExecuteJdbcQuery extends Base {
 			qs.setName("QuerySender");
 			qs.setDatasourceName(datasource);
 			qs.setQueryType(queryType);
+			qs.setTrimSpaces(trimSpaces);
 			qs.setAvoidLocking(avoidLocking);
 			qs.setBlobSmartGet(true);
 			qs.configure(true);

--- a/webapp/src/main/webapp/iaf/gui/views/ExecuteJdbcQuery.html
+++ b/webapp/src/main/webapp/iaf/gui/views/ExecuteJdbcQuery.html
@@ -34,6 +34,11 @@
                             <div class="col-sm-9">
                                 <span class="form-control m-b" style="border: none;"><input icheck type="checkbox" ng-model="form.avoidLocking" /></span>
                             </div>
+                        </div><div class="form-group">
+                            <label class="col-sm-3 control-label">Trim Spaces</label>
+                            <div class="col-sm-9">
+                                <span class="form-control m-b" style="border: none;"><input icheck type="checkbox" ng-model="form.trimSpaces" /></span>
+                            </div>
                         </div>
                         <div class="form-group">
                             <label class="col-sm-3 control-label">Query</label>


### PR DESCRIPTION
- Set trimSpaces to false for the directQuerySender instance used for execute query
- add ability to change it from the console.

Related to #992 