### PR TITLE
Show a warning for transaction timeout

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/core/PipeLine.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeLine.java
@@ -334,12 +334,9 @@ public class PipeLine implements ICacheEnabled<String,String>, HasStatistics {
 		requestSizeStats = new SizeStatisticsKeeper("- pipeline in");
 
 		if (isTransacted() && getTransactionTimeout()>0) {
-			String systemTransactionTimeout = Misc.getSystemTransactionTimeout();
-			if (systemTransactionTimeout!=null && StringUtils.isNumeric(systemTransactionTimeout)) {
-				int stt = Integer.parseInt(systemTransactionTimeout);
-				if (getTransactionTimeout()>stt) {
-					ConfigurationWarnings.add(null, log, getLogPrefix()+"has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the system transaction timeout ["+stt+"]");
-				}
+			Integer maximumTransactionTimeout = Misc.getMaximumTransactionTimeout();
+			if (maximumTransactionTimeout != null && getTransactionTimeout() > maximumTransactionTimeout) {
+				ConfigurationWarnings.add(null, log, getLogPrefix()+"has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the maximum transaction timeout ["+maximumTransactionTimeout+"]");
 			}
 		}
 

--- a/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
@@ -700,13 +700,6 @@ public class Receiver<M> implements IManagable, IReceiverStatistics, IMessageHan
 					if (maximumTransactionTimeout != null && getTransactionTimeout() > maximumTransactionTimeout) {
 						ConfigurationWarnings.add(null, log, getLogPrefix()+"has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the maximum transaction timeout ["+maximumTransactionTimeout+"]");
 					}
-					String maximumTransactionTimeout = Misc.getMaximumTransactionTimeout();
-					if (maximumTransactionTimeout!=null && StringUtils.isNumeric(maximumTransactionTimeout)) {
-						int mtt = Integer.parseInt(maximumTransactionTimeout);
-						if (getTransactionTimeout()>mtt) {
-							ConfigurationWarnings.add(this, log, "has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the maximum transaction timeout ["+mtt+"]");
-						}
-					}
 				}
 			}
 

--- a/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
@@ -703,8 +703,15 @@ public class Receiver<M> implements IManagable, IReceiverStatistics, IMessageHan
 							ConfigurationWarnings.add(this, log, "has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the system transaction timeout ["+stt+"]");
 						}
 					}
+					String maximumTransactionTimeout = Misc.getMaximumTransactionTimeout();
+					if (maximumTransactionTimeout!=null && StringUtils.isNumeric(maximumTransactionTimeout)) {
+						int mtt = Integer.parseInt(maximumTransactionTimeout);
+						if (getTransactionTimeout()>mtt) {
+							ConfigurationWarnings.add(this, log, "has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the maximum transaction timeout ["+mtt+"]");
+						}
+					}
 				}
