### PR TITLE
fix test scenarios to create required folder automatically

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
@@ -121,10 +121,10 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 				throw new ConfigurationException("property fxf.dir has not been initialised");
 			}
 			if(isCreateFolder() && !new File(fxfDir).exists() && !new File(fxfDir).mkdirs()) {
-				throw new ConfigurationException("cannot create fxf.dir in the path ['" + fxfDir + "]'");
+				throw new ConfigurationException(" Cannot create fxf.dir in the path '" + fxfDir + "'");
 			}
 			if(!new File(fxfDir).isDirectory()) {
-				throw new ConfigurationException("fxf.dir ['" + fxfDir + "'] doesn't exist or is not a directory");
+				throw new ConfigurationException("fxf.dir '" + fxfDir + "' doesn't exist or is not a directory");
 			}
 			transferFlowIdTp = XmlUtils.getXPathTransformerPool(null, "/OnCompletedTransferNotify_Action/TransferFlowId", "text", false, getParameterList());
 			clientFilenameTp = XmlUtils.getXPathTransformerPool(null, "/OnCompletedTransferNotify_Action/ClientFilename", "text", false, getParameterList());

--- a/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
@@ -120,10 +120,8 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 			if (fxfDir == null) {
 				throw new ConfigurationException("property fxf.dir has not been initialised");
 			}
