### PR TITLE
Add pipeline message and execute query to Security Log

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ExecuteJdbcQuery.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ExecuteJdbcQuery.java
@@ -22,6 +22,7 @@ import nl.nn.adapterframework.jdbc.transformer.QueryOutputToJson;
 import nl.nn.adapterframework.jms.JmsRealm;
 import nl.nn.adapterframework.jms.JmsRealmFactory;
 import nl.nn.adapterframework.stream.Message;
+import nl.nn.adapterframework.util.LogUtil;
 
 import javax.annotation.security.RolesAllowed;
 import javax.ws.rs.Consumes;
@@ -33,6 +34,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -52,6 +54,7 @@ import java.util.Map.Entry;
 public final class ExecuteJdbcQuery extends Base {
 
 	public static final String DBXML2CSV_XSLT="xml/xsl/dbxml2csv.xslt";
+	private Logger secLog = LogUtil.getLogger("SEC");
 
 	@GET
 	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})
@@ -139,6 +142,8 @@ public final class ExecuteJdbcQuery extends Base {
 		if(datasource == null || resultType == null || query == null) {
 			throw new ApiException("Missing data, datasource, resultType and query are expected.", 400);
 		}
+
+		secLog.info(String.format("executing query [%s] on datasource [%s] queryType [%s] avoidLocking [%s]", query, datasource, queryType, avoidLocking));
 
 		//We have all info we need, lets execute the query!
 		DirectQuerySender qs;

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ServletDispatcher.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ServletDispatcher.java
@@ -15,7 +15,6 @@ limitations under the License.
 */
 package nl.nn.adapterframework.webcontrol.api;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -28,6 +27,7 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.Bus;
 import org.apache.cxf.transport.servlet.CXFServlet;
 import org.apache.logging.log4j.Logger;
@@ -51,20 +51,19 @@ import nl.nn.adapterframework.util.LogUtil;
 @IbisInitializer
 public class ServletDispatcher extends CXFServlet implements DynamicRegistration.ServletWithParameters {
 
-	private static final long serialVersionUID = 2L;
+	private static final long serialVersionUID = 3L;
 
 	private Logger secLog = LogUtil.getLogger("SEC");
 	private Logger log = LogUtil.getLogger(this);
-	private AppConstants appConstants = AppConstants.getInstance();
+	private static final AppConstants APP_CONSTANTS = AppConstants.getInstance();
 
-	private final boolean IAF_API_ENABLED = appConstants.getBoolean("iaf-api.enabled", true);
-	private final String CORS_ALLOW_ORIGIN = appConstants.getString("iaf-api.cors.allowOrigin", ""); //Defaults to nothing
-	private final String CORS_EXPOSE_HEADERS = appConstants.getString("iaf-api.cors.exposeHeaders", "Allow, ETag, Content-Disposition");
+	private static final boolean IAF_API_ENABLED = APP_CONSTANTS.getBoolean("iaf-api.enabled", true);
+	private static final String CORS_ALLOW_ORIGIN = APP_CONSTANTS.getString("iaf-api.cors.allowOrigin", ""); //Defaults to nothing
+	private static final String CORS_EXPOSE_HEADERS = APP_CONSTANTS.getString("iaf-api.cors.exposeHeaders", "Allow, ETag, Content-Disposition");
 	//TODO: Maybe filter out the methods that are not present on the resource? Till then allow all methods
-	private final String CORS_ALLOW_METHODS = appConstants.getString("iaf-api.cors.allowMethods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
+	private static final String CORS_ALLOW_METHODS = APP_CONSTANTS.getString("iaf-api.cors.allowMethods", "GET, POST, PUT, DELETE, OPTIONS, HEAD");
 
 	private List<String> allowedCorsDomains =  new ArrayList<String>();
-	private String mappingPrefix = "";
 
 	@Override
 	public void init(ServletConfig servletConfig) throws ServletException {
@@ -105,8 +104,9 @@ public class ServletDispatcher extends CXFServlet implements DynamicRegistration
 		/**
 		 * Log POST, PUT and DELETE requests
 		 */
-		if(!method.equalsIgnoreCase("GET") && !method.equalsIgnoreCase("OPTIONS"))
+		if(!method.equalsIgnoreCase("GET") && !method.equalsIgnoreCase("OPTIONS")) {
 			secLog.info(HttpUtils.getExtendedCommandIssuedBy(request));
+		}
 
 		/**
 		 * Handle Cross-Origin Resource Sharing
@@ -137,7 +137,7 @@ public class ServletDispatcher extends CXFServlet implements DynamicRegistration
 			}
 			else {
 				//If origin has been set, but has not been whitelisted, report the request in security log.
-				secLog.info("host["+request.getRemoteHost()+"] tried to access uri["+mappingPrefix+request.getPathInfo()+"] with origin["+origin+"] but was blocked due to CORS restrictions");
+				secLog.info("host["+request.getRemoteHost()+"] tried to access uri["+request.getPathInfo()+"] with origin["+origin+"] but was blocked due to CORS restrictions");
 			}
 			//If we pass one of the valid domains, it can be used to spoof the connection
 		}

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ServletDispatcher.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ServletDispatcher.java
@@ -27,7 +27,6 @@ import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.commons.lang.StringUtils;
 import org.apache.cxf.Bus;
 import org.apache.cxf.transport.servlet.CXFServlet;
 import org.apache.logging.log4j.Logger;

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/TestPipeline.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/TestPipeline.java
@@ -25,12 +25,10 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
 import javax.annotation.security.RolesAllowed;
-import javax.servlet.ServletConfig;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
-import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -59,10 +57,8 @@ import nl.nn.adapterframework.util.XmlUtils;
 
 @Path("/")
 public final class TestPipeline extends Base {
-	@Context ServletConfig servletConfig;
 
 	protected Logger secLog = LogUtil.getLogger("SEC");
-
 	private boolean secLogMessage = AppConstants.getInstance().getBoolean("sec.log.includeMessage", false);
 
 	@POST
@@ -72,7 +68,7 @@ public final class TestPipeline extends Base {
 	@Produces(MediaType.APPLICATION_JSON)
 	@Consumes(MediaType.MULTIPART_FORM_DATA)
 	public Response postTestPipeLine(MultipartBody inputDataMap) throws ApiException {
-		Map<String, Object> result = new HashMap<String, Object>();
+		Map<String, Object> result = new HashMap<>();
 
 		IbisManager ibisManager = getIbisManager();
 		if (ibisManager == null) {
@@ -185,9 +181,9 @@ public final class TestPipeline extends Base {
 		}
 		Date now = new Date();
 		PipeLineSessionBase.setListenerParameters(pls, messageId, technicalCorrelationId, now, now);
-		if (writeSecLogMessage) {
-			secLog.info("message [" + message + "]");
-		}
+
+		secLog.info(String.format("testing pipeline of adapter [%s] %s", adapter.getName(), (writeSecLogMessage ? "message [" + message + "]" : "")));
+
 		return adapter.processMessage(messageId, new Message(message), pls);
 	}
 }


### PR DESCRIPTION
```
2020-10-26 17:14:38,231 [http-nio-80-exec-2] requestUri [/iaf/api/jdbc/query] params [] method [POST] remoteHost [0:0:0:0:0:0:0:1] remoteAddress [0:0:0:0:0:0:0:1] remoteUser [null]
2020-10-26 17:14:38,262 [http-nio-80-exec-2] executing query [select * from ibisstore] on datasource [jdbc/ibis4test-oracle-docker] queryType [select] avoidLocking [false]
```

```
2020-10-26 17:23:05,735 [http-nio-80-exec-9] requestUri [/iaf/api/test-pipeline] params [] method [POST] remoteHost [0:0:0:0:0:0:0:1] remoteAddress [0:0:0:0:0:0:0:1] remoteUser [null]
2020-10-26 17:23:05,801 [http-nio-80-exec-9] testing pipeline of adapter [ApiListener_SimpleInsert]
```