-			} 
+			}
 
 			if (StringUtils.isNotEmpty(getCorrelationIDXPath()) || StringUtils.isNotEmpty(getCorrelationIDStyleSheet())) {
 				correlationIDTp=TransformerPool.configureTransformer0(getLogPrefix(), configurationClassLoader, getCorrelationIDNamespaceDefs(), getCorrelationIDXPath(), getCorrelationIDStyleSheet(),"text",false,null,0);

--- a/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
@@ -696,12 +696,9 @@ public class Receiver<M> implements IManagable, IReceiverStatistics, IMessageHan
 				}
 
 				if (getTransactionTimeout()>0) {
-					String systemTransactionTimeout = Misc.getSystemTransactionTimeout();
-					if (systemTransactionTimeout!=null && StringUtils.isNumeric(systemTransactionTimeout)) {
-						int stt = Integer.parseInt(systemTransactionTimeout);
-						if (getTransactionTimeout()>stt) {
-							ConfigurationWarnings.add(this, log, "has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the system transaction timeout ["+stt+"]");
-						}
+					Integer maximumTransactionTimeout = Misc.getMaximumTransactionTimeout();
+					if (maximumTransactionTimeout != null && getTransactionTimeout() > maximumTransactionTimeout) {
+						ConfigurationWarnings.add(null, log, getLogPrefix()+"has a transaction timeout ["+getTransactionTimeout()+"] which exceeds the maximum transaction timeout ["+maximumTransactionTimeout+"]");
 					}
 					String maximumTransactionTimeout = Misc.getMaximumTransactionTimeout();
 					if (maximumTransactionTimeout!=null && StringUtils.isNumeric(maximumTransactionTimeout)) {

--- a/core/src/main/java/nl/nn/adapterframework/util/Misc.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/Misc.java
@@ -18,9 +18,6 @@ package nl.nn.adapterframework.util;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.time.DurationFormatUtils;
 import org.apache.logging.log4j.Logger;
-import org.xml.sax.SAXException;
-
-import javax.xml.transform.TransformerException;
 import java.io.*;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -1088,78 +1085,62 @@ public class Misc {
 		}
 	}
 
-	public static String getTotalTransactionLifetimeTimeout() throws IOException, SAXException, TransformerException {
-		String confSrvString = getConfigurationServer();
-		if (confSrvString==null) {
-			return null;
-		}
-		return getTotalTransactionLifetimeTimeout(confSrvString);
-	}
-
-	public static String getTotalTransactionLifetimeTimeout(String configServerXml) throws IOException, SAXException, TransformerException {
-		if (configServerXml==null) {
-			return null;
-		}
-		String confSrvString = XmlUtils.removeNamespaces(configServerXml);
-		confSrvString = XmlUtils.removeNamespaces(confSrvString);
-		String xPath = "Server/components/services/@totalTranLifetimeTimeout";
-		TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(xPath));
-		return tp.transform(confSrvString, null);
-	}
-
-	public static String getMaximumTransactionTimeout() throws IOException, SAXException, TransformerException {
-		String confSrvString = getConfigurationServer();
-		if (confSrvString==null) {
-			return null;
-		}
-		return getMaximumTransactionTimeout(confSrvString);
-	}
-
-	public static String getMaximumTransactionTimeout(String configServerXml) throws IOException, SAXException, TransformerException {
-		if (configServerXml==null) {
-			return null;
-		}
-		String confSrvString = XmlUtils.removeNamespaces(configServerXml);
-		confSrvString = XmlUtils.removeNamespaces(confSrvString);
-		String xPath = "Server/components/services/@propogatedOrBMTTranLifetimeTimeout";
-		TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(xPath));
-		return tp.transform(confSrvString, null);
-	}
-
-	public static String getSystemTransactionTimeout() {
+	public static Integer getTotalTransactionLifetimeTimeout() {
 		String confSrvString = null;
 		try {
 			confSrvString = getConfigurationServer();
 		} catch (Exception e) {
 			log.warn("Exception getting configurationServer",e);
 		}
-		if (confSrvString==null) {
+		return getTotalTransactionLifetimeTimeout(confSrvString);
+	}
+
+	public static Integer getTotalTransactionLifetimeTimeout(String configServerXml){
+		if (configServerXml==null) {
 			return null;
 		}
-		String totalTransactionLifetimeTimeout = null;
-		String maximumTransactionTimeout = null;
 		try {
-			totalTransactionLifetimeTimeout = Misc.getTotalTransactionLifetimeTimeout(confSrvString);
-		} catch (Exception e) {
+			String confSrvString = XmlUtils.removeNamespaces(configServerXml);
+			confSrvString = XmlUtils.removeNamespaces(confSrvString);
+			String xPath = "Server/components/services/@totalTranLifetimeTimeout";
+			TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(xPath));
+			String ttlt = tp.transform(confSrvString, null);
+			if(ttlt != null) {
+				return Integer.valueOf(ttlt);
+			}
+		} catch(Exception e) {
 			log.warn("Exception getting totalTransactionLifetimeTimeout",e);
 		}
+		return null;
+	}
+
+	public static Integer getMaximumTransactionTimeout() {
+		String confSrvString = null;
 		try {
-			maximumTransactionTimeout = Misc.getMaximumTransactionTimeout(confSrvString);
+			confSrvString = getConfigurationServer();
 		} catch (Exception e) {
+			log.warn("Exception getting configurationServer",e);
+		}
+		return getMaximumTransactionTimeout(confSrvString);
+	}
+
+	public static Integer getMaximumTransactionTimeout(String configServerXml) {
+		if (configServerXml==null) {
+			return null;
+		}
+		try {
+			String confSrvString = XmlUtils.removeNamespaces(configServerXml);
+			confSrvString = XmlUtils.removeNamespaces(confSrvString);
+			String xPath = "Server/components/services/@propogatedOrBMTTranLifetimeTimeout";
+			TransformerPool tp = TransformerPool.getInstance(XmlUtils.createXPathEvaluatorSource(xPath));
+			String mtt = tp.transform(confSrvString, null);
+			if(StringUtils.isNotEmpty(mtt)) {
+				return Integer.valueOf(mtt);
+			}
+		} catch(Exception e) {
 			log.warn("Exception getting maximumTransactionTimeout",e);
 		}
-		if (totalTransactionLifetimeTimeout==null || maximumTransactionTimeout==null) {
-			return null;
-		} else {
-			if (StringUtils.isNumeric(totalTransactionLifetimeTimeout) && StringUtils.isNumeric(maximumTransactionTimeout)) {
-				int ttlf = Integer.parseInt(totalTransactionLifetimeTimeout);
-				int mtt = Integer.parseInt(maximumTransactionTimeout);
-				int stt = Math.min(ttlf, mtt);
-				return String.valueOf(stt);
-			} else {
-				return null;
-			}
-		}
+		return null;
 	}
 
 	public static String getAge(long value) {

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/action/ShowSecurityItems.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/action/ShowSecurityItems.java
@@ -654,12 +654,10 @@ public final class ShowSecurityItems extends ActionBase {
 			} else {
 				XmlBuilder transactionService = new XmlBuilder("transactionService");
 				serverProps.addSubElement(transactionService);
-				String totalTransactionLifetimeTimeout = Misc.getTotalTransactionLifetimeTimeout(confSrvString);
-				transactionService.addAttribute("totalTransactionLifetimeTimeout", totalTransactionLifetimeTimeout);
-				String maximumTransactionTimeout = Misc.getMaximumTransactionTimeout(confSrvString);
-				transactionService.addAttribute("maximumTransactionTimeout", maximumTransactionTimeout);
+				transactionService.addAttribute("totalTransactionLifetimeTimeout", Misc.getTotalTransactionLifetimeTimeout(confSrvString));
+				transactionService.addAttribute("maximumTransactionTimeout", Misc.getMaximumTransactionTimeout(confSrvString));
 			}
-		} catch (Exception e) {
+		} catch (IOException e) {
 			log.warn("error retrieving configuration server properties", e);
 			serverProps.addAttribute("error", "true");
 			serverProps.setCdataValue(e.getMessage());

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ShowSecurityItems.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ShowSecurityItems.java
@@ -360,23 +360,19 @@ public final class ShowSecurityItems extends Base {
 	private Map<String, Object> addServerProps() {
 		Map<String, Object> serverProps = new HashMap<String, Object>(2);
 
-		String totalTransactionLifetimeTimeout;
-		try {
-			totalTransactionLifetimeTimeout = Misc.getTotalTransactionLifetimeTimeout();
-		} catch (Exception e) {
-			totalTransactionLifetimeTimeout = "*** ERROR ***";
+		Integer totalTransactionLifetimeTimeout = Misc.getTotalTransactionLifetimeTimeout();
+		if(totalTransactionLifetimeTimeout == null) {
+			serverProps.put("totalTransactionLifetimeTimeout", "-");
+		} else {
+			serverProps.put("totalTransactionLifetimeTimeout", totalTransactionLifetimeTimeout);
 		}
-		if(totalTransactionLifetimeTimeout == null) totalTransactionLifetimeTimeout = "-";
 
-		serverProps.put("totalTransactionLifetimeTimeout", totalTransactionLifetimeTimeout);
-		String maximumTransactionTimeout;
-		try {
-			maximumTransactionTimeout = Misc.getMaximumTransactionTimeout();
-		} catch (Exception e) {
-			maximumTransactionTimeout = "*** ERROR ***";
+		Integer maximumTransactionTimeout = Misc.getMaximumTransactionTimeout();
+		if(maximumTransactionTimeout == null) {
+			serverProps.put("maximumTransactionTimeout", "-");
+		} else {
+			serverProps.put("maximumTransactionTimeout", maximumTransactionTimeout);
 		}
-		if(maximumTransactionTimeout == null) maximumTransactionTimeout = "-";
-		serverProps.put("maximumTransactionTimeout", maximumTransactionTimeout);
 		return serverProps;
 	}
 }

--- a/webapp/src/main/webapp/iaf/gui/views/ShowSecurityItems.html
+++ b/webapp/src/main/webapp/iaf/gui/views/ShowSecurityItems.html
@@ -38,11 +38,13 @@
 						<table class="table">
 							<tbody>
 								<tr>
-									<td>Total transaction lifetime timeout (in seconds)</td>
+									<td title="The default maximum time allowed for a transaction that is started on this server before the transaction service initiates timeout completion. Any transaction that does not begin completion processing before this timeout occurs is rolled back. This timeout is used only if the application component does not set its own transaction timeout. The upper-limit of this timeout is constrained by the maximum transaction timeout. For example, if you set a value of 500 for the total transaction lifetime timeout, and a value of 300 for the maximum transaction timeout, transactions will time out after 300 seconds."
+										>Total transaction lifetime timeout (in seconds)</td>
 									<td>{{serverProps.totalTransactionLifetimeTimeout}}</td>
 								</tr>
 								<tr>
-									<td>Maximum transaction timeout (in seconds)</td>
+									<td title="Specifies the upper limit of the transaction timeout for transactions that run in this server. This value should be greater than or equal to the total transaction lifetime timeout and greater than or equal to the application component timeout. If the maximum transaction timeout is set to a value less than either the total transaction lifetime timeout or the application component timeout, application component transactions that may require more time will timeout when the maximum transaction timeout is reached."
+										>Maximum transaction timeout (in seconds)</td>
 									<td>{{serverProps.maximumTransactionTimeout}}</td>
 								</tr>
 							</tbody>


### PR DESCRIPTION
In case the transaction timeout is greater than the maximum transaction timeout, will add a configuration warning to be shown in the console