-			if(isCreateFolder() && !new File(fxfDir).exists()) {
-				if(!new File(fxfDir).mkdirs()) {
-					throw new ConfigurationException(" Cannot create fxf.dir in the path '" + fxfDir + "'");
-				}
+			if(isCreateFolder() && !new File(fxfDir).exists() && !new File(fxfDir).mkdirs()) {
+				throw new ConfigurationException(" Cannot create fxf.dir in the path '" + fxfDir + "'");
 			}
 			if(!new File(fxfDir).isDirectory()) {
 				throw new ConfigurationException("fxf.dir '" + fxfDir + "' doesn't exist or is not a directory");
@@ -314,11 +312,11 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 		return fxfVersion;
 	}
 
-	public boolean isCreateFolder() {
-		return createFolder;
-	}
 	@IbisDoc({"when set to <code>true</code>, the folder corresponding fxf.dir property will be created in case it does not exist", "false"})
 	public void setCreateFolder(boolean createFolder) {
 		this.createFolder = createFolder;
+	}
+	public boolean isCreateFolder() {
+		return createFolder;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
@@ -121,10 +121,10 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 				throw new ConfigurationException("property fxf.dir has not been initialised");
 			}
 			if(isCreateFolder() && !new File(fxfDir).exists() && !new File(fxfDir).mkdirs()) {
-				throw new ConfigurationException(" Cannot create fxf.dir in the path '" + fxfDir + "'");
+				throw new ConfigurationException("cannot create fxf.dir in the path [" + fxfDir + "]");
 			}
 			if(!new File(fxfDir).isDirectory()) {
-				throw new ConfigurationException("fxf.dir '" + fxfDir + "' doesn't exist or is not a directory");
+				throw new ConfigurationException("fxf.dir [" + fxfDir + "] doesn't exist or is not a directory");
 			}
 			transferFlowIdTp = XmlUtils.getXPathTransformerPool(null, "/OnCompletedTransferNotify_Action/TransferFlowId", "text", false, getParameterList());
 			clientFilenameTp = XmlUtils.getXPathTransformerPool(null, "/OnCompletedTransferNotify_Action/ClientFilename", "text", false, getParameterList());

--- a/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2016, 2020 Nationale-Nederlanden
+   Copyright 2013, 2016, 2020 Nationale-Nederlanden, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import nl.nn.adapterframework.core.IPipeLineSession;
 import nl.nn.adapterframework.core.PipeRunException;
 import nl.nn.adapterframework.core.PipeRunResult;
 import nl.nn.adapterframework.core.PipeStartException;
+import nl.nn.adapterframework.doc.IbisDoc;
 import nl.nn.adapterframework.extensions.esb.EsbSoapWrapperPipe;
 import nl.nn.adapterframework.parameters.Parameter;
 import nl.nn.adapterframework.parameters.ParameterList;
@@ -74,6 +75,7 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 	private String flowIdSessionKey = "flowId";
 	private String fxfDirSessionKey = "fxfDir";
 	private String fxfFileSessionKey = "fxfFile";
+	private boolean createFolder = false;
 
 
 	@Override
@@ -117,7 +119,13 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 			fxfDir = AppConstants.getInstance(getConfigurationClassLoader()).getResolvedProperty("fxf.dir");
 			if (fxfDir == null) {
 				throw new ConfigurationException("property fxf.dir has not been initialised");
-			} else if (!new File(fxfDir).isDirectory()) {
+			}
+			if(isCreateFolder() && !new File(fxfDir).exists()) {
+				if(!new File(fxfDir).mkdirs()) {
+					throw new ConfigurationException(" Cannot create fxf.dir in the path '" + fxfDir + "'");
+				}
+			}
+			if(!new File(fxfDir).isDirectory()) {
 				throw new ConfigurationException("fxf.dir '" + fxfDir + "' doesn't exist or is not a directory");
 			}
 			transferFlowIdTp = XmlUtils.getXPathTransformerPool(null, "/OnCompletedTransferNotify_Action/TransferFlowId", "text", false, getParameterList());
@@ -304,5 +312,13 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 
 	public String getFxfVersion() {
 		return fxfVersion;
+	}
+
+	public boolean isCreateFolder() {
+		return createFolder;
+	}
+	@IbisDoc({"when set to <code>true</code>, the folder corresponding fxf.dir property will be created in case it does not exist", "false"})
+	public void setCreateFolder(boolean createFolder) {
+		this.createFolder = createFolder;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/fxf/FxfWrapperPipe.java
@@ -121,10 +121,10 @@ public class FxfWrapperPipe extends EsbSoapWrapperPipe {
 				throw new ConfigurationException("property fxf.dir has not been initialised");
 			}
 			if(isCreateFolder() && !new File(fxfDir).exists() && !new File(fxfDir).mkdirs()) {
-				throw new ConfigurationException(" Cannot create fxf.dir in the path '" + fxfDir + "'");
+				throw new ConfigurationException("cannot create fxf.dir in the path ['" + fxfDir + "]'");
 			}
 			if(!new File(fxfDir).isDirectory()) {
-				throw new ConfigurationException("fxf.dir '" + fxfDir + "' doesn't exist or is not a directory");
+				throw new ConfigurationException("fxf.dir ['" + fxfDir + "'] doesn't exist or is not a directory");
 			}
 			transferFlowIdTp = XmlUtils.getXPathTransformerPool(null, "/OnCompletedTransferNotify_Action/TransferFlowId", "text", false, getParameterList());
 			clientFilenameTp = XmlUtils.getXPathTransformerPool(null, "/OnCompletedTransferNotify_Action/ClientFilename", "text", false, getParameterList());

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
@@ -206,7 +206,7 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 	}
 
 	public void open() throws FileSystemException {
-		if (StringUtils.isNotEmpty(getInputFolder()) && !fileSystem.folderExists(getInputFolder())) {
+		if (StringUtils.isNotEmpty(getInputFolder()) && !fileSystem.folderExists(getInputFolder()) && !getAction().equals(ACTION_MKDIR)) {
 			if (isCreateFolder()) {
 				log.debug("creating inputFolder ["+getInputFolder()+"]");
 				fileSystem.createFolder(getInputFolder());

--- a/core/src/main/java/nl/nn/adapterframework/pipes/UnzipPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/UnzipPipe.java
@@ -36,6 +36,7 @@ import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang.StringUtils;
 
 import nl.nn.adapterframework.configuration.ConfigurationException;
+import nl.nn.adapterframework.configuration.ConfigurationWarning;
 import nl.nn.adapterframework.core.IPipeLineSession;
 import nl.nn.adapterframework.core.PipeRunException;
 import nl.nn.adapterframework.core.PipeRunResult;
@@ -339,10 +340,16 @@ public class UnzipPipe extends FixedForwardPipe {
 	}
 
 	@IbisDoc({"if set <code>true</code>, validation of directory is ignored", "false"})
+	public void setAssumeDirectoryExists(boolean assumeDirectoryExists) {
+		this.assumeDirectoryExists = assumeDirectoryExists;
+	}
 	public boolean isAssumeDirectoryExists() {
 		return assumeDirectoryExists;
 	}
-	public void setAssumeDirectoryExists(boolean assumeDirectoryExists) {
-		this.assumeDirectoryExists = assumeDirectoryExists;
+
+	@Deprecated
+	@ConfigurationWarning("the attribute 'checkDirectory' has been renamed to 'assumeDirectoryExists'")
+	public void setCheckDirectory(boolean checkDirectory) {
+		this.assumeDirectoryExists = checkDirectory;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/pipes/UnzipPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/UnzipPipe.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013, 2020 Nationale-Nederlanden
+   Copyright 2013 Nationale-Nederlanden, 2020 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -104,7 +104,7 @@ public class UnzipPipe extends FixedForwardPipe {
 	private File dir; // File representation of directory
 	private List<String> base64Extensions;
 
-	private boolean checkDirectory=false;
+	private boolean assumeDirectoryExists=false;
 
 	@Override
 	public void configure() throws ConfigurationException {
@@ -115,7 +115,7 @@ public class UnzipPipe extends FixedForwardPipe {
 			}
 		} else {
 			dir = new File(getDirectory());
-			if(!isCheckDirectory()) {
+			if(!isAssumeDirectoryExists()) {
 				if (!dir.exists()) {
 					throw new ConfigurationException(getLogPrefix(null)+"directory ["+getDirectory()+"] does not exist");
 				}
@@ -281,7 +281,7 @@ public class UnzipPipe extends FixedForwardPipe {
 	public String getDirectory() {
 		return directory;
 	}
-	
+
 	@IbisDoc({"sessionkey with a directory value to extract the archive to", ""})
 	public void setDirectorySessionKey(String directorySessionKey) {
 		this.directorySessionKey = directorySessionKey;
@@ -289,7 +289,7 @@ public class UnzipPipe extends FixedForwardPipe {
 	public String getDirectorySessionKey() {
 		return directorySessionKey;
 	}
-	
+
 	@IbisDoc({"when true, file is automatically deleted upon normal jvm termination", "true"})
 	public void setDeleteOnExit(boolean b) {
 		deleteOnExit = b;
@@ -337,14 +337,12 @@ public class UnzipPipe extends FixedForwardPipe {
 	public boolean isCreateSubdirectories() {
 		return createSubdirectories;
 	}
-	
-	@IbisDoc({"if set <code>true</code>, validation on directory is ignored", "false"})
-	public boolean isCheckDirectory()
-	{
-		return checkDirectory;
+
+	@IbisDoc({"if set <code>true</code>, validation of directory is ignored", "false"})
+	public boolean isAssumeDirectoryExists() {
+		return assumeDirectoryExists;
 	}
-	public void setCheckDirectory(boolean checkDirectory)
-	{
-		this.checkDirectory = checkDirectory;
+	public void setAssumeDirectoryExists(boolean assumeDirectoryExists) {
+		this.assumeDirectoryExists = assumeDirectoryExists;
 	}
 }

--- a/test/src/main/configurations/MainConfig/ConfigurationFxF3.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationFxF3.xml
@@ -12,7 +12,7 @@
 				className="nl.nn.adapterframework.extensions.fxf.FxfXmlValidator"
 				direction="receive" />
 			<inputWrapper className="nl.nn.adapterframework.extensions.fxf.FxfWrapperPipe"
-				direction="unwrap" />
+				direction="unwrap" createFolder="true"/>
 			<pipe name="EchoPipe" className="nl.nn.adapterframework.pipes.EchoPipe" />
 		</pipeline>
 	</adapter>
@@ -29,7 +29,7 @@
 			<pipe name="EchoSender"
 				className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe">
 				<inputWrapper className="nl.nn.adapterframework.extensions.fxf.FxfWrapperPipe"
-					flowId="NNX01234" />
+					flowId="NNX01234" createFolder="true"/>
 				<inputValidator
 					className="nl.nn.adapterframework.extensions.fxf.FxfXmlValidator" />
 				<sender className="nl.nn.adapterframework.senders.EchoSender" />
@@ -50,7 +50,7 @@
 			<pipe name="EchoSender"
 				className="nl.nn.adapterframework.pipes.GenericMessageSendingPipe">
 				<inputWrapper className="nl.nn.adapterframework.extensions.fxf.FxfWrapperPipe"
-					flowId="NNX01234" fxfVersion="3.2" cmhVersion="2" />
+					flowId="NNX01234" fxfVersion="3.2" cmhVersion="2" createFolder="true"/>
 				<inputValidator
 					className="nl.nn.adapterframework.extensions.fxf.FxfXmlValidator"
 					fxfVersion="3.2" />

--- a/test/src/main/configurations/MainConfig/ConfigurationUnzip.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationUnzip.xml
@@ -6,9 +6,16 @@
 			serviceName="ibis4test-ZipFilePathListener" />
 	</Receiver>
 
-	<Pipeline firstPipe="unzipFile">
+	<Pipeline firstPipe="createOutputFolder">
 
-		<UnzipPipe name="unzipFile"
+		<LocalFileSystemPipe 
+			name="createOutputFolder" 
+			action="list"
+			createFolder="true"
+			inputFolder="${testdata.dir}/unzip/"
+		/>
+		
+		<UnzipPipe name="unzipFile" assumeDirectoryExists="true"
 			directory="${testdata.dir}/unzip/" getInputFromSessionKey="stream">
 
 			<Forward name="success" path="EXIT" />

--- a/test/src/main/configurations/MainConfig/ConfigurationUnzip.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationUnzip.xml
@@ -6,7 +6,7 @@
 			serviceName="ibis4test-ZipFilePathListener" />
 	</Receiver>
 
-	<Pipeline firstPipe="createOutputFolder">
+	<Pipeline>
 
 		<LocalFileSystemPipe 
 			name="createOutputFolder" 

--- a/test/src/main/configurations/MainConfig/ConfigurationZip.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationZip.xml
@@ -22,7 +22,7 @@
 				name="UnZip"
 				className="nl.nn.adapterframework.pipes.UnzipPipe" 
 				directory="${testdata.dir}/zip"
-				checkDirectory="true"
+				assumeDirectoryExists="true"
 				>
 				<forward name="success" path="READY"/>
 			</pipe>


### PR DESCRIPTION
- rename checkDirectory to assumeDirectoryExists in UnzipPipe
- Introduce a createFolder attribute in FxfWrapperPipe to create the fxf.dir folder in case it does not exists
- fix unzip exception forward test scenario to create unzip folder at the beginning
Fixes #1065 