### PR TITLE
Fix #1026 Fix exception overriding in webservice sender

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/http/HttpResponseHandler.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/HttpResponseHandler.java
@@ -136,4 +136,11 @@ public class HttpResponseHandler {
 		}
 		return headerMap;
 	}
+
+	public Boolean isMultipart() {
+		if(getContentType().getMimeType().contains("multipart")) {
+			return true;
+		}
+		return false;
+	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/http/HttpSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/HttpSender.java
@@ -569,6 +569,10 @@ public class HttpSender extends HttpSenderBase {
 		}
 	}
 
+	/**
+	 * When an exception occurs and the response cannot be parsed, we do not want to throw a 'missing response' exception. 
+	 * Since this method is used when handling other exceptions thrown by {@link WebServiceSender} and {@link HttpSender} , silently return null, to avoid npe's, ioexceptions etc.
+	 */
 	public String getResponseBodyAsString(HttpResponseHandler responseHandler, boolean throwIOExceptionWhenParsingResponse) throws IOException {
 		String charset = responseHandler.getCharset();
 		log.debug(getLogPrefix()+"response body uses charset ["+charset+"]");

--- a/core/src/main/java/nl/nn/adapterframework/http/WebServiceSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/WebServiceSender.java
@@ -144,7 +144,7 @@ public class WebServiceSender extends HttpSender {
 		try {
 			httpResult = super.extractResult(responseHandler, session).asString();
 		} catch (SenderException e) {
-			soapWrapper.checkForSoapFault(getResponseBodyAsString(responseHandler), e);
+			soapWrapper.checkForSoapFault(getResponseBodyAsString(responseHandler, false), e);
 			throw e;
 		}
 

--- a/core/src/test/java/nl/nn/adapterframework/http/WebServiceSenderResultTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/WebServiceSenderResultTest.java
@@ -53,7 +53,7 @@ public class WebServiceSenderResultTest extends Mockito {
 
 	private WebServiceSender sender = null;
 
-	public WebServiceSender createWebSeriveSender(InputStream responseStream, String contentType, int statusCode) throws IOException {
+	public WebServiceSender createWebServiceSender(InputStream responseStream, String contentType, int statusCode) throws IOException {
 		CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
 		CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
 		StatusLine statusLine = mock(StatusLine.class);
@@ -86,25 +86,9 @@ public class WebServiceSenderResultTest extends Mockito {
 		return sender;
 	}
 
-	public WebServiceSender createWebServiceSenderFromFile(String testFile, int statusCode) throws IOException {
+	public WebServiceSender createWebServiceSenderFromFile(String testFile, String contentType, int statusCode) throws IOException {
 		InputStream file = getFile(testFile);
-		byte[] fileArray = Misc.streamToBytes(file);
-		String contentType = null;
-
-		BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(fileArray)));
-		for (String line = null; null != (line = reader.readLine());) {
-			if(line.startsWith("Content-Type")) {
-				contentType = line.substring(line.indexOf(":") + 1).trim();
-				break;
-			}
-		}
-		reader.close();
-
-		if(contentType != null)
-			System.out.println("found Content-Type ["+contentType+"]");
-
-		InputStream dummyXmlString = new ByteArrayInputStream(fileArray);
-		return createWebSeriveSender(dummyXmlString, contentType, statusCode);
+		return createWebServiceSender(file, contentType, statusCode);
 	}
 
 	@After
@@ -126,7 +110,7 @@ public class WebServiceSenderResultTest extends Mockito {
 
 	@Test
 	public void simpleSoapMultiPartResponseMocked() throws Exception {
-		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart.txt", 200);
+		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart.txt", "multipart/form-data", 200);
 
 		IPipeLineSession pls = new PipeLineSessionBase();
 
@@ -153,7 +137,7 @@ public class WebServiceSenderResultTest extends Mockito {
 	@Test
 	public void simpleSoapMultiPartResponseMocked500StatusCode() throws Exception {
 		thrown.expect(SenderException.class);
-		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart.txt", 500);
+		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart.txt", "multipart/form-data", 500);
 
 		IPipeLineSession pls = new PipeLineSessionBase();
 
@@ -167,7 +151,7 @@ public class WebServiceSenderResultTest extends Mockito {
 	public void simpleInvalidMultipartResponse() throws Exception {
 		thrown.expectMessage("Missing start boundary");
 
-		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart2.txt", 200);
+		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart2.txt", "multipart/form-data", 200);
 
 		IPipeLineSession pls = new PipeLineSessionBase();
 
@@ -179,7 +163,7 @@ public class WebServiceSenderResultTest extends Mockito {
 
 	@Test
 	public void simpleMtomResponseMockedHttpGet() throws Exception {
-		WebServiceSender sender = createWebServiceSenderFromFile("mtom-multipart2.txt", 200);
+		WebServiceSender sender = createWebServiceSenderFromFile("mtom-multipart2.txt", "multipart/related", 200);
 
 		IPipeLineSession pls = new PipeLineSessionBase();
 

--- a/core/src/test/java/nl/nn/adapterframework/http/WebServiceSenderResultTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/WebServiceSenderResultTest.java
@@ -17,11 +17,8 @@ package nl.nn.adapterframework.http;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.BufferedReader;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.net.URL;
 import java.util.Map;
 

--- a/core/src/test/java/nl/nn/adapterframework/http/WebServiceSenderResultTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/WebServiceSenderResultTest.java
@@ -1,0 +1,202 @@
+/*
+   Copyright 2020 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.http;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URL;
+import java.util.Map;
+
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHost;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.mockito.Mockito;
+
+import nl.nn.adapterframework.core.IPipeLineSession;
+import nl.nn.adapterframework.core.PipeLineSessionBase;
+import nl.nn.adapterframework.core.SenderException;
+import nl.nn.adapterframework.stream.Message;
+import nl.nn.adapterframework.util.Misc;
+
+public class WebServiceSenderResultTest extends Mockito {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private WebServiceSender sender = null;
+
+	public WebServiceSender createWebSeriveSender(InputStream responseStream, String contentType, int statusCode) throws IOException {
+		CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
+		CloseableHttpResponse httpResponse = mock(CloseableHttpResponse.class);
+		StatusLine statusLine = mock(StatusLine.class);
+		HttpEntity httpEntity = mock(HttpEntity.class);
+
+		when(statusLine.getStatusCode()).thenReturn(statusCode);
+		when(httpResponse.getStatusLine()).thenReturn(statusLine);
+		when(httpResponse.getStatusLine().getStatusCode()).thenReturn(statusCode);
+
+		if(contentType != null) {
+			Header contentTypeHeader = new BasicHeader("Content-Type", contentType);
+			when(httpEntity.getContentType()).thenReturn(contentTypeHeader);
+		}
+		when(httpEntity.getContent()).thenReturn(responseStream);
+		when(httpResponse.getEntity()).thenReturn(httpEntity);
+
+		//Mock all requests
+		when(httpClient.execute(any(HttpHost.class), any(HttpRequestBase.class), any(HttpContext.class))).thenReturn(httpResponse);
+
+		WebServiceSender sender = spy(new WebServiceSender());
+		when(sender.getHttpClient()).thenReturn(httpClient);
+
+		//Some default settings, url will be mocked.
+		sender.setUrl("http://127.0.0.1/");
+		sender.setIgnoreRedirects(true);
+		sender.setVerifyHostname(false);
+		sender.setAllowSelfSignedCertificates(true);
+
+		this.sender = sender;
+		return sender;
+	}
+
+	public WebServiceSender createWebServiceSenderFromFile(String testFile, int statusCode) throws IOException {
+		InputStream file = getFile(testFile);
+		byte[] fileArray = Misc.streamToBytes(file);
+		String contentType = null;
+
+		BufferedReader reader = new BufferedReader(new InputStreamReader(new ByteArrayInputStream(fileArray)));
+		for (String line = null; null != (line = reader.readLine());) {
+			if(line.startsWith("Content-Type")) {
+				contentType = line.substring(line.indexOf(":") + 1).trim();
+				break;
+			}
+		}
+		reader.close();
+
+		if(contentType != null)
+			System.out.println("found Content-Type ["+contentType+"]");
+
+		InputStream dummyXmlString = new ByteArrayInputStream(fileArray);
+		return createWebSeriveSender(dummyXmlString, contentType, statusCode);
+	}
+
+	@After
+	public void setDown() throws SenderException {
+		if (sender != null) {
+			sender.close();
+			sender = null;
+		}
+	}
+
+	private final String BASEDIR = "/nl/nn/adapterframework/http/";
+	private InputStream getFile(String file) throws IOException {
+		URL url = this.getClass().getResource(BASEDIR+file);
+		if (url == null) {
+			throw new IOException("file not found");
+		}
+		return url.openStream();
+	}
+
+	@Test
+	public void simpleSoapMultiPartResponseMocked() throws Exception {
+		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart.txt", 200);
+
+		IPipeLineSession pls = new PipeLineSessionBase();
+
+		sender.configure();
+		sender.open();
+
+		String result = sender.sendMessage(new Message("tralala"), pls).asString();
+		assertEquals("<TestElement xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">test value</TestElement>", result);
+
+		int multipartAttachmentCount = 0;
+		for (Map.Entry<String, Object> entry : pls.entrySet()) {
+			System.out.println("found multipart ["+entry.getKey()+"]");
+			multipartAttachmentCount++;
+		}
+		assertEquals(2, multipartAttachmentCount);
+
+		InputStream multipart1 = (InputStream)pls.get("multipart1");
+		assertEquals("Content of a txt file.", Misc.streamToString(multipart1).trim());
+
+		InputStream multipart2 = (InputStream)pls.get("multipart2");
+		assertEquals("<!DOCTYPE html><title>Content of a html file.</title>", Misc.streamToString(multipart2).trim());
+	}
+
+	@Test
+	public void simpleSoapMultiPartResponseMocked500StatusCode() throws Exception {
+		thrown.expect(SenderException.class);
+		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart.txt", 500);
+
+		IPipeLineSession pls = new PipeLineSessionBase();
+
+		sender.configure();
+		sender.open();
+
+		sender.sendMessage(new Message("tralala"), pls).asString();
+	}
+
+	@Test
+	public void simpleInvalidMultipartResponse() throws Exception {
+		thrown.expectMessage("Missing start boundary");
+
+		WebServiceSender sender = createWebServiceSenderFromFile("soapMultipart2.txt", 200);
+
+		IPipeLineSession pls = new PipeLineSessionBase();
+
+		sender.configure();
+		sender.open();
+
+		sender.sendMessage(new Message("tralala"), pls).asString();
+	}
+
+	@Test
+	public void simpleMtomResponseMockedHttpGet() throws Exception {
+		WebServiceSender sender = createWebServiceSenderFromFile("mtom-multipart2.txt", 200);
+
+		IPipeLineSession pls = new PipeLineSessionBase();
+
+		sender.configure();
+		sender.open();
+
+		String result = sender.sendMessage(new Message("tralala"), pls).asString();
+		assertEquals("<TestElement xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">test value</TestElement>", result.trim());
+
+		int multipartAttachmentCount = 0;
+		for (Map.Entry<String, Object> entry : pls.entrySet()) {
+			System.out.println("found multipart key["+entry.getKey()+"] type["+(entry.getValue().getClass())+"]");
+			multipartAttachmentCount++;
+		}
+		assertEquals(1, multipartAttachmentCount);
+
+		InputStream multipart1 = (InputStream)pls.get("multipart1");
+		assertEquals("PDF-1.4 content", Misc.streamToString(multipart1).trim());
+	}
+}

--- a/core/src/test/resources/nl/nn/adapterframework/http/mtom-multipart2.txt
+++ b/core/src/test/resources/nl/nn/adapterframework/http/mtom-multipart2.txt
@@ -1,0 +1,27 @@
+HTTP/1.1 200 OK
+Message-Id: testmessageac13ecb1--30fe9225_16caa708707_-7fb1
+Date: Fri, 05 Oct 2018 15:56:44 GMT
+Keep-Alive: timeout=15, max=100
+Connection: Keep-Alive
+Content-Type: multipart/related; type="application/xop+xml"; boundary="uuid:a1a5f51a-3c87-4751-a892-50a3f04a7a9d"; start="<root.message@cxf.apache.org>"; start-info="text/xml"
+Content-Language: nl-NL
+Content-Length: 104652
+
+--uuid:a1a5f51a-3c87-4751-a892-50a3f04a7a9d
+Content-Type: application/xop+xml; charset=UTF-8; type="text/xml";
+Content-Transfer-Encoding: binary
+Content-ID: <root.message@cxf.apache.org>
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+	<soapenv:Header/>
+	<soapenv:Body>
+		<TestElement>test value</TestElement>
+	</soapenv:Body>
+</soapenv:Envelope>
+
+--uuid:a1a5f51a-3c87-4751-a892-50a3f04a7a9d
+Content-Type: application/octet-stream
+Content-Transfer-Encoding: binary
+Content-ID: <attachment>
+
+PDF-1.4 content

--- a/core/src/test/resources/nl/nn/adapterframework/http/soapMultipart.txt
+++ b/core/src/test/resources/nl/nn/adapterframework/http/soapMultipart.txt
@@ -1,0 +1,34 @@
+POST / HTTP/1.1
+Message-Id: testmessageac13ecb1--30fe9225_16caa708707_-7fb1
+Host: localhost:8000
+User-Agent: Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:29.0) Gecko/20100101 Firefox/29.0
+Accept: text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8
+Accept-Language: en-US,en;q=0.5
+Accept-Encoding: gzip, deflate
+Connection: keep-alive
+Content-Type: multipart/form-data; boundary=---------------------------9051914041544843365972754266
+Content-Length: 554
+
+-----------------------------9051914041544843365972754266
+Content-Disposition: form-data; name="text"
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+	<soapenv:Header/>
+	<soapenv:Body>
+		<TestElement>test value</TestElement>
+	</soapenv:Body>
+</soapenv:Envelope>
+
+-----------------------------9051914041544843365972754266
+Content-Disposition: form-data; name="file1"; filename="a.txt"
+Content-Type: text/plain
+
+Content of a txt file.
+
+-----------------------------9051914041544843365972754266
+Content-Disposition: form-data; name="file2"; filename="a.html"
+Content-Type: text/html
+
+<!DOCTYPE html><title>Content of a html file.</title>
+
+-----------------------------9051914041544843365972754266--

--- a/core/src/test/resources/nl/nn/adapterframework/http/soapMultipart2.txt
+++ b/core/src/test/resources/nl/nn/adapterframework/http/soapMultipart2.txt
@@ -1,0 +1,10 @@
+Content-Type: multipart/form-data;charset=ISO-8859-1
+Content-Length: 957
+Date: Wed, 07 Oct 2020 12:38:42 GMT
+
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+	<soapenv:Header/>
+	<soapenv:Body>
+		<TestElement>test value</TestElement>
+	</soapenv:Body>
+</soapenv:Envelope>


### PR DESCRIPTION
- multipartResponse attribute will be deprecated. Responses with a 'multipart/*' content-type will be detected automatically.
Fixes #1026 