### PR TITLE
Introduce storeForwardInSessionKey attribute in XmlSwitch 

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
@@ -224,7 +224,7 @@ public class XmlSwitch extends AbstractPipe {
 	@Deprecated
 	@ConfigurationWarning("Please use the attribute styleSheetName.")
 	public void setServiceSelectionStylesheetFilename(String newServiceSelectionStylesheetFilename) {
-		this.styleSheetName = newServiceSelectionStylesheetFilename;
+		setStyleSheetName(newServiceSelectionStylesheetFilename); 
 	}
 
 	@IbisDoc({"2", "xpath-expression that returns a string representing the forward to look up. It's possible to refer to a parameter (which e.g. contains a value from a sessionkey) by using the parameter name prefixed with $", ""})

--- a/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
@@ -61,6 +61,7 @@ public class XmlSwitch extends AbstractPipe {
 	private String xpathExpression=null;
 	private String namespaceDefs = null; 
 	private String sessionKey=null;
+	private String storeForwardInSessionKey=null;
 	private String notFoundForwardName=null;
 	private String emptyForwardName=null;
 	private int xsltVersion=0; // set to 0 for auto detect.
@@ -204,6 +205,10 @@ public class XmlSwitch extends AbstractPipe {
 		if (pipeForward==null) {
 			throw new PipeRunException (this, getLogPrefix(session)+"cannot find forward or pipe named ["+forward+"]");
 		}
+		if(StringUtils.isNotEmpty(getStoreForwardInSessionKey())) {
+			session.put(getStoreForwardInSessionKey(), pipeForward.getName());
+		}
+		
 		return new PipeRunResult(pipeForward, message);
 	}
 	
@@ -272,5 +277,14 @@ public class XmlSwitch extends AbstractPipe {
 	@ConfigurationWarning("Its value is now auto detected. If necessary, replace with a setting of xsltVersion")
 	public void setXslt2(boolean b) {
 		xsltVersion=b?2:1;
+	}
+
+	public String getStoreForwardInSessionKey() {
+		return storeForwardInSessionKey;
+	}
+
+	@IbisDoc({"8", "Selected forward name will be stored in the specified session key.", ""})
+	public void setStoreForwardInSessionKey(String storeForwardInSessionKey) {
+		this.storeForwardInSessionKey = storeForwardInSessionKey;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/XmlSwitch.java
@@ -46,7 +46,7 @@ import nl.nn.adapterframework.util.XmlUtils;
  * <table border="1">
  * <tr><th>state</th><th>condition</th></tr>
  * <tr><td>&lt;name of the root-element&gt;</td><td>default</td></tr>
- * <tr><td>&lt;result of transformation&gt</td><td>when {@link #setServiceSelectionStylesheetFilename(String) serviceSelectionStylesheetFilename} or {@link #setXpathExpression(String) xpathExpression} is specified</td></tr>
+ * <tr><td>&lt;result of transformation&gt</td><td>when {@link #setStyleSheetName(String) styleSheetName} or {@link #setXpathExpression(String) xpathExpression} is specified</td></tr>
  * </table>
  * </p>
  * @author Johan Verrips
@@ -57,19 +57,19 @@ public class XmlSwitch extends AbstractPipe {
 	public static final String XML_SWITCH_FORWARD_NOT_FOUND_MONITOR_EVENT = "Switch: Forward Not Found";
 	private static final String DEFAULT_SERVICESELECTION_XPATH = XmlUtils.XPATH_GETROOTNODENAME;
 
-	private String serviceSelectionStylesheetFilename=null;
-	private String xpathExpression=null;
+	private String styleSheetName = null;
+	private String xpathExpression = null;
 	private String namespaceDefs = null; 
-	private String sessionKey=null;
-	private String storeForwardInSessionKey=null;
-	private String notFoundForwardName=null;
-	private String emptyForwardName=null;
-	private int xsltVersion=0; // set to 0 for auto detect.
+	private String sessionKey = null;
+	private String storeForwardInSessionKey = null;
+	private String notFoundForwardName = null;
+	private String emptyForwardName = null;
+	private int xsltVersion = 0; // set to 0 for auto detect.
 
-	private TransformerPool transformerPool=null;
+	private TransformerPool transformerPool = null;
 
 	/**
-	 * If no {@link #setServiceSelectionStylesheetFilename(String) serviceSelectionStylesheetFilename} is specified, the
+	 * If no {@link #setStyleSheetName(String) styleSheetName} is specified, the
 	 * switch uses the root node. 
 	 */
 	@Override
@@ -87,23 +87,23 @@ public class XmlSwitch extends AbstractPipe {
 		}
 
 		if (StringUtils.isNotEmpty(getXpathExpression())) {
-			if (!StringUtils.isEmpty(getServiceSelectionStylesheetFilename())) {
-				throw new ConfigurationException(getLogPrefix(null) + "cannot have both an xpathExpression and a serviceSelectionStylesheetFilename specified");
+			if (!StringUtils.isEmpty(getStyleSheetName())) {
+				throw new ConfigurationException(getLogPrefix(null) + "cannot have both an xpathExpression and a styleSheetName specified");
 			}
 			transformerPool = TransformerPool.configureTransformer0(getLogPrefix(null), getConfigurationClassLoader(), getNamespaceDefs(), getXpathExpression(), null, "text", false, getParameterList(), 0);
 		} 
 		else {
-			if (!StringUtils.isEmpty(getServiceSelectionStylesheetFilename())) {
+			if (!StringUtils.isEmpty(getStyleSheetName())) {
 				try {
-					Resource stylesheet = Resource.getResource(getConfigurationClassLoader(), getServiceSelectionStylesheetFilename());
+					Resource stylesheet = Resource.getResource(getConfigurationClassLoader(), getStyleSheetName());
 					if (stylesheet==null) {
-						throw new ConfigurationException(getLogPrefix(null) + "cannot find stylesheet ["+getServiceSelectionStylesheetFilename()+"]");
+						throw new ConfigurationException(getLogPrefix(null) + "cannot find stylesheet ["+getStyleSheetName()+"]");
 					}
 					transformerPool = TransformerPool.getInstance(stylesheet, getXsltVersion());
 				} catch (IOException e) {
-					throw new ConfigurationException(getLogPrefix(null) + "cannot retrieve ["+ serviceSelectionStylesheetFilename + "]", e);
+					throw new ConfigurationException(getLogPrefix(null) + "cannot retrieve ["+ styleSheetName + "]", e);
 				} catch (TransformerConfigurationException te) {
-					throw new ConfigurationException(getLogPrefix(null) + "got error creating transformer from file [" + serviceSelectionStylesheetFilename + "]", te);
+					throw new ConfigurationException(getLogPrefix(null) + "got error creating transformer from file [" + styleSheetName + "]", te);
 				}
 			} else {
 				if (StringUtils.isEmpty(getSessionKey())) {
@@ -211,16 +211,22 @@ public class XmlSwitch extends AbstractPipe {
 		
 		return new PipeRunResult(pipeForward, message);
 	}
-	
 
 	@IbisDoc({"1", "stylesheet may return a string representing the forward to look up", "<i>a stylesheet that returns the name of the root-element</i>"})
+	public void setStyleSheetName(String styleSheetName) {
+		this.styleSheetName = styleSheetName;
+	}
+	public String getStyleSheetName() {
+		return styleSheetName;
+	}
+
+	@IbisDoc({"stylesheet may return a string representing the forward to look up", "<i>a stylesheet that returns the name of the root-element</i>"})
+	@Deprecated
+	@ConfigurationWarning("Please use the attribute styleSheetName.")
 	public void setServiceSelectionStylesheetFilename(String newServiceSelectionStylesheetFilename) {
-		serviceSelectionStylesheetFilename = newServiceSelectionStylesheetFilename;
+		this.styleSheetName = newServiceSelectionStylesheetFilename;
 	}
-	public String getServiceSelectionStylesheetFilename() {
-		return serviceSelectionStylesheetFilename;
-	}
-	
+
 	@IbisDoc({"2", "xpath-expression that returns a string representing the forward to look up. It's possible to refer to a parameter (which e.g. contains a value from a sessionkey) by using the parameter name prefixed with $", ""})
 	public void setXpathExpression(String xpathExpression) {
 		this.xpathExpression = xpathExpression;
@@ -237,9 +243,9 @@ public class XmlSwitch extends AbstractPipe {
 		return namespaceDefs;
 	}
 
-	@IbisDoc({"4", "Name of the key in the <code>PipeLineSession</code> to retrieve the input message from, if a serviceSelectionStylesheetFilename or a xpathExpression is specified. " + 
-					"If no serviceSelectionStylesheetFilename or xpathExpression is specified, the value of the session variable is used as the name of the forward. " + 
-					"If none of sessionKey, serviceSelectionStylesheetFilename or xpathExpression are specified, the element name of the root node of the input message is taken as the name of forward.", ""})
+	@IbisDoc({"4", "Name of the key in the <code>PipeLineSession</code> to retrieve the input message from, if a styleSheetName or a xpathExpression is specified. " + 
+					"If no styleSheetName or xpathExpression is specified, the value of the session variable is used as the name of the forward. " + 
+					"If none of sessionKey, styleSheetName or xpathExpression are specified, the element name of the root node of the input message is taken as the name of forward.", ""})
 	public void setSessionKey(String sessionKey){
 		this.sessionKey = sessionKey;
 	}

--- a/core/src/test/java/nl/nn/adapterframework/pipes/XmlSwitchTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/XmlSwitchTest.java
@@ -123,6 +123,30 @@ public class XmlSwitchTest extends PipeTestBase<XmlSwitch> {
 		String input=TestFileUtils.getTestFile("/XmlSwitch/in.xml");
 		testSwitch(input,"selectValue");
 	}
+	
+	@Test
+	public void storeForwardInSessionKey() throws Exception {
+		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.registerForward(new PipeForward("selectValue","SelectValue-Path"));
+		pipe.setSessionKey("selectKey");
+		String forwardName = "forwardName";
+		pipe.setStoreForwardInSessionKey(forwardName);
+		session=new PipeLineSessionBase();
+		session.put("selectKey", "selectValue");
+		String input=TestFileUtils.getTestFile("/XmlSwitch/in.xml");
+		testSwitch(input,"selectValue");
+		assertEquals("selectValue", session.get(forwardName).toString());
+	}
+
+	@Test
+	public void basicSelectionWithStylesheet() throws Exception {
+		pipe.registerForward(new PipeForward("Envelope","Envelope-Path"));
+		pipe.registerForward(new PipeForward("SetRequest","SetRequest-Path"));
+		pipe.setStyleSheetName("/XmlSwitch/selection.xsl");
+		pipe.setNamespaceAware(false);
+		String input=TestFileUtils.getTestFile("/XmlSwitch/in.xml");
+		testSwitch(input,"SetRequest");
+	}
 
 
 }

--- a/core/src/test/resources/XmlSwitch/selection.xsl
+++ b/core/src/test/resources/XmlSwitch/selection.xsl
@@ -1,0 +1,8 @@
+<xsl:stylesheet version="2.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+	<xsl:output method="text" version="1.0" encoding="UTF-8" indent="yes" omit-xml-declaration="yes"/>
+
+	<xsl:template match="/">
+		<xsl:value-of select="name(/*[local-name()='Envelope']/*[local-name()='Body']/*[name()!='MessageHeader'])"/>
+	</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
- Introduces storeForwardInSessionKey attribute to store resulting forward name in a session key.
- Deprecates serviceSelectionStylesheetFilename  attribute and introduces styleSheetName attribute for the same purpose.
Fixes #1003 
Fixes #1055 