### PR TITLE
Upgrade commons digester

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -116,14 +116,8 @@
 			<artifactId>commons-pool</artifactId>
 		</dependency>
 		<dependency>
-			<groupId>commons-digester</groupId>
-			<artifactId>commons-digester</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>commons-logging</groupId>
-					<artifactId>commons-logging</artifactId>
-				</exclusion>
-			</exclusions>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-digester3</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>commons-codec</groupId>

--- a/core/src/main/java/nl/nn/adapterframework/configuration/AbstractSpringPoweredDigesterFactory.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/AbstractSpringPoweredDigesterFactory.java
@@ -19,7 +19,7 @@ import nl.nn.adapterframework.core.INamedObject;
 import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.LogUtil;
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.digester.AbstractObjectCreationFactory;
+import org.apache.commons.digester3.AbstractObjectCreationFactory;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -58,7 +58,7 @@ import java.util.Map;
  * @since   4.8
  *
  */
-public abstract class AbstractSpringPoweredDigesterFactory extends AbstractObjectCreationFactory {
+public abstract class AbstractSpringPoweredDigesterFactory extends AbstractObjectCreationFactory<Object> {
 	protected Logger log = LogUtil.getLogger(this);
 
     private static IbisContext ibisContext;
@@ -277,7 +277,7 @@ public abstract class AbstractSpringPoweredDigesterFactory extends AbstractObjec
 	}
 
 	private void addConfigWarning(Object currObj, String name, String message) {
-		Locator loc = digester.getDocumentLocator();
+		Locator loc = getDigester().getDocumentLocator();
 		String msg = "line "+loc.getLineNumber()+", col "+loc.getColumnNumber()+": "+getObjectName(currObj, name)+": "+message;
 		ConfigurationWarnings.add(null, log, msg);
 	}
@@ -365,9 +365,9 @@ public abstract class AbstractSpringPoweredDigesterFactory extends AbstractObjec
 	}
 
 	protected Map<String, String> copyAttrsToMap(Attributes attrs) {
-		Map<String, String> map = new HashMap<String, String>(attrs.getLength());
+		Map<String, String> map = new HashMap<>(attrs.getLength());
 		for (int i = 0; i < attrs.getLength(); ++i) {
-            String value = attrs.getValue(i);
+			String value = attrs.getValue(i);
 			map.put(attrs.getQName(i), value);
 		}
 		return map;

--- a/core/src/main/java/nl/nn/adapterframework/configuration/AttributeCheckingRule.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/AttributeCheckingRule.java
@@ -23,7 +23,7 @@ import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.LogUtil;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.digester.Rule;
+import org.apache.commons.digester3.Rule;
 import org.apache.logging.log4j.Logger;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.core.annotation.AnnotationUtils;
@@ -56,7 +56,7 @@ public class AttributeCheckingRule extends Rule {
 
 	@Override
 	public void begin(String uri, String elementName, Attributes attributes) throws Exception {
-		Object top = digester.peek();
+		Object top = getDigester().peek();
 
 		for (int i = 0; i < attributes.getLength(); i++) {
 			String name = attributes.getLocalName(i);
@@ -73,13 +73,13 @@ public class AttributeCheckingRule extends Rule {
 					m = PropertyUtils.getWriteMethod(pd);
 				}
 				if (m==null) {
-					Locator loc = digester.getDocumentLocator();
+					Locator loc = getDigester().getDocumentLocator();
 					String msg = "line "+loc.getLineNumber()+", col "+loc.getColumnNumber()+": "+getObjectName(top)+" does not have an attribute ["+name+"] to set to value ["+attributes.getValue(name)+"]";
 					ConfigurationWarnings.add(null, log, msg); //We need to use this as it's a configuration specific warning
 				} else {
 					ConfigurationWarning warning = AnnotationUtils.findAnnotation(m, ConfigurationWarning.class);
 					if(warning != null) {
-						Locator loc = digester.getDocumentLocator();
+						Locator loc = getDigester().getDocumentLocator();
 						String msg = "line "+loc.getLineNumber()+", col "+loc.getColumnNumber()+": "+getObjectName(top)+" attribute ["+name+"]";
 						boolean isDeprecated = AnnotationUtils.findAnnotation(m, Deprecated.class) != null;
 

--- a/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationDigester.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationDigester.java
@@ -92,6 +92,7 @@ public class ConfigurationDigester {
 
 	private static final String attributesGetter_xslt = "/xml/xsl/AttributesGetter.xsl";
 
+	private String digesterRulesFile = FrankDigesterRules.DIGESTER_RULES_FILE;
 	private boolean configLogAppend = false;
 
 	String lastResolvedEntity = null;
@@ -129,8 +130,10 @@ public class ConfigurationDigester {
 		digester.push(configuration);
 
 		ClassLoader configurationClassLoader = configuration.getClassLoader();
+		Resource digesterRulesResource = Resource.getResource(configurationClassLoader, getDigesterRules());
 
-		DigesterLoader loader = DigesterLoader.newLoader(new FrankDigesterRules(digester));
+		FrankDigesterRules digesterRules = new FrankDigesterRules(digester, digesterRulesResource);
+		DigesterLoader loader = DigesterLoader.newLoader(digesterRules);
 		loader.addRules(digester);
 
 		if (MonitorManager.getInstance().isEnabled()) {
@@ -198,9 +201,9 @@ public class ConfigurationDigester {
 			if (digester != null ) {
 				currentElementName = digester.getCurrentElementName();
 			}
-			ConfigurationException e = new ConfigurationException("error during unmarshalling configuration from file [" + configurationFile +
-				"] in element ["+currentElementName+"]"+(StringUtils.isEmpty(lastResolvedEntity)?"":" last resolved entity ["+lastResolvedEntity+"]"), t);
-			throw e;
+
+			throw new ConfigurationException("error during unmarshalling configuration from file [" + configurationFile +
+				"] with digester-rules-file ["+getDigesterRules()+"] in element ["+currentElementName+"]"+(StringUtils.isEmpty(lastResolvedEntity)?"":" last resolved entity ["+lastResolvedEntity+"]"), t);
 		}
 		if (MonitorManager.getInstance().isEnabled()) {
 			MonitorManager.getInstance().configure(configuration);
@@ -243,5 +246,13 @@ public class ConfigurationDigester {
 				configWarnings.addDefaultValueExceptions(mergedKey);
 			}
 		}
+	}
+
+	public void setDigesterRules(String string) {
+		digesterRulesFile = string;
+	}
+
+	public String getDigesterRules() {
+		return digesterRulesFile;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationDigester.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationDigester.java
@@ -177,7 +177,7 @@ public class ConfigurationDigester {
 			String original = XmlUtils.identityTransform(configurationResource);
 			fillConfigWarnDefaultValueExceptions(XmlUtils.stringToSource(original)); // must use 'original', cannot use configurationResource, because EntityResolver will not be properly set
 			configuration.setOriginalConfiguration(original);
-			List<String> propsToHide = new ArrayList<String>();
+			List<String> propsToHide = new ArrayList<>();
 			String propertiesHideString = AppConstants.getInstance(Thread.currentThread().getContextClassLoader()).getString("properties.hide", null);
 			if (propertiesHideString != null) {
 				propsToHide.addAll(Arrays.asList(propertiesHideString.split("[,\\s]+")));

--- a/core/src/main/java/nl/nn/adapterframework/configuration/classloaders/ClassLoaderBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/classloaders/ClassLoaderBase.java
@@ -229,6 +229,10 @@ public abstract class ClassLoaderBase extends ClassLoader implements IConfigurat
 
 	@Override
 	protected Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+		if(name == null) {
+			throw new IllegalArgumentException("classname to load may not be null");
+		}
+
 		Throwable throwable = null;
 		try {
 			return getParent().loadClass(name); // First try to load the class natively

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRule.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRule.java
@@ -1,0 +1,72 @@
+package nl.nn.adapterframework.configuration.digester;
+
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.apache.commons.digester3.ObjectCreationFactory;
+import org.apache.commons.lang3.StringUtils;
+
+import nl.nn.adapterframework.util.ClassUtils;
+
+@XmlRootElement(name = "rule")
+public class DigesterRule {
+
+	@XmlAttribute(name = "pattern")
+	private String pattern;
+
+	public String getPattern() {
+		return pattern;
+	}
+
+	@XmlAttribute(name = "factory")
+	private String factory;
+
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	public ObjectCreationFactory<Object> getFactory() {
+		if(StringUtils.isNotEmpty(factory)) {
+			Object object;
+			try {
+				object = ClassUtils.newInstance(factory);
+			} catch (Exception e) {
+				throw new IllegalArgumentException("factory ["+factory+"] not found", e);
+			}
+			if(object instanceof ObjectCreationFactory) {
+				return (ObjectCreationFactory) object;
+			} else {
+				throw new IllegalArgumentException("factory type must implement ObjectCreationFactory");
+			}
+		}
+		return null;
+	}
+
+	@XmlAttribute(name = "object")
+	private String objectClassName;
+
+	public String getObject() {
+		if(StringUtils.isNotEmpty(objectClassName)) {
+			return objectClassName;
+		}
+		return null;
+	}
+
+	@XmlAttribute(name = "nextRule")
+	private String nextRule;
+
+	public String getNext() {
+		return nextRule;
+	}
+
+	@XmlAttribute(name = "parameterType")
+	private String parameterType;
+
+	public Class<?> getParameterType() {
+		if(StringUtils.isNotEmpty(parameterType)) {
+			try {
+				return ClassUtils.loadClass(parameterType);
+			} catch (ClassNotFoundException e) {
+				throw new IllegalArgumentException("class ["+parameterType+"] not found", e);
+			}
+		}
+		return null;
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRule.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRule.java
@@ -1,72 +1,45 @@
 package nl.nn.adapterframework.configuration.digester;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 
-import org.apache.commons.digester3.ObjectCreationFactory;
-import org.apache.commons.lang3.StringUtils;
+import lombok.Getter;
+import lombok.Setter;
 
-import nl.nn.adapterframework.util.ClassUtils;
-
-@XmlRootElement(name = "rule")
+/**
+ * Java representation of a digester rule specified in the digester-rules.xml file.
+ *
+ */
 public class DigesterRule {
 
-	@XmlAttribute(name = "pattern")
-	private String pattern;
+	/**
+	 * The digester rule's pattern.
+	 */
+	private @Getter @Setter String pattern;
 
-	public String getPattern() {
-		return pattern;
-	}
+	/**
+	 * The 'object-create-rule' attribute.
+	 */
+	private @Getter @Setter String object;
 
-	@XmlAttribute(name = "factory")
-	private String factory;
+	/**
+	 * The 'factory-create-rule' attribute.
+	 * When non specified it uses the GenericFactory. When specified as 
+	 * NULL-String it does not use a factory.
+	 */
+	private @Getter @Setter String factory;
 
-	@SuppressWarnings({ "rawtypes", "unchecked" })
-	public ObjectCreationFactory<Object> getFactory() {
-		if(StringUtils.isNotEmpty(factory)) {
-			Object object;
-			try {
-				object = ClassUtils.newInstance(factory);
-			} catch (Exception e) {
-				throw new IllegalArgumentException("factory ["+factory+"] not found", e);
-			}
-			if(object instanceof ObjectCreationFactory) {
-				return (ObjectCreationFactory) object;
-			} else {
-				throw new IllegalArgumentException("factory type must implement ObjectCreationFactory");
-			}
-		}
-		return null;
-	}
+	/**
+	 * The 'set-next-rule' attribute.
+	 */
+	private @Getter @Setter String registerMethod;
 
-	@XmlAttribute(name = "object")
-	private String objectClassName;
+	/**
+	 * The 'set-top-rule' attribute.
+	 */
+	private @Getter @Setter String selfRegisterMethod;
 
-	public String getObject() {
-		if(StringUtils.isNotEmpty(objectClassName)) {
-			return objectClassName;
-		}
-		return null;
-	}
-
-	@XmlAttribute(name = "nextRule")
-	private String nextRule;
-
-	public String getNext() {
-		return nextRule;
-	}
-
-	@XmlAttribute(name = "parameterType")
-	private String parameterType;
-
-	public Class<?> getParameterType() {
-		if(StringUtils.isNotEmpty(parameterType)) {
-			try {
-				return ClassUtils.loadClass(parameterType);
-			} catch (ClassNotFoundException e) {
-				throw new IllegalArgumentException("class ["+parameterType+"] not found", e);
-			}
-		}
-		return null;
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRulesHandler.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRulesHandler.java
@@ -1,0 +1,54 @@
+/*
+   Copyright 2020 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.configuration.digester;
+
+import java.lang.reflect.InvocationTargetException;
+
+import org.apache.commons.beanutils.BeanUtils;
+import org.apache.logging.log4j.Logger;
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.helpers.DefaultHandler;
+
+import nl.nn.adapterframework.util.LogUtil;
+
+public abstract class DigesterRulesHandler extends DefaultHandler {
+	protected final Logger log = LogUtil.getLogger(this);
+
+	/**
+	 * Parse all digester rules as {@link DigesterRule}
+	 */
+	@Override
+	public final void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+		if("rule".equals(qName)) {
+			DigesterRule rule = new DigesterRule();
+			for (int i = 0; i < attributes.getLength(); ++i) {
+				String method = attributes.getQName(i);
+				String value = attributes.getValue(i);
+				try {
+					BeanUtils.setProperty(rule, method, value);
+				} catch (IllegalAccessException | InvocationTargetException e) {
+					log.warn("unable to set method ["+method+"] with value ["+value+"]");
+					e.printStackTrace();
+				}
+			}
+
+			handle(rule);
+		}
+	}
+
+	protected abstract void handle(DigesterRule rule);
+}

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRulesParser.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/DigesterRulesParser.java
@@ -1,0 +1,73 @@
+package nl.nn.adapterframework.configuration.digester;
+
+import org.apache.commons.digester3.Digester;
+import org.apache.commons.digester3.ObjectCreationFactory;
+import org.apache.commons.digester3.Rule;
+import org.apache.commons.digester3.binder.LinkedRuleBuilder;
+import org.apache.commons.digester3.binder.RulesBinder;
+import org.apache.commons.lang3.StringUtils;
+
+import nl.nn.adapterframework.configuration.AttributeCheckingRule;
+import nl.nn.adapterframework.configuration.GenericFactory;
+import nl.nn.adapterframework.util.ClassUtils;
+
+public class DigesterRulesParser extends DigesterRulesHandler {
+	private Digester digester;
+	private RulesBinder rulesBinder;
+	private Rule attributeChecker = new AttributeCheckingRule();
+
+	public DigesterRulesParser(Digester digester, RulesBinder rulesBinder) {
+		this.digester = digester;
+		this.rulesBinder = rulesBinder;
+	}
+
+	@Override
+	protected void handle(DigesterRule rule) {
+		if(log.isTraceEnabled()) log.trace("adding digesterRule " + rule.toString());
+
+		LinkedRuleBuilder ruleBuilder = rulesBinder.forPattern(rule.getPattern());
+		if(StringUtils.isNotEmpty(rule.getObject())) { //If a class is specified, load the class through the digester create-object-rule
+			ruleBuilder.createObject().ofType(rule.getObject());
+		} else {
+			ObjectCreationFactory<Object> factory = getFactory(rule.getFactory());
+			if(factory != null) {
+				factory.setDigester(digester); //When using a custom factory you have to inject the digester manually... Sigh
+				ruleBuilder.factoryCreate().usingFactory(factory); //If a factory is specified, use the factory to create the object
+			}
+		}
+		ruleBuilder.setProperties(); //set the set-properties-rule
+		if(rule.getRegisterMethod() != null) { //set the register method (set-next-rule)
+			ruleBuilder.setNext(rule.getRegisterMethod());
+		}
+		if(rule.getSelfRegisterMethod() != null) { //set the register method (set-top-rule)
+			ruleBuilder.setTop(rule.getSelfRegisterMethod());
+		}
+		ruleBuilder.addRule(attributeChecker); //Add the attribute checker
+	}
+
+	/**
+	 * Return the specified factory or the default factory when empty.
+	 */
+	@SuppressWarnings({ "rawtypes", "unchecked" })
+	private ObjectCreationFactory<Object> getFactory(String factory) {
+		if("null".equals(factory)) { //Check against a null-string when you don't want to use the default factory
+			if(log.isTraceEnabled()) log.trace("NULL factory specified, skip factory registration");
+			return null;
+		} else if(StringUtils.isNotEmpty(factory)) {
+			Object object;
+			try {
+				if(log.isTraceEnabled()) log.trace("attempting to create new factory of class ["+factory+"]");
+				object = ClassUtils.newInstance(factory);
+			} catch (Exception e) {
+				throw new IllegalArgumentException("factory ["+factory+"] not found", e);
+			}
+			if(object instanceof ObjectCreationFactory) {
+				return (ObjectCreationFactory) object;
+			} else {
+				throw new IllegalArgumentException("factory type must implement ObjectCreationFactory");
+			}
+		}
+		if(log.isTraceEnabled()) log.trace("no factory specified, returing default ["+GenericFactory.class.getCanonicalName()+"]");
+		return new GenericFactory();
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
@@ -1,0 +1,139 @@
+/*
+   Copyright 2020 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.configuration.digester;
+
+import org.apache.commons.digester3.Digester;
+import org.apache.commons.digester3.ObjectCreationFactory;
+import org.apache.commons.digester3.Rule;
+import org.apache.commons.digester3.binder.LinkedRuleBuilder;
+import org.apache.commons.digester3.binder.RulesBinder;
+import org.apache.commons.digester3.binder.RulesModule;
+import org.apache.logging.log4j.Logger;
+
+import nl.nn.adapterframework.configuration.AttributeCheckingRule;
+import nl.nn.adapterframework.configuration.ConfigurationDigesterFactory;
+import nl.nn.adapterframework.configuration.GenericFactory;
+import nl.nn.adapterframework.configuration.JmsRealmsFactory;
+import nl.nn.adapterframework.configuration.ListenerFactory;
+import nl.nn.adapterframework.configuration.RecordHandlingFlowFactory;
+import nl.nn.adapterframework.util.LogUtil;
+
+public class FrankDigesterRules implements RulesModule {
+
+	private final Logger log = LogUtil.getLogger(this);
+	private GenericFactory factory = new GenericFactory();
+	private Rule attributeChecker = new AttributeCheckingRule();
+	private Digester digester;
+
+	public FrankDigesterRules(Digester digester) {
+		this.digester = digester;
+	}
+
+	@Override
+	public void configure(RulesBinder rulesBinder) {
+		rulesBinder.forPattern("IOS-Adaptering");
+		rulesBinder.forPattern("configuration");
+
+		createRule(rulesBinder, "*/include", new ConfigurationDigesterFactory(), "include");
+
+		createRule(rulesBinder, "*/jmsRealms", new JmsRealmsFactory());
+		createRule(rulesBinder, "*/jmsRealm", "registerJmsRealm");
+
+		createRule(rulesBinder, "*/sapSystem", "nl.nn.adapterframework.extensions.sap.SapSystem", "registerItem");
+
+		createRule(rulesBinder, "*/adapter", "registerAdapter");
+		createRule(rulesBinder, "*/pipeline", "registerPipeLine");
+		createRule(rulesBinder, "*/errorMessageFormatter", "setErrorMessageFormatter");
+
+		createRule(rulesBinder, "*/receiver", "registerReceiver");
+		createRule(rulesBinder, "*/sender", "setSender");
+		createRule(rulesBinder, "*/postboxSender", "setSender");
+		createRule(rulesBinder, "*/listener", new ListenerFactory(), "setListener");
+		createRule(rulesBinder, "*/postboxListener", "setListener");
+		createRule(rulesBinder, "*/errorSender", "setErrorSender");
+		createRule(rulesBinder, "*/messageLog", "setMessageLog");
+		createRule(rulesBinder, "*/inProcessStorage", "setInProcessStorage");
+		createRule(rulesBinder, "*/errorStorage", "setErrorStorage");
+		createRule(rulesBinder, "*/inputValidator", "setInputValidator");
+		createRule(rulesBinder, "*/outputValidator", "setOutputValidator");
+		createRule(rulesBinder, "*/inputWrapper", "setInputWrapper");
+		createRule(rulesBinder, "*/outputWrapper", "setOutputWrapper");
+
+		createRule(rulesBinder, "*/pipe", "addPipe");
+		createRule(rulesBinder, "*/forward", "registerForward");
+		createRule(rulesBinder, "*/child", "registerChild");
+		createRule(rulesBinder, "*/pipeline/exits/exit", "registerPipeLineExit");
+
+		createRule(rulesBinder, "*/scheduler/job", "registerScheduledJob");
+		createRule(rulesBinder, "*/locker", "setLocker");
+		createRule(rulesBinder, "*/param", "addParameter");
+		createRule(rulesBinder, "*/directoryCleaner", "addDirectoryCleaner");
+		createRule(rulesBinder, "*/readerFactory", "setReaderFactory");
+
+		createRule(rulesBinder, "*/manager", "registerManager");
+		createRule(rulesBinder, "*/manager/flow", new RecordHandlingFlowFactory(), "addHandler");
+		createRule(rulesBinder, "*/recordHandler", "registerRecordHandler");
+		createRule(rulesBinder, "*/resultHandler", "registerResultHandler");
+
+		createRule(rulesBinder, "*/statisticsHandlers", "registerStatisticsHandler");
+		createRule(rulesBinder, "*/statisticsHandler", "registerStatisticsHandler");
+		createRule(rulesBinder, "*/cache", "registerCache");
+	}
+
+	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, String next) {
+		return createRule(rulesBinder, pattern, null, factory, next, null);
+	}
+	//This is here to be able to load classes (through reflection) that are not in the core module
+	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, String objectClassName, String next) {
+		try {
+			Class<?> clazz = this.getClass().getClassLoader().loadClass(objectClassName);
+			return createRule(rulesBinder, pattern, clazz, next);
+		} catch (ClassNotFoundException e) {
+			throw new IllegalArgumentException("class ["+objectClassName+"] not found", e);
+		}
+	}
+	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, Class<?> clazz, String next) {
+		return createRule(rulesBinder, pattern, clazz, null, next, null);
+	}
+	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, ObjectCreationFactory<Object> factory) {
+		return createRule(rulesBinder, pattern, factory, null);
+	}
+	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, ObjectCreationFactory<Object> factory, String next) {
+		return createRule(rulesBinder, pattern, null, factory, next, null);
+	}
+
+	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, Class<?> clazz, ObjectCreationFactory<Object> factory, String next, Class<?> parameterType) {
+		if(log.isTraceEnabled()) log.trace(String.format("adding digesterRule pattern [%s] class [%s] factory [%s] next-rule [%s] parameterType [%s]", pattern, clazz, factory, next, parameterType));
+
+		LinkedRuleBuilder ruleBuilder = rulesBinder.forPattern(pattern);
+		if(clazz != null) {
+			ruleBuilder.createObject().ofType(clazz);
+		} else {
+			factory.setDigester(digester); //When using a custom factory you have to inject the digester manually... Sigh
+			ruleBuilder.factoryCreate().usingFactory(factory);
+		}
+		ruleBuilder.setProperties();
+		if(next != null) {
+			if(parameterType != null) {
+				ruleBuilder.setNext(next).withParameterType(parameterType);
+			} else {
+				ruleBuilder.setNext(next);
+			}
+		}
+		ruleBuilder.addRule(attributeChecker);
+		return ruleBuilder;
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
@@ -17,32 +17,13 @@ package nl.nn.adapterframework.configuration.digester;
 
 import java.io.IOException;
 
-import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-import javax.xml.parsers.ParserConfigurationException;
-
 import org.apache.commons.digester3.Digester;
-import org.apache.commons.digester3.ObjectCreationFactory;
-import org.apache.commons.digester3.Rule;
-import org.apache.commons.digester3.binder.LinkedRuleBuilder;
 import org.apache.commons.digester3.binder.RulesBinder;
 import org.apache.commons.digester3.binder.RulesModule;
-import org.apache.logging.log4j.Logger;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
 import org.xml.sax.SAXException;
 
-import nl.nn.adapterframework.configuration.AttributeCheckingRule;
-import nl.nn.adapterframework.configuration.GenericFactory;
 import nl.nn.adapterframework.core.Resource;
-import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.XmlUtils;
-import nl.nn.adapterframework.xml.NonResolvingExternalEntityResolver;
 
 /**
  * Custom implementation that replaces the old digester-rules.xml file.
@@ -53,12 +34,12 @@ import nl.nn.adapterframework.xml.NonResolvingExternalEntityResolver;
 public class FrankDigesterRules implements RulesModule {
 	public static final String DIGESTER_RULES_FILE = "digester-rules.xml";
 
-	private final Logger log = LogUtil.getLogger(this);
-	private GenericFactory factory = new GenericFactory();
-	private Rule attributeChecker = new AttributeCheckingRule();
 	private Digester digester;
 	private Resource digesterRules = null;
 
+	/**
+	 * We need to parse the Digester in case a factory create rule is used
+	 */
 	public FrankDigesterRules(Digester digester) {
 		this(digester, null);
 	}
@@ -77,56 +58,13 @@ public class FrankDigesterRules implements RulesModule {
 			digesterRules = Resource.getResource(digester.getClassLoader(), DIGESTER_RULES_FILE);
 		}
 
+		DigesterRulesHandler handler = new DigesterRulesParser(digester, rulesBinder);
 		try {
-			JAXBContext jaxbContext = JAXBContext.newInstance(DigesterRule.class);
-			Unmarshaller jaxbUnmarshaller = jaxbContext.createUnmarshaller();
-			DocumentBuilderFactory documentFactory = XmlUtils.getDocumentBuilderFactory();
-			documentFactory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-			DocumentBuilder builder = documentFactory.newDocumentBuilder();
-			builder.setEntityResolver(new NonResolvingExternalEntityResolver());
-
-			Document document = builder.parse(digesterRules.asInputSource());
-			Node rules = document.getFirstChild(); //get the <digester-rules/> tag
-			for(Node ruleNode : XmlUtils.getChildTags((Element)rules, "rule")) {
-				DigesterRule rule = (DigesterRule) jaxbUnmarshaller.unmarshal(ruleNode);
-				createRule(rulesBinder, rule.getPattern(), rule.getObject(), rule.getFactory(), rule.getNext(), rule.getParameterType());
-			}
-		} catch (JAXBException e) {
-			throw new IllegalStateException("unable to unmarshal a xml node", e);
+			XmlUtils.parseXml(digesterRules.asInputSource(), handler);
 		} catch (IOException e) {
-			throw new IllegalStateException("digesterRules file cannot be found", e);
-		} catch (ParserConfigurationException e) {
-			throw new IllegalStateException("documentBuilder cannot be initialized", e);
+			throw new IllegalStateException("unable to open digesterRules file", e);
 		} catch (SAXException e) {
 			throw new IllegalStateException("unable to parse digesterRules file", e);
 		}
-	}
-
-	/**
-	 * Create a generic parser to create the object, set the properties (set-properties-rule), 
-	 * set the register method (set-next-rule) add the attributeCheckerRule on a per pattern basis.
-	 */
-	protected void createRule(RulesBinder rulesBinder, String pattern, String clazz, ObjectCreationFactory<Object> factory, String next, Class<?> parameterType) {
-		if(log.isTraceEnabled()) log.trace(String.format("adding digesterRule pattern [%s] class [%s] factory [%s] next-rule [%s] parameterType [%s]", pattern, clazz, factory, next, parameterType));
-
-		LinkedRuleBuilder ruleBuilder = rulesBinder.forPattern(pattern);
-		if(clazz != null) { //If a class is specified, load the class through the digester create-object-rule
-			ruleBuilder.createObject().ofType(clazz);
-		} else {
-			if(factory == null) {
-				factory = this.factory;
-			}
-			factory.setDigester(digester); //When using a custom factory you have to inject the digester manually... Sigh
-			ruleBuilder.factoryCreate().usingFactory(factory); //If a factory is specified, use the factory to create the object
-		}
-		ruleBuilder.setProperties(); //set the set-properties-rule
-		if(next != null) { //set the register method (set-next-rule)
-			if(parameterType != null) {
-				ruleBuilder.setNext(next).withParameterType(parameterType);
-			} else {
-				ruleBuilder.setNext(next);
-			}
-		}
-		ruleBuilder.addRule(attributeChecker); //Add the attribute checker
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
@@ -31,6 +31,12 @@ import nl.nn.adapterframework.configuration.ListenerFactory;
 import nl.nn.adapterframework.configuration.RecordHandlingFlowFactory;
 import nl.nn.adapterframework.util.LogUtil;
 
+/**
+ * Custom implementation that replaces the old digester-rules.xml file.
+ * Where previously you had to specify a 'create', 'set-properties' and a 'set-next-rule'
+ * In this implementation you only have to call 'createRule(rulesBinder, PATTERN, NEXT-RULE')
+ *
+ */
 public class FrankDigesterRules implements RulesModule {
 
 	private final Logger log = LogUtil.getLogger(this);
@@ -116,27 +122,28 @@ public class FrankDigesterRules implements RulesModule {
 	}
 
 	/**
-	 * Create a generic parser to create the object, set the properties, add the attributeChecker on a per pattern basis.
+	 * Create a generic parser to create the object, set the properties (set-properties-rule), 
+	 * set the register method (set-next-rule) add the attributeCheckerRule on a per pattern basis.
 	 */
 	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, Class<?> clazz, ObjectCreationFactory<Object> factory, String next, Class<?> parameterType) {
 		if(log.isTraceEnabled()) log.trace(String.format("adding digesterRule pattern [%s] class [%s] factory [%s] next-rule [%s] parameterType [%s]", pattern, clazz, factory, next, parameterType));
 
 		LinkedRuleBuilder ruleBuilder = rulesBinder.forPattern(pattern);
-		if(clazz != null) {
+		if(clazz != null) { //If a class is specified, load the class through the digester create-object-rule
 			ruleBuilder.createObject().ofType(clazz);
 		} else {
 			factory.setDigester(digester); //When using a custom factory you have to inject the digester manually... Sigh
-			ruleBuilder.factoryCreate().usingFactory(factory);
+			ruleBuilder.factoryCreate().usingFactory(factory); //If a factory is specified, use the factory to create the object
 		}
-		ruleBuilder.setProperties();
-		if(next != null) {
+		ruleBuilder.setProperties(); //set the set-properties-rule
+		if(next != null) { //set the register method (set-next-rule)
 			if(parameterType != null) {
 				ruleBuilder.setNext(next).withParameterType(parameterType);
 			} else {
 				ruleBuilder.setNext(next);
 			}
 		}
-		ruleBuilder.addRule(attributeChecker);
+		ruleBuilder.addRule(attributeChecker); //Add the attribute checker
 		return ruleBuilder;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRules.java
@@ -115,6 +115,9 @@ public class FrankDigesterRules implements RulesModule {
 		return createRule(rulesBinder, pattern, null, factory, next, null);
 	}
 
+	/**
+	 * Create a generic parser to create the object, set the properties, add the attributeChecker on a per pattern basis.
+	 */
 	private LinkedRuleBuilder createRule(RulesBinder rulesBinder, String pattern, Class<?> clazz, ObjectCreationFactory<Object> factory, String next, Class<?> parameterType) {
 		if(log.isTraceEnabled()) log.trace(String.format("adding digesterRule pattern [%s] class [%s] factory [%s] next-rule [%s] parameterType [%s]", pattern, clazz, factory, next, parameterType));
 

--- a/core/src/main/java/nl/nn/adapterframework/doc/DigesterRulesParser.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/DigesterRulesParser.java
@@ -15,6 +15,7 @@
 */
 package nl.nn.adapterframework.doc;
 
+import org.apache.commons.lang3.StringUtils;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
@@ -26,48 +27,48 @@ import java.util.List;
 import java.util.StringTokenizer;
 
 public class DigesterRulesParser extends DefaultHandler {
-    private String currentIbisBeanName;
-    private List<ChildIbisBeanMapping> childIbisBeanMappings = new ArrayList<ChildIbisBeanMapping>();
+	private String currentIbisBeanName;
+	private List<ChildIbisBeanMapping> childIbisBeanMappings = new ArrayList<>();
 
-    @Override
-    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-        if ("pattern".equals(qName)) {
-            String pattern = attributes.getValue("value");
-            StringTokenizer tokenizer = new StringTokenizer(pattern, "/");
-            while (tokenizer.hasMoreElements()) {
-                String token = tokenizer.nextToken();
-                if (!"*".equals(token)) {
-                    currentIbisBeanName = token;
-                }
-            }
-        } else if ("set-next-rule".equals(qName)) {
-            String methodName = attributes.getValue("methodname");
-            childIbisBeanMappings.add(getChildIbisBeanMapping(methodName, currentIbisBeanName));
-        }
-    }
+	@Override
+	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+		if("rule".equals(qName)) {
+			String pattern = attributes.getValue("pattern");
+			StringTokenizer tokenizer = new StringTokenizer(pattern, "/");
+			while(tokenizer.hasMoreElements()) {
+				String token = tokenizer.nextToken();
+				if(!"*".equals(token)) {
+					currentIbisBeanName = token;
+				}
+			}
+			String methodName = attributes.getValue("next");
+			if(StringUtils.isNotEmpty(methodName)) {
+				childIbisBeanMappings.add(getChildIbisBeanMapping(methodName, currentIbisBeanName));
+			}
+		}
+	}
 
-    @Override
-    public void endElement(String uri, String localName, String qName)
-            throws SAXException {
-        if ("pattern".equals(qName)) {
-            currentIbisBeanName = null;
-        }
-    }
+	@Override
+	public void endElement(String uri, String localName, String qName) throws SAXException {
+		if("pattern".equals(qName)) {
+			currentIbisBeanName = null;
+		}
+	}
 
-    public List<ChildIbisBeanMapping> getChildIbisBeanMappings() {
-        return childIbisBeanMappings;
-    }
+	public List<ChildIbisBeanMapping> getChildIbisBeanMappings() {
+		return childIbisBeanMappings;
+	}
 
-    private static ChildIbisBeanMapping getChildIbisBeanMapping(String methodName, String childIbisBeanName) {
-        ChildIbisBeanMapping result = new ChildIbisBeanMapping();
-        result.setMaxOccurs(-1);
-    	result.setMethodName(methodName);
-        result.setChildIbisBeanName(childIbisBeanName);
-        if (methodName.startsWith("set")) {
-            result.setMaxOccurs(1);
-        } else if (!(methodName.startsWith("add") || methodName.startsWith("register"))) {
-            throw new RuntimeException("Unknow verb in method name: " + methodName);
-        }
-        return result;
-    }
+	private static ChildIbisBeanMapping getChildIbisBeanMapping(String methodName, String childIbisBeanName) {
+		ChildIbisBeanMapping result = new ChildIbisBeanMapping();
+		result.setMaxOccurs(-1);
+		result.setMethodName(methodName);
+		result.setChildIbisBeanName(childIbisBeanName);
+		if(methodName.startsWith("set")) {
+			result.setMaxOccurs(1);
+		} else if(!(methodName.startsWith("add") || methodName.startsWith("register"))) {
+			throw new IllegalStateException("Unknow verb in method name: " + methodName);
+		}
+		return result;
+	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/IbisBeanMappingParser.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/IbisBeanMappingParser.java
@@ -15,43 +15,32 @@
 */
 package nl.nn.adapterframework.doc;
 
-import org.apache.commons.lang3.StringUtils;
-import org.xml.sax.Attributes;
-import org.xml.sax.SAXException;
-import org.xml.sax.helpers.DefaultHandler;
-
-import nl.nn.adapterframework.doc.objects.ChildIbisBeanMapping;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-public class DigesterRulesParser extends DefaultHandler {
-	private String currentIbisBeanName;
+import org.apache.commons.lang3.StringUtils;
+
+import nl.nn.adapterframework.configuration.digester.DigesterRule;
+import nl.nn.adapterframework.configuration.digester.DigesterRulesHandler;
+import nl.nn.adapterframework.doc.objects.ChildIbisBeanMapping;
+
+public class IbisBeanMappingParser extends DigesterRulesHandler {
 	private List<ChildIbisBeanMapping> childIbisBeanMappings = new ArrayList<>();
 
 	@Override
-	public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-		if("rule".equals(qName)) {
-			String pattern = attributes.getValue("pattern");
-			StringTokenizer tokenizer = new StringTokenizer(pattern, "/");
-			while(tokenizer.hasMoreElements()) {
-				String token = tokenizer.nextToken();
-				if(!"*".equals(token)) {
-					currentIbisBeanName = token;
-				}
-			}
-			String methodName = attributes.getValue("next");
-			if(StringUtils.isNotEmpty(methodName)) {
-				childIbisBeanMappings.add(getChildIbisBeanMapping(methodName, currentIbisBeanName));
+	protected void handle(DigesterRule rule) {
+		String pattern = rule.getPattern();
+		StringTokenizer tokenizer = new StringTokenizer(pattern, "/");
+		String currentIbisBeanName = null;
+		while(tokenizer.hasMoreElements()) {
+			String token = tokenizer.nextToken();
+			if(!"*".equals(token)) {
+				currentIbisBeanName = token;
 			}
 		}
-	}
-
-	@Override
-	public void endElement(String uri, String localName, String qName) throws SAXException {
-		if("pattern".equals(qName)) {
-			currentIbisBeanName = null;
+		if(StringUtils.isNotEmpty(rule.getRegisterMethod())) {
+			childIbisBeanMappings.add(getChildIbisBeanMapping(rule.getRegisterMethod(), currentIbisBeanName));
 		}
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/doc/InfoBuilderSource.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/InfoBuilderSource.java
@@ -340,7 +340,7 @@ class InfoBuilderSource {
 	}
 
 	static List<ChildIbisBeanMapping> getChildIbisBeanMappings() throws IOException, SAXException {
-		DigesterRulesParser digesterRulesParser = new DigesterRulesParser();
+		IbisBeanMappingParser digesterRulesParser = new IbisBeanMappingParser();
 		try {
 			XmlUtils.parseXml(Misc.resourceToString(ClassUtils.getResourceURL(IbisDocPipe.class, "digester-rules.xml")), digesterRulesParser);
 		} catch (Exception e) {

--- a/core/src/main/java/nl/nn/adapterframework/doc/objects/ChildIbisBeanMapping.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/objects/ChildIbisBeanMapping.java
@@ -15,6 +15,8 @@
 */
 package nl.nn.adapterframework.doc.objects;
 
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import lombok.Getter;
 import lombok.Setter;
 
@@ -23,7 +25,12 @@ import lombok.Setter;
  *
  */
 public class ChildIbisBeanMapping {
-    private @Getter @Setter String methodName; // E.g. registerAdapter
-    private @Getter @Setter String childIbisBeanName; // E.g. adapter
-    private @Getter @Setter int maxOccurs;
+	private @Getter @Setter String methodName; // E.g. registerAdapter
+	private @Getter @Setter String childIbisBeanName; // E.g. adapter
+	private @Getter @Setter int maxOccurs;
+
+	@Override
+	public String toString() {
+		return ToStringBuilder.reflectionToString(this);
+	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/monitoring/MonitorManager.java
+++ b/core/src/main/java/nl/nn/adapterframework/monitoring/MonitorManager.java
@@ -39,9 +39,9 @@ import nl.nn.adapterframework.util.Lock;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.XmlBuilder;
 
-import org.apache.commons.digester.AbstractObjectCreationFactory;
-import org.apache.commons.digester.Digester;
-import org.apache.commons.digester.Rule;
+import org.apache.commons.digester3.AbstractObjectCreationFactory;
+import org.apache.commons.digester3.Digester;
+import org.apache.commons.digester3.Rule;
 import org.apache.logging.log4j.Logger;
 import org.xml.sax.Attributes;
 

--- a/core/src/main/java/nl/nn/adapterframework/pipes/CompressPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/CompressPipe.java
@@ -30,6 +30,7 @@ import java.util.zip.ZipOutputStream;
 
 import org.apache.commons.lang.StringUtils;
 
+import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.IPipeLineSession;
 import nl.nn.adapterframework.core.ParameterException;
 import nl.nn.adapterframework.core.PipeForward;
@@ -66,7 +67,16 @@ public class CompressPipe extends FixedForwardPipe {
 	private boolean compress;
 	private boolean convert2String;
 	private String fileFormat;
-	
+
+	@Override
+	public void configure() throws ConfigurationException {
+		super.configure();
+
+		if(!resultIsContent && !messageIsContent && outputDirectory == null) {
+			throw new ConfigurationException("outputDirectory must be set");
+		}
+	}
+
 	@Override
 	public PipeRunResult doPipe(Message message, IPipeLineSession session) throws PipeRunException {
 		try {

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/action/ShowMonitorExecute.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/action/ShowMonitorExecute.java
@@ -29,7 +29,7 @@ import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.Misc;
 import nl.nn.adapterframework.util.XmlBuilder;
 
-import org.apache.commons.digester.Digester;
+import org.apache.commons.digester3.Digester;
 import org.apache.commons.lang.StringUtils;
 import org.apache.struts.action.DynaActionForm;
 import org.apache.struts.upload.FormFile;

--- a/core/src/main/resources/digester-rules.xml
+++ b/core/src/main/resources/digester-rules.xml
@@ -1,57 +1,58 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <digester-rules>
 	<!-- Rules are parsed with the DigesterRuleParser. Objects will be created with the Spring Beans Factory. -->
+	<!-- See DigesterRule for more information -->
 
-	<rule pattern="IOS-Adaptering"/><!-- deprecated, use configuration or module instead -->
-	<rule pattern="configuration"/>
+	<rule pattern="IOS-Adaptering" factory="null"/><!-- deprecated, use configuration or module instead -->
+	<rule pattern="configuration" factory="null"/>
 
-	<rule pattern="*/include" factory="nl.nn.adapterframework.configuration.ConfigurationDigesterFactory" top="include"/>
+	<rule pattern="*/include" factory="nl.nn.adapterframework.configuration.ConfigurationDigesterFactory" selfRegisterMethod="include"/>
 
 
 	<rule pattern="*/jmsRealms" factory="nl.nn.adapterframework.configuration.JmsRealmsFactory"/>
-	<rule pattern="*/jmsRealm" next="registerJmsRealm"/>
+	<rule pattern="*/jmsRealm" registerMethod="registerJmsRealm"/>
 
-	<rule pattern="*/sapSystem" object="nl.nn.adapterframework.extensions.sap.SapSystem" top="registerItem"/>
+	<rule pattern="*/sapSystem" object="nl.nn.adapterframework.extensions.sap.SapSystem" selfRegisterMethod="registerItem"/>
 
-	<rule pattern="*/adapter" next="registerAdapter"/>
-	<rule pattern="*/pipeline" next="registerPipeLine"/>
-	<rule pattern="*/errorMessageFormatter" next="setErrorMessageFormatter"/>
+	<rule pattern="*/adapter" registerMethod="registerAdapter" />
+	<rule pattern="*/pipeline" registerMethod="registerPipeLine"/>
+	<rule pattern="*/errorMessageFormatter" registerMethod="setErrorMessageFormatter"/>
 
-	<rule pattern="*/receiver" next="registerReceiver"/>
-	<rule pattern="*/sender" next="setSender"/>
-	<rule pattern="*/postboxSender" next="setSender"/>
-	<rule pattern="*/listener" factory="nl.nn.adapterframework.configuration.ListenerFactory" next="setListener"/>
-	<rule pattern="*/postboxListener" next="setListener"/>
-	<rule pattern="*/errorSender" next="setErrorSender"/>
-	<rule pattern="*/messageLog" next="setMessageLog"/>
-	<rule pattern="*/inProcessStorage" next="setInProcessStorage"/>
-	<rule pattern="*/errorStorage" next="setErrorStorage"/>
-	<rule pattern="*/inputValidator" next="setInputValidator"/>
-	<rule pattern="*/outputValidator" next="setOutputValidator"/>
-	<rule pattern="*/inputWrapper" next="setInputWrapper"/>
-	<rule pattern="*/outputWrapper" next="setOutputWrapper"/>
+	<rule pattern="*/receiver" registerMethod="registerReceiver"/>
+	<rule pattern="*/sender" registerMethod="setSender"/>
+	<rule pattern="*/postboxSender" registerMethod="setSender"/>
+	<rule pattern="*/listener" factory="nl.nn.adapterframework.configuration.ListenerFactory" registerMethod="setListener"/>
+	<rule pattern="*/postboxListener" registerMethod="setListener"/>
+	<rule pattern="*/errorSender" registerMethod="setErrorSender"/>
+	<rule pattern="*/messageLog" registerMethod="setMessageLog"/>
+	<rule pattern="*/inProcessStorage" registerMethod="setInProcessStorage"/>
+	<rule pattern="*/errorStorage" registerMethod="setErrorStorage"/>
+	<rule pattern="*/inputValidator" registerMethod="setInputValidator"/>
+	<rule pattern="*/outputValidator" registerMethod="setOutputValidator"/>
+	<rule pattern="*/inputWrapper" registerMethod="setInputWrapper"/>
+	<rule pattern="*/outputWrapper" registerMethod="setOutputWrapper"/>
 
-	<rule pattern="*/pipe" next="addPipe" paramtype="nl.nn.adapterframework.core.IPipe"/>
+	<rule pattern="*/pipe" registerMethod="addPipe" paramtype="nl.nn.adapterframework.core.IPipe"/>
 
 	<!-- forward element is on the pipeline / global-forward as well as on the pipe element -->
-	<rule pattern="*/forward" next="registerForward"/>
-	<rule pattern="*/child" next="registerChild"/>
-	<rule pattern="*/pipeline/exits/exit" next="registerPipeLineExit"/>
+	<rule pattern="*/forward" registerMethod="registerForward"/>
+	<rule pattern="*/child" registerMethod="registerChild"/>
+	<rule pattern="*/pipeline/exits/exit" registerMethod="registerPipeLineExit"/>
 
-	<rule pattern="*/scheduler/job" next="registerScheduledJob"/>
-	<rule pattern="*/locker" next="setLocker"/>
-	<rule pattern="*/param" next="addParameter" />
-	<rule pattern="*/directoryCleaner" next="addDirectoryCleaner" />
+	<rule pattern="*/scheduler/job" registerMethod="registerScheduledJob"/>
+	<rule pattern="*/locker" registerMethod="setLocker"/>
+	<rule pattern="*/param" registerMethod="addParameter" />
+	<rule pattern="*/directoryCleaner" registerMethod="addDirectoryCleaner" />
 
 	<!-- batch related rules -->
-	<rule pattern="*/readerFactory" next="setReaderFactory"/>
-	<rule pattern="*/manager" next="registerManager"/>
-	<rule pattern="*/manager/flow" factory="nl.nn.adapterframework.configuration.RecordHandlingFlowFactory" next="addHandler"/>
-	<rule pattern="*/recordHandler" next="registerRecordHandler"/>
-	<rule pattern="*/resultHandler" next="registerResultHandler"/>
+	<rule pattern="*/readerFactory" registerMethod="setReaderFactory"/>
+	<rule pattern="*/manager" registerMethod="registerManager"/>
+	<rule pattern="*/manager/flow" factory="nl.nn.adapterframework.configuration.RecordHandlingFlowFactory" registerMethod="addHandler"/>
+	<rule pattern="*/recordHandler" registerMethod="registerRecordHandler"/>
+	<rule pattern="*/resultHandler" registerMethod="registerResultHandler"/>
 
 
-	<rule pattern="*/statisticsHandlers" next="registerStatisticsHandler"/>
-	<rule pattern="*/statisticsHandler" next="registerStatisticsHandler"/>
-	<rule pattern="*/cache" next="registerCache"/>
+	<rule pattern="*/statisticsHandlers" registerMethod="registerStatisticsHandler"/>
+	<rule pattern="*/statisticsHandler" registerMethod="registerStatisticsHandler"/>
+	<rule pattern="*/cache" registerMethod="registerCache"/>
 </digester-rules>

--- a/core/src/main/resources/digester-rules.xml
+++ b/core/src/main/resources/digester-rules.xml
@@ -1,227 +1,57 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE digester-rules PUBLIC "-//Apache Commons //DTD digester-rules XML V1.0//EN" "http://commons.apache.org/digester/dtds/digester-rules-3.0.dtd">
 <digester-rules>
+	<!-- Rules are parsed with the DigesterRuleParser. Objects will be created with the Spring Beans Factory. -->
 
-    <!-- Objects created using a factory-create-rule are created via the Spring Beans Factory.
-         Objects created using an object-create-rule are created directly by the Apache Digester,
-         and do not pass by the Spring Beans Factory. -->
+	<rule pattern="IOS-Adaptering"/><!-- deprecated, use configuration or module instead -->
+	<rule pattern="configuration"/>
 
-  <pattern value="IOS-Adaptering"><!-- deprecated, use configuration or module instead -->
-    <set-properties-rule/>
-  </pattern>
-
-  <pattern value="configuration">
-    <set-properties-rule/>
-  </pattern>
-
-  <pattern value="*/include">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.ConfigurationDigesterFactory"/>
-    <set-properties-rule/>
-    <set-top-rule methodname="include"/>
-  </pattern>
-
-  <pattern value="*/jmsRealms">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.JmsRealmsFactory"/>
-    <set-properties-rule/>
-  </pattern>
-  <pattern value="*/jmsRealm">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerJmsRealm"/>
-  </pattern>
-
-  <pattern value="*/sapSystem">
-    <object-create-rule classname="nl.nn.adapterframework.extensions.sap.SapSystem"/>
-    <set-properties-rule/>
-    <set-top-rule methodname="registerItem"/>
-  </pattern>
+	<rule pattern="*/include" factory="nl.nn.adapterframework.configuration.ConfigurationDigesterFactory" top="include"/>
 
 
-  <pattern value="*/adapter">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerAdapter"/>
-  </pattern>
-  <pattern value="*/pipeline">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerPipeLine"/>
-  </pattern>
-  <pattern value="*/errorMessageFormatter">
-    <object-create-rule classname="nl.nn.adapterframework.errormessageformatters.XslErrorMessageFormatter" attrname="className"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="setErrorMessageFormatter"/>
-  </pattern>
+	<rule pattern="*/jmsRealms" factory="nl.nn.adapterframework.configuration.JmsRealmsFactory"/>
+	<rule pattern="*/jmsRealm" next="registerJmsRealm"/>
 
-  <pattern value="*/receiver">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerReceiver"/>
-  </pattern>
-  <pattern value="*/sender">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.core.ISender" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="setSender"/>
-  </pattern>
-  <pattern value="*/postboxSender">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.core.IPostboxSender" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="setSender"/>
-  </pattern>
-  <pattern value="*/listener">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.ListenerFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="setListener"/>
-  </pattern>
-  <pattern value="*/postboxListener">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.core.IPostboxListener" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="setListener"/>
-  </pattern>
-  <pattern value="*/errorSender">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.core.ISender" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="setErrorSender"/>
-  </pattern>
-  <pattern value="*/messageLog">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.core.ITransactionalStorage" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="setMessageLog"/>
-  </pattern>
-  <pattern value="*/inProcessStorage">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.core.ITransactionalStorage" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="setInProcessStorage"/>
-  </pattern>
-  <pattern value="*/errorStorage">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.core.ITransactionalStorage" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="setErrorStorage"/>
-  </pattern>
-  <pattern value="*/inputValidator">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="setInputValidator"/>
-  </pattern>
-  <pattern value="*/outputValidator">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="setOutputValidator"/>
-  </pattern>
-  <pattern value="*/inputWrapper">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="setInputWrapper"/>
-  </pattern>
-  <pattern value="*/outputWrapper">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="setOutputWrapper"/>
-  </pattern>
+	<rule pattern="*/sapSystem" object="nl.nn.adapterframework.extensions.sap.SapSystem" top="registerItem"/>
 
-  <pattern value="*/pipe">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="addPipe" paramtype="nl.nn.adapterframework.core.IPipe"/>
-  </pattern>
-  <!-- forward element is on the pipeline / global-forward as well as on the
-         pipe element -->
-  <pattern value="*/forward">
-    <object-create-rule classname="nl.nn.adapterframework.core.PipeForward"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerForward"/>
-  </pattern>
+	<rule pattern="*/adapter" next="registerAdapter"/>
+	<rule pattern="*/pipeline" next="registerPipeLine"/>
+	<rule pattern="*/errorMessageFormatter" next="setErrorMessageFormatter"/>
 
-  <pattern value="*/child">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="java.Object" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="registerChild"/>
-  </pattern>
+	<rule pattern="*/receiver" next="registerReceiver"/>
+	<rule pattern="*/sender" next="setSender"/>
+	<rule pattern="*/postboxSender" next="setSender"/>
+	<rule pattern="*/listener" factory="nl.nn.adapterframework.configuration.ListenerFactory" next="setListener"/>
+	<rule pattern="*/postboxListener" next="setListener"/>
+	<rule pattern="*/errorSender" next="setErrorSender"/>
+	<rule pattern="*/messageLog" next="setMessageLog"/>
+	<rule pattern="*/inProcessStorage" next="setInProcessStorage"/>
+	<rule pattern="*/errorStorage" next="setErrorStorage"/>
+	<rule pattern="*/inputValidator" next="setInputValidator"/>
+	<rule pattern="*/outputValidator" next="setOutputValidator"/>
+	<rule pattern="*/inputWrapper" next="setInputWrapper"/>
+	<rule pattern="*/outputWrapper" next="setOutputWrapper"/>
 
-  <pattern value="*/pipeline/exits/exit">
-    <object-create-rule classname="nl.nn.adapterframework.core.PipeLineExit"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerPipeLineExit"/>
-  </pattern>
+	<rule pattern="*/pipe" next="addPipe" paramtype="nl.nn.adapterframework.core.IPipe"/>
 
-  <pattern value="*/scheduler/job">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <!--<object-create-rule classname="nl.nn.adapterframework.scheduler.JobDef"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="registerScheduledJob"/>
-  </pattern>
+	<!-- forward element is on the pipeline / global-forward as well as on the pipe element -->
+	<rule pattern="*/forward" next="registerForward"/>
+	<rule pattern="*/child" next="registerChild"/>
+	<rule pattern="*/pipeline/exits/exit" next="registerPipeLineExit"/>
 
-  <pattern value="*/locker">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="setLocker"/>
-  </pattern>
+	<rule pattern="*/scheduler/job" next="registerScheduledJob"/>
+	<rule pattern="*/locker" next="setLocker"/>
+	<rule pattern="*/param" next="addParameter" />
+	<rule pattern="*/directoryCleaner" next="addDirectoryCleaner" />
 
-  <pattern value="*/param">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="addParameter" />
-  </pattern>
+	<!-- batch related rules -->
+	<rule pattern="*/readerFactory" next="setReaderFactory"/>
+	<rule pattern="*/manager" next="registerManager"/>
+	<rule pattern="*/manager/flow" factory="nl.nn.adapterframework.configuration.RecordHandlingFlowFactory" next="addHandler"/>
+	<rule pattern="*/recordHandler" next="registerRecordHandler"/>
+	<rule pattern="*/resultHandler" next="registerResultHandler"/>
 
-  <pattern value="*/directoryCleaner">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory" />
-    <set-properties-rule/>
-    <set-next-rule methodname="addDirectoryCleaner" />
-  </pattern>
 
-  <!-- batch related rules -->
-  <pattern value="*/readerFactory">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="setReaderFactory"/>
-  </pattern>
-  <pattern value="*/manager">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.batch.IRecordHandlerManager" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="registerManager"/>
-  </pattern>
-  <pattern value="*/manager/flow">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.RecordHandlingFlowFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.batch.RecordHandlingFlow" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="addHandler"/>
-  </pattern>
-  <pattern value="*/recordHandler">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.batch.IRecordHandler" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="registerRecordHandler"/>
-  </pattern>
-  <pattern value="*/resultHandler">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <!--<object-create-rule classname="nl.nn.adapterframework.batch.IResultHandler" attrname="className"/> -->
-    <set-properties-rule/>
-    <set-next-rule methodname="registerResultHandler"/>
-  </pattern>
-
-  <pattern value="*/statisticsHandlers">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerStatisticsHandler"/>
-  </pattern>
-  <pattern value="*/statisticsHandler">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerStatisticsHandler"/>
-  </pattern>
-
-  <pattern value="*/cache">
-    <factory-create-rule classname="nl.nn.adapterframework.configuration.GenericFactory"/>
-    <set-properties-rule/>
-    <set-next-rule methodname="registerCache"/>
-  </pattern>
+	<rule pattern="*/statisticsHandlers" next="registerStatisticsHandler"/>
+	<rule pattern="*/statisticsHandler" next="registerStatisticsHandler"/>
+	<rule pattern="*/cache" next="registerCache"/>
 </digester-rules>

--- a/core/src/main/resources/digester-rules.xml
+++ b/core/src/main/resources/digester-rules.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE digester-rules PUBLIC "-//Apache Commons //DTD digester-rules XML V1.0//EN" "http://commons.apache.org/digester/dtds/digester-rules-3.0.dtd">
 <digester-rules>
 
     <!-- Objects created using a factory-create-rule are created via the Spring Beans Factory.

--- a/core/src/main/resources/springCommon.xml
+++ b/core/src/main/resources/springCommon.xml
@@ -278,7 +278,7 @@
 	Beans created from Configuration.xml, but prototyped here for
 	extra dependencies which cannot be created otherwise.
 	Bean names are prefixed with 'proto-' so that autowiring by
-	name doesn't create unnecessarily instances.
+	name doesn't create instances unnecessarily.
 	-->
 	<bean
 		name="proto-adapter"

--- a/core/src/main/resources/springCommon.xml
+++ b/core/src/main/resources/springCommon.xml
@@ -278,11 +278,32 @@
 	Beans created from Configuration.xml, but prototyped here for
 	extra dependencies which cannot be created otherwise.
 	Bean names are prefixed with 'proto-' so that autowiring by
-	name doesn't create unnessecary instances.
+	name doesn't create unnecessarily instances.
 	-->
 	<bean
 		name="proto-adapter"
 		class="nl.nn.adapterframework.core.Adapter"
+		autowire="byName"
+		scope="prototype"
+	/>
+
+	<bean
+		name="proto-errorMessageFormatter"
+		class="nl.nn.adapterframework.errormessageformatters.XslErrorMessageFormatter"
+		autowire="byName"
+		scope="prototype"
+	/>
+
+	<bean
+		name="proto-forward"
+		class="nl.nn.adapterframework.core.PipeForward"
+		autowire="byName"
+		scope="prototype"
+	/>
+
+	<bean
+		name="proto-exit"
+		class="nl.nn.adapterframework.core.PipeLineExit"
 		autowire="byName"
 		scope="prototype"
 	/>

--- a/core/src/test/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRulesTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRulesTest.java
@@ -1,0 +1,60 @@
+package nl.nn.adapterframework.configuration.digester;
+
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.digester3.Digester;
+import org.apache.commons.digester3.ObjectCreationFactory;
+import org.apache.commons.digester3.binder.LinkedRuleBuilder;
+import org.apache.commons.digester3.binder.RulesBinder;
+import org.apache.commons.digester3.binder.RulesModule;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+public class FrankDigesterRulesTest extends Mockito {
+	private class DummyRulesBinder implements RulesBinder {
+
+		@Override
+		public void install(RulesModule rulesModule) {
+			//Package private rulesModule which we cannot implement
+		}
+
+		@Override
+		public ClassLoader getContextClassLoader() {
+			return null; //We don't need/use the classloader?
+		}
+
+		@Override
+		public LinkedRuleBuilder forPattern(String pattern) {
+			return null; //Since this is a package private final we cant stub it...
+		}
+
+		@Override
+		public void addError(String messagePattern, Object... arguments) {
+			//Ignore parse errors
+		}
+
+		@Override
+		public void addError(Throwable t) {
+			//Ignore parse errors
+		}
+	};
+
+	@Test
+	public void parseDigesterRulesXml() {
+		Digester digester = new Digester();
+		List<String> patterns = new ArrayList<>();
+		FrankDigesterRules digesterRules = new FrankDigesterRules(digester) {
+			@Override
+			protected void createRule(RulesBinder rulesBinder, String pattern, String clazz, ObjectCreationFactory<Object> factory, String next, Class<?> parameterType) {
+				patterns.add(pattern);
+			}
+		};
+
+		digesterRules.configure(mock(DummyRulesBinder.class));
+
+		assertTrue("must at least have 33 patterns", patterns.size() >= 33);
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRulesTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/configuration/digester/FrankDigesterRulesTest.java
@@ -30,7 +30,7 @@ import nl.nn.adapterframework.util.XmlUtils;
 
 public class FrankDigesterRulesTest extends Mockito {
 	private class DummyDigesterRulesParser extends DigesterRulesHandler {
-		List<DigesterRule> rules = new ArrayList<>();
+		private List<DigesterRule> rules = new ArrayList<>();
 
 		@Override
 		protected void handle(DigesterRule rule) {

--- a/core/src/test/java/nl/nn/adapterframework/doc/TestDigesterRulesParser.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/TestDigesterRulesParser.java
@@ -1,0 +1,23 @@
+package nl.nn.adapterframework.doc;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+import nl.nn.adapterframework.doc.objects.ChildIbisBeanMapping;
+
+public class TestDigesterRulesParser {
+
+	@Test
+	public void testParser() throws Exception {
+		List<ChildIbisBeanMapping> beanList = InfoBuilderSource.getChildIbisBeanMappings();
+		assertTrue(beanList.size()>=33); //Expect to find at least 33 pattern mappings
+
+		ChildIbisBeanMapping mapping = beanList.get(0);
+		assertNotNull(mapping.getMethodName()); //Should never be null
+		assertNotNull(mapping.getChildIbisBeanName()); //Should never be null
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/TestDigesterRulesParser.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/TestDigesterRulesParser.java
@@ -14,7 +14,7 @@ public class TestDigesterRulesParser {
 	@Test
 	public void testParser() throws Exception {
 		List<ChildIbisBeanMapping> beanList = InfoBuilderSource.getChildIbisBeanMappings();
-		assertTrue(beanList.size()>=33); //Expect to find at least 33 pattern mappings
+		assertTrue(beanList.size() >= 33); //Expect to find at least 33 pattern mappings
 
 		ChildIbisBeanMapping mapping = beanList.get(0);
 		assertNotNull(mapping.getMethodName()); //Should never be null

--- a/core/src/test/java/nl/nn/adapterframework/pipes/CompressPipeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/pipes/CompressPipeTest.java
@@ -1,188 +1,188 @@
 package nl.nn.adapterframework.pipes;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.Test;
+
+import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.IPipeLineSession;
 import nl.nn.adapterframework.core.PipeLineSessionBase;
 import nl.nn.adapterframework.core.PipeRunException;
-import org.junit.Test;
 
-import static org.junit.Assert.*;
+public class CompressPipeTest extends PipeTestBase<CompressPipe> {
+	private String dummyString = "dummyString";
+	private String dummyStringSemiColon = dummyString + ";";
 
-public class CompressPipeTest extends PipeTestBase<CompressPipe>{
+	private IPipeLineSession session = new PipeLineSessionBase();
 
-    private IPipeLineSession session = new PipeLineSessionBase();
+	@Override
+	public CompressPipe createPipe() {
+		return new CompressPipe();
+	}
 
-    @Override
-    public CompressPipe createPipe() {
-        return new CompressPipe();
-    }
+	@Test
+	public void testGetterSetterMessageIsContent() {
+		pipe.setMessageIsContent(true);
+		boolean checkBoolean = pipe.isMessageIsContent();
+		assertEquals(true, checkBoolean);
 
-    @Test
-    public void testGetterSetterMessageIsContent() {
-        pipe.setMessageIsContent(true);
-        boolean checkBoolean = pipe.isMessageIsContent();
-        assertEquals(true, checkBoolean);
+		pipe.setMessageIsContent(false);
+		checkBoolean = pipe.isMessageIsContent();
+		assertEquals(false, checkBoolean);
+	}
 
-        pipe.setMessageIsContent(false);
-        checkBoolean = pipe.isMessageIsContent();
-        assertEquals(false, checkBoolean);
-    }
+	@Test
+	public void testGetterSetterResultIsContent() {
+		pipe.setResultIsContent(true);
+		boolean checkBoolean = pipe.isResultIsContent();
+		assertEquals(true, checkBoolean);
 
-    @Test
-    public void testGetterSetterResultIsContent() {
-        pipe.setResultIsContent(true);
-        boolean checkBoolean = pipe.isResultIsContent();
-        assertEquals(true, checkBoolean);
+		pipe.setResultIsContent(false);
+		checkBoolean = pipe.isResultIsContent();
+		assertEquals(false, checkBoolean);
+	}
 
-        pipe.setResultIsContent(false);
-        checkBoolean = pipe.isResultIsContent();
-        assertEquals(false, checkBoolean);
-    }
+	@Test
+	public void testGetterSetterOuputDirectory() {
+		pipe.setOutputDirectory(dummyString);
+		String otherString = pipe.getOutputDirectory();
+		assertEquals(dummyString, otherString);
+	}
 
-    @Test
-    public void testGetterSetterOuputDirectory() {
-        String dummyString =  "dummyString";
-        pipe.setOutputDirectory(dummyString);
-        String otherString = pipe.getOutputDirectory();
-        assertEquals(dummyString, otherString);
-    }
+	@Test
+	public void testGetterSetterFilenamePattern() {
+		pipe.setFilenamePattern(dummyString);
+		String otherString = pipe.getFilenamePattern();
+		assertEquals(dummyString, otherString);
+	}
 
-    @Test
-    public void testGetterSetterFilenamePattern() {
-        String dummyString = "dummyString";
-        pipe.setFilenamePattern(dummyString);
-        String otherString = pipe.getFilenamePattern();
-        assertEquals(dummyString, otherString);
-    }
+	@Test
+	public void testGetterSetterZipEntryPattern() {
+		pipe.setZipEntryPattern(dummyString);
+		String otherString = pipe.getZipEntryPattern();
+		assertEquals(dummyString, otherString);
+	}
 
-    @Test
-    public void testGetterSetterZipEntryPattern() {
-        String dummyString = "dummyString";
-        pipe.setZipEntryPattern(dummyString);
-        String otherString = pipe.getZipEntryPattern();
-        assertEquals(dummyString, otherString);
-    }
+	@Test
+	public void testGetterSetterCompress() {
+		pipe.setCompress(true);
+		boolean checkBoolean = pipe.isCompress();
+		assertEquals(true, checkBoolean);
 
-    @Test
-    public void testGetterSetterCompress() {
-        pipe.setCompress(true);
-        boolean checkBoolean = pipe.isCompress();
-        assertEquals(true, checkBoolean);
+		pipe.setCompress(false);
+		checkBoolean = pipe.isCompress();
+		assertEquals(false, checkBoolean);
+	}
 
-        pipe.setCompress(false);
-        checkBoolean = pipe.isCompress();
-        assertEquals(false, checkBoolean);
-    }
+	@Test
+	public void testGetterSetterConvert2String() {
+		pipe.setConvert2String(true);
+		boolean checkBoolean = pipe.isConvert2String();
+		assertEquals(true, checkBoolean);
 
-    @Test
-    public void testGetterSetterConvert2String() {
-        pipe.setConvert2String(true);
-        boolean checkBoolean = pipe.isConvert2String();
-        assertEquals(true, checkBoolean);
+		pipe.setConvert2String(false);
+		checkBoolean = pipe.isConvert2String();
+		assertEquals(false, checkBoolean);
+	}
 
-        pipe.setConvert2String(false);
-        checkBoolean = pipe.isConvert2String();
-        assertEquals(false, checkBoolean);
-    }
+	@Test(expected = ConfigurationException.class)
+	public void testCaptureFakeFilePath() throws Exception {
+		pipe.setMessageIsContent(false);
+		pipe.setCompress(true);
 
-    // TODO : There is no getter for file format
-//    @Test
-//    public void testGetterSetterFileFormat() {
-//        String dummyString = "dummyString";
-//        pipe.setFileFormat(dummyString);
-//        String otherString = pipe.file
-//        assertEquals(dummyString, otherString);
-//    }
+		configureAndStartPipe();
+		doPipe(pipe, dummyStringSemiColon, session);
+	}
 
-    @Test(expected = PipeRunException.class)
-    public void testCaptureFakeFilePath() throws PipeRunException {
-        Object input = "dummyString;";
-        pipe.setMessageIsContent(false);
-        pipe.setCompress(true);
+	@Test(expected = ConfigurationException.class)
+	public void testCaptureUncompressedLegitimateFilePath() throws Exception {
+		pipe.setMessageIsContent(false);
+		pipe.setCompress(false);
+		pipe.setFileFormat("gz");
 
-        doPipe(pipe,input, session);
-    }
+		configureAndStartPipe();
+		doPipe(pipe, dummyStringSemiColon, session);
+	}
 
-    @Test(expected = PipeRunException.class)
-    public void testCaptureUncompressedLegitimateFilePath() throws PipeRunException {
-        Object input = "dummyString;";
-        pipe.setMessageIsContent(false);
-        pipe.setCompress(false);
-        pipe.setFileFormat("gz");
+	@Test(expected = PipeRunException.class)
+	public void testResultIsContent() throws Exception {
+		pipe.setMessageIsContent(true);
+		pipe.setResultIsContent(true);
 
-        doPipe(pipe,input, session);
-    }
+		configureAndStartPipe();
+		doPipe(pipe, dummyStringSemiColon, session);
+	}
 
-    @Test(expected = PipeRunException.class)
-    public void testResultIsContent() throws PipeRunException {
-        Object input = "dummyString;";
-        pipe.setMessageIsContent(true);
-        pipe.setResultIsContent(true);
-        doPipe(pipe,input, session);
-    }
+	@Test
+	public void testCompressWithLegitimateFileFormat() throws Exception {
+		pipe.setFileFormat("gz");
+		pipe.setMessageIsContent(true);
+		pipe.setResultIsContent(true);
+		pipe.setCompress(true);
 
-    @Test
-    public void testCompressWithLegitimateFileFormat() throws PipeRunException {
-        Object input = "dummyString;";
-        pipe.setFileFormat("gz");
-        pipe.setMessageIsContent(true);
-        pipe.setResultIsContent(true);
-        pipe.setCompress(true);
-        assertNotNull(doPipe(pipe,input, session));
-    }
+		configureAndStartPipe();
+		assertNotNull(doPipe(pipe, dummyStringSemiColon, session));
+	}
 
-    @Test
-    public void testCompressWithIllegimitateFileFormat() throws PipeRunException {
-        Object input = "dummyString;";
-        pipe.setFileFormat("notNull");
-        pipe.setMessageIsContent(true);
-        pipe.setResultIsContent(true);
-        pipe.setCompress(true);
-        assertTrue(doPipe(pipe,input, session) !=  null); // TODO should assert proper return value
-    }
+	@Test
+	public void testCompressWithIllegimitateFileFormat() throws Exception {
+		pipe.setFileFormat("notNull");
+		pipe.setMessageIsContent(true);
+		pipe.setResultIsContent(true);
+		pipe.setCompress(true);
 
+		configureAndStartPipe();
+		assertNotNull(doPipe(pipe, dummyStringSemiColon, session)); // TODO should assert proper return value
+	}
 
-    @Test
-    public void testUncompressedWithIlligimitateFileFormat() throws PipeRunException {
-        Object input = "dummyString;";
-        pipe.setFileFormat("notNull");
-        pipe.setMessageIsContent(true);
-        pipe.setResultIsContent(true);
-        pipe.setCompress(false);
-        assertTrue(doPipe(pipe,input, session) !=  null); // TODO should assert proper return value
-    }
+	@Test
+	public void testUncompressedWithIlligimitateFileFormat() throws Exception {
+		pipe.setFileFormat("notNull");
+		pipe.setMessageIsContent(true);
+		pipe.setResultIsContent(true);
+		pipe.setCompress(false);
 
-    @Test
-    public void testConvertByteToStringForResultMsg() throws PipeRunException {
-        Object input = "dummyString;";
-        pipe.setFileFormat("notNull");
-        pipe.setMessageIsContent(true);
-        pipe.setResultIsContent(true);
-        pipe.setCompress(false);
-        pipe.setConvert2String(true);
-        assertTrue(doPipe(pipe,input, session) !=  null); // TODO should assert proper return value
-    }
+		configureAndStartPipe();
+		assertNotNull(doPipe(pipe, dummyStringSemiColon, session)); // TODO should assert proper return value
+	}
 
-    @Test(expected = PipeRunException.class)
-    public void testCaptureIllegitimateFilePath() throws PipeRunException {
-        Object input = "dummyString";
-        pipe.setMessageIsContent(false);
-        pipe.setCompress(true);
+	@Test
+	public void testConvertByteToStringForResultMsg() throws Exception {
+		pipe.setFileFormat("notNull");
+		pipe.setMessageIsContent(true);
+		pipe.setResultIsContent(true);
+		pipe.setCompress(false);
+		pipe.setConvert2String(true);
 
-        doPipe(pipe,input, session);
-    }
+		configureAndStartPipe();
+		assertNotNull(doPipe(pipe, dummyStringSemiColon, session)); // TODO should assert proper return value
+	}
 
-    @Test(expected = PipeRunException.class)
-    public void testCaptureIllegitimateByteArray() throws PipeRunException {
-        Object input = "dummyString".getBytes();
-        pipe.setMessageIsContent(true);
-        doPipe(pipe,input, session);
-    }
+	@Test(expected = ConfigurationException.class)
+	public void testCaptureIllegitimateFilePath() throws Exception {
+		pipe.setMessageIsContent(false);
+		pipe.setCompress(true);
 
-    @Test(expected = PipeRunException.class)
-    public void testCaptureUnconvertableArray() throws PipeRunException {
-        Object input = "dummyString";
-        pipe.setMessageIsContent(true);
-        doPipe(pipe,input, session);
-    }
+		configureAndStartPipe();
+		doPipe(pipe, dummyStringSemiColon, session);
+	}
 
+	@Test(expected = PipeRunException.class)
+	public void testCaptureIllegitimateByteArray() throws Exception {
+		Object input = dummyString.getBytes();
+		pipe.setMessageIsContent(true);
+
+		configureAndStartPipe();
+		doPipe(pipe, input, session);
+	}
+
+	@Test(expected = PipeRunException.class)
+	public void testCaptureUnconvertableArray() throws Exception {
+		Object input = dummyString;
+		pipe.setMessageIsContent(true);
+
+		configureAndStartPipe();
+		doPipe(pipe, input, session);
+	}
 }

--- a/example/src/test/java/nl/nn/adapterframework/webcontrol/pipes/IbisConsoleTest.java
+++ b/example/src/test/java/nl/nn/adapterframework/webcontrol/pipes/IbisConsoleTest.java
@@ -57,7 +57,6 @@ public class IbisConsoleTest {
 		ibisTester = new IbisTester();
 		System.setProperty("HelloWorld.job.active", "false");
 		System.setProperty("junit.active", "true");
-		System.setProperty("strutsConsole.enabled", "true"); //Enable the old adapters
 		System.setProperty("configurations.names", "${instance.name},NotExistingConfig");
 
 		ibisTester.initTest();
@@ -84,7 +83,7 @@ public class IbisConsoleTest {
 		ShowConfigurationStatus showConfigurationStatus = new ShowConfigurationStatus();
 		PipeLine pipeLine = new PipeLine();
 		Adapter adapter = (Adapter) ibisContext.getIbisManager().getRegisteredAdapter("WebControlShowConfigurationStatus");
-		assertNotNull("adapter is null", adapter);
+		assertNotNull("adapter is null. registered adapters ["+ibisContext.getIbisManager().getRegisteredAdapters()+"]", adapter);
 		pipeLine.setAdapter(adapter);
 		showConfigurationStatus.registerForward(createPipeSuccessForward());
 		showConfigurationStatus.configure(pipeLine);
@@ -102,7 +101,7 @@ public class IbisConsoleTest {
 		ShowConfigurationStatus showConfigurationStatus = new ShowConfigurationStatus();
 		PipeLine pipeLine = new PipeLine();
 		Adapter adapter = (Adapter) ibisContext.getIbisManager().getRegisteredAdapter("WebControlShowConfigurationStatus");
-		assertNotNull("adapter is null", adapter);
+		assertNotNull("adapter is null. registered adapters ["+ibisContext.getIbisManager().getRegisteredAdapters()+"]", adapter);
 		pipeLine.setAdapter(adapter);
 		showConfigurationStatus.registerForward(createPipeSuccessForward());
 		showConfigurationStatus.configure(pipeLine);
@@ -120,7 +119,7 @@ public class IbisConsoleTest {
 		ShowEnvironmentVariables showEnvironmentVariables = new ShowEnvironmentVariables();
 		PipeLine pipeLine = new PipeLine();
 		Adapter adapter = (Adapter) ibisContext.getIbisManager().getRegisteredAdapter("WebControlShowEnvironmentVariables");
-		assertNotNull("adapter is null", adapter);
+		assertNotNull("adapter is null. registered adapters ["+ibisContext.getIbisManager().getRegisteredAdapters()+"]", adapter);
 		pipeLine.setAdapter(adapter);
 		showEnvironmentVariables.registerForward(createPipeSuccessForward());
 		showEnvironmentVariables.configure(pipeLine);

--- a/example/src/test/java/nl/nn/adapterframework/webcontrol/pipes/IbisConsoleTest.java
+++ b/example/src/test/java/nl/nn/adapterframework/webcontrol/pipes/IbisConsoleTest.java
@@ -3,6 +3,7 @@ package nl.nn.adapterframework.webcontrol.pipes;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assume.assumeTrue;
 
 import java.io.IOException;
 import java.net.URL;
@@ -36,6 +37,8 @@ import nl.nn.adapterframework.util.Misc;
 import nl.nn.adapterframework.util.XmlUtils;
 
 public class IbisConsoleTest {
+	private static boolean TEST_ENABLED = "true".equals(System.getProperty("ibisTester.enabled"));
+
 	private static String SHOW_CONFIGURATION_STATUS_XSLT = "webcontrol/pipes/xsl/ShowConfigurationStatus.xsl";
 	private static String SHOW_ENVIRONMENT_VARIABLES_XSLT = "webcontrol/pipes/xsl/ShowEnvironmentVariables.xsl";
 	private static Transformer showConfigurationStatusTransformer;
@@ -54,6 +57,8 @@ public class IbisConsoleTest {
 
 	@BeforeClass
 	public static void initTest() throws ConfigurationException, TransformerConfigurationException, IOException {
+		assumeTrue(TEST_ENABLED);
+
 		ibisTester = new IbisTester();
 		System.setProperty("HelloWorld.job.active", "false");
 		System.setProperty("junit.active", "true");
@@ -80,6 +85,8 @@ public class IbisConsoleTest {
 
 	@Test
 	public void ShowConfigurationStatus_all() throws ConfigurationException, PipeRunException, DomBuilderException, SAXException, IOException, TransformerException {
+		assumeTrue(TEST_ENABLED);
+
 		ShowConfigurationStatus showConfigurationStatus = new ShowConfigurationStatus();
 		PipeLine pipeLine = new PipeLine();
 		Adapter adapter = (Adapter) ibisContext.getIbisManager().getRegisteredAdapter("WebControlShowConfigurationStatus");
@@ -98,6 +105,8 @@ public class IbisConsoleTest {
 
 	@Test
 	public void ShowConfigurationStatus_single() throws ConfigurationException, PipeRunException, DomBuilderException, SAXException, IOException, TransformerException {
+		assumeTrue(TEST_ENABLED);
+
 		ShowConfigurationStatus showConfigurationStatus = new ShowConfigurationStatus();
 		PipeLine pipeLine = new PipeLine();
 		Adapter adapter = (Adapter) ibisContext.getIbisManager().getRegisteredAdapter("WebControlShowConfigurationStatus");
@@ -116,6 +125,8 @@ public class IbisConsoleTest {
 
 	@Test
 	public void showEnvironmentVariables() throws ConfigurationException, PipeRunException, DomBuilderException, SAXException, IOException, TransformerException {
+		assumeTrue(TEST_ENABLED);
+
 		ShowEnvironmentVariables showEnvironmentVariables = new ShowEnvironmentVariables();
 		PipeLine pipeLine = new PipeLine();
 		Adapter adapter = (Adapter) ibisContext.getIbisManager().getRegisteredAdapter("WebControlShowEnvironmentVariables");

--- a/example/src/test/java/nl/nn/adapterframework/webcontrol/pipes/IbisConsoleTest.java
+++ b/example/src/test/java/nl/nn/adapterframework/webcontrol/pipes/IbisConsoleTest.java
@@ -57,6 +57,7 @@ public class IbisConsoleTest {
 		ibisTester = new IbisTester();
 		System.setProperty("HelloWorld.job.active", "false");
 		System.setProperty("junit.active", "true");
+		System.setProperty("strutsConsole.enabled", "true"); //Enable the old adapters
 		System.setProperty("configurations.names", "${instance.name},NotExistingConfig");
 
 		ibisTester.initTest();

--- a/example/src/test/resources/webcontrol/pipes/ShowConfigurationStatus_all.xml
+++ b/example/src/test/resources/webcontrol/pipes/ShowConfigurationStatus_all.xml
@@ -13,11 +13,11 @@
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Configuration [IAF_Util] startup in 0 ms</configurationMessage>
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Configuration [Ibis4Example] LiquiBase applying change [Ibis4Example:1:Niels Meijer] description [insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE] tag [Ibis4Example:1:Niels Meijer]</configurationMessage>
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Configuration [Ibis4Example] startup in 0 ms</configurationMessage>
-         <configurationMessage date="0000-00-00 00:00:00.000" level="ERROR">Configuration [NotExistingConfig]  exception: error during unmarshalling configuration from file [Configuration.xml] with digester-rules-file [digester-rules.xml] in element []: Configuration file not found: Configuration.xml</configurationMessage>
+         <configurationMessage date="0000-00-00 00:00:00.000" level="ERROR">Configuration [NotExistingConfig]  exception: error during unmarshalling configuration from file [Configuration.xml] in element []: Configuration file not found: Configuration.xml</configurationMessage>
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Application [Ibis4Example] startup in 0 ms</configurationMessage>
       </configurationMessages>
       <exceptions>
-         <exception config="NotExistingConfig">error during unmarshalling configuration from file [Configuration.xml] with digester-rules-file [digester-rules.xml] in element []: Configuration file not found: Configuration.xml</exception>
+         <exception config="NotExistingConfig">error during unmarshalling configuration from file [Configuration.xml] in element []: Configuration file not found: Configuration.xml</exception>
       </exceptions>
       <warnings>
          <warning config="Ibis4Example" severe="true">Errorlog contains 6 records. Service Management should check whether these records have to be resent or deleted</warning>

--- a/example/src/test/resources/webcontrol/pipes/ShowConfigurationStatus_all.xml
+++ b/example/src/test/resources/webcontrol/pipes/ShowConfigurationStatus_all.xml
@@ -13,11 +13,11 @@
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Configuration [IAF_Util] startup in 0 ms</configurationMessage>
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Configuration [Ibis4Example] LiquiBase applying change [Ibis4Example:1:Niels Meijer] description [insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE; insert tableName=IBISSTORE] tag [Ibis4Example:1:Niels Meijer]</configurationMessage>
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Configuration [Ibis4Example] startup in 0 ms</configurationMessage>
-         <configurationMessage date="0000-00-00 00:00:00.000" level="ERROR">Configuration [NotExistingConfig]  exception: error during unmarshalling configuration from file [Configuration.xml] in element []: Configuration file not found: Configuration.xml</configurationMessage>
+         <configurationMessage date="0000-00-00 00:00:00.000" level="ERROR">Configuration [NotExistingConfig]  exception: error during unmarshalling configuration from file [Configuration.xml] with digester-rules-file [digester-rules.xml] in element []: Configuration file not found: Configuration.xml</configurationMessage>
          <configurationMessage date="0000-00-00 00:00:00.000" level="INFO">Application [Ibis4Example] startup in 0 ms</configurationMessage>
       </configurationMessages>
       <exceptions>
-         <exception config="NotExistingConfig">error during unmarshalling configuration from file [Configuration.xml] in element []: Configuration file not found: Configuration.xml</exception>
+         <exception config="NotExistingConfig">error during unmarshalling configuration from file [Configuration.xml] with digester-rules-file [digester-rules.xml] in element []: Configuration file not found: Configuration.xml</exception>
       </exceptions>
       <warnings>
          <warning config="Ibis4Example" severe="true">Errorlog contains 6 records. Service Management should check whether these records have to be resent or deleted</warning>

--- a/test/src/test/testtool/Validators/SoapValidator/scenario08.properties
+++ b/test/src/test/testtool/Validators/SoapValidator/scenario08.properties
@@ -3,8 +3,8 @@ scenario.active=${strutsConsole.enabled}
 
 include = common.properties
 
-step1.api.SoapAndRestWsdlStruts.write = Schema/get-wsdl.txt
-step2.api.SoapAndRestWsdlStruts.read  = Schema/SoapValidator.wsdl
+step1.api.SoapAndRestWsdlStruts.write = ../Schema/get-wsdl.txt
+step2.api.SoapAndRestWsdlStruts.read  = ../Schema/SoapValidator.wsdl
 
 ignoreContentBetweenKeys1.key1=<wsdl:documentation>Generated
 ignoreContentBetweenKeys1.key2=</wsdl:documentation>


### PR DESCRIPTION
I bumped into many issues while trying to parse the old XML digester rules file. It turns out that since version 2 most classes have become either package private or final so it's near impossible to extend. The DTD supplied by the dependency is also out of date creating inconsistent xml parsing/validating problems. Many bugs have been reported but since 2013 there has been no development activity. See: [DigesterRuleParser](https://issues.apache.org/jira/browse/DIGESTER-168), [properties-rule](https://user.commons.apache.narkive.com/QeKWeYQo/digester-xml-rules-set-properties-rule-and-ignoring-missing-properties),  [and dtd inconsistencies](https://stackoverflow.com/questions/11169761/when-using-commons-digester-xml-rules-how-do-i-exclude-some-attributes-of-the-x).
