### PR TITLE
Prepare filling the Frank!Doc model from a doclet

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/doc/Utils.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/Utils.java
@@ -25,10 +25,7 @@ import java.util.Set;
 import nl.nn.adapterframework.doc.doclet.FrankMethod;
 
 /**
- * Utility methods for the Frank!Doc. Many of these delegate to {@link nl.nn.adapterframework.doc.InfoBuilderSource}.
- * Eventually, the implementations should be moved from {@link nl.nn.adapterframework.doc.InfoBuilderSource} to
- * this class. This cannot be done now because the Frank!Doc is being updated. We still have to support the old
- * Frank!Doc, which includes code from {@link nl.nn.adapterframework.doc.InfoBuilderSource}.
+ * Utility methods for the Frank!Doc.
  * @author martijn
  *
  */
@@ -51,6 +48,13 @@ public final class Utils {
 
 	private static final Set<String> JAVA_BOXED = new HashSet<String>(Arrays.asList(new String[] {
 			JAVA_STRING, JAVA_INTEGER, JAVA_BOOLEAN, JAVA_LONG, JAVA_BYTE, JAVA_SHORT}));
+
+	// All types that are accepted by method isGetterOrSetter() 
+	public static final Set<String> ALLOWED_SETTER_TYPES = new HashSet<>();
+	static {
+		ALLOWED_SETTER_TYPES.addAll(primitiveToBoxed.keySet());
+		ALLOWED_SETTER_TYPES.addAll(JAVA_BOXED);
+	}
 
 	private Utils() {
 	}
@@ -86,6 +90,6 @@ public final class Utils {
 	}
 
 	public static String toUpperCamelCase(String arg) {
-		return InfoBuilderSource.toUpperCamelCase(arg);
+		return arg.substring(0,  1).toUpperCase() + arg.substring(1);
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/Utils.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/Utils.java
@@ -16,56 +16,68 @@ limitations under the License.
 
 package nl.nn.adapterframework.doc;
 
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
-import nl.nn.adapterframework.doc.objects.SpringBean;
+import nl.nn.adapterframework.doc.doclet.FrankMethod;
 
 public final class Utils {
+	private static final String JAVA_STRING = "java.lang.String";
+	private static final String JAVA_INTEGER = "java.lang.Integer";
+	private static final String JAVA_BOOLEAN = "java.lang.Boolean";
+	private static final String JAVA_LONG = "java.lang.Long";
+	private static final String JAVA_BYTE = "java.lang.Byte";
+	private static final String JAVA_SHORT = "java.lang.Short";
+
+	private static Map<String, String> primitiveToBoxed = new HashMap<>();
+	static {
+		primitiveToBoxed.put("int", JAVA_INTEGER);
+		primitiveToBoxed.put("boolean", JAVA_BOOLEAN);
+		primitiveToBoxed.put("long", JAVA_LONG);
+		primitiveToBoxed.put("byte", JAVA_BYTE);
+		primitiveToBoxed.put("short", JAVA_SHORT);
+	}
+
+	private static final Set<String> JAVA_BOXED = new HashSet<String>(Arrays.asList(new String[] {
+			JAVA_STRING, JAVA_INTEGER, JAVA_BOOLEAN, JAVA_LONG, JAVA_BYTE, JAVA_SHORT}));
+
 	private Utils() {
 	}
 
-	/**
-	 * @param interfaceName The interface for which we want SpringBean objects.
-	 * @return All classes implementing interfaceName, ordered by their full class name.
-	 */
-	public static List<SpringBean> getSpringBeans(final String interfaceName) throws ReflectiveOperationException {
-		Class<?> interfaze = getClass(interfaceName);
-		if(interfaze == null) {
-			throw new ReflectiveOperationException("Class or interface is not available on the classpath: " + interfaceName);
-		}
-		if(!interfaze.isInterface()) {
-			throw new ReflectiveOperationException("This exists on the classpath but is not an interface: " + interfaceName);
-		}
-		Set<SpringBean> unfiltered = InfoBuilderSource.getSpringBeans(interfaze);
-		List<SpringBean> result = new ArrayList<SpringBean>();
-		for(SpringBean b: unfiltered) {
-			if(interfaze.isAssignableFrom(b.getClazz())) {
-				result.add(b);
-			}
-		}
-		return result;
+	public static boolean isAttributeGetterOrSetter(FrankMethod method) {
+		boolean isSetter = method.getReturnType().isPrimitive()
+				&& method.getReturnType().getName().equals("void")
+				&& (method.getParameterTypes().length == 1)
+				&& (method.getParameterTypes()[0].isPrimitive()
+						|| JAVA_BOXED.contains(method.getParameterTypes()[0].getName()));
+		boolean isGetter = (
+					(method.getReturnType().isPrimitive()
+							&& !method.getReturnType().getName().equals("void"))
+					|| JAVA_BOXED.contains(method.getReturnType().getName())
+				) && (method.getParameterTypes().length == 0);
+		return isSetter || isGetter;
 	}
 
-	public static Class<?> getClass(final String name) {
-		return InfoBuilderSource.getClass(name);
+	public static boolean isConfigChildSetter(FrankMethod method) {
+		return (method.getParameterTypes().length == 1)
+				&& (! method.getParameterTypes()[0].isPrimitive())
+				&& (! JAVA_BOXED.contains(method.getParameterTypes()[0].getName()))
+				&& (method.getReturnType().isPrimitive())
+				&& (method.getReturnType().getName().equals("void"));
 	}
 
-	public static boolean isAttributeGetterOrSetter(Method method) {
-		return InfoBuilderSource.isGetterOrSetter(method);
-	}
-
-	public static boolean isConfigChildSetter(Method method) {
-		return InfoBuilderSource.isConfigChildSetter(method);
+	public static String promoteIfPrimitive(String typeName) {
+		if(primitiveToBoxed.containsKey(typeName)) {
+			return primitiveToBoxed.get(typeName);
+		} else {
+			return typeName;
+		}
 	}
 
 	public static String toUpperCamelCase(String arg) {
 		return InfoBuilderSource.toUpperCamelCase(arg);
-	}
-
-	public static String promoteIfPrimitive(String typeName) {
-		return InfoBuilderSource.promoteIfPrimitive(typeName);
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/DocletReflectiveOperationException.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/DocletReflectiveOperationException.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 public class DocletReflectiveOperationException extends Exception {

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/DocletReflectiveOperationException.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/DocletReflectiveOperationException.java
@@ -1,0 +1,9 @@
+package nl.nn.adapterframework.doc.doclet;
+
+public class DocletReflectiveOperationException extends Exception {
+	private static final long serialVersionUID = -3398857271185515294L;
+
+	public DocletReflectiveOperationException(String msg, Throwable cause) {
+		super(msg, cause);
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotation.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotation.java
@@ -17,5 +17,5 @@ limitations under the License.
 package nl.nn.adapterframework.doc.doclet;
 
 public interface FrankAnnotation extends FrankProgramElement {
-	Object getValue() throws DocletReflectiveOperationException;
+	Object getValue() throws FrankDocException;
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotation.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotation.java
@@ -1,0 +1,5 @@
+package nl.nn.adapterframework.doc.doclet;
+
+public interface FrankAnnotation extends FrankProgramElement {
+	Object getValue() throws DocletReflectiveOperationException;
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotation.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotation.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 public interface FrankAnnotation extends FrankProgramElement {

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflect.java
@@ -1,0 +1,41 @@
+package nl.nn.adapterframework.doc.doclet;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+class FrankAnnotationReflect implements FrankAnnotation {
+	private Annotation annotation;
+
+	FrankAnnotationReflect(Annotation annotation) {
+		this.annotation = annotation;
+	}
+
+	@Override
+	public String getName() {
+		return annotation.annotationType().getName();
+	}
+	
+	@Override
+	public boolean isPublic() {
+		return Modifier.isPublic(annotation.annotationType().getModifiers());
+	}
+
+	public FrankAnnotation[] getAnnotations() {
+		return new FrankAnnotation[] {};
+	}
+
+	public FrankAnnotation getAnnotation(String name) {
+		return null;
+	}
+
+	@Override
+	public Object getValue() throws DocletReflectiveOperationException {
+		try {
+			Method valueMethod = annotation.annotationType().getMethod("value");
+			return valueMethod.invoke(annotation);
+		} catch(Exception e) {
+			throw new DocletReflectiveOperationException(String.format("Could not get value of annotation [%s]", getName()), e);
+		}
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflect.java
@@ -46,12 +46,12 @@ class FrankAnnotationReflect implements FrankAnnotation {
 	}
 
 	@Override
-	public Object getValue() throws DocletReflectiveOperationException {
+	public Object getValue() throws FrankDocException {
 		try {
 			Method valueMethod = annotation.annotationType().getMethod("value");
 			return valueMethod.invoke(annotation);
 		} catch(Exception e) {
-			throw new DocletReflectiveOperationException(String.format("Could not get value of annotation [%s]", getName()), e);
+			throw new FrankDocException(String.format("Could not get value of annotation [%s]", getName()), e);
 		}
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflect.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 import java.lang.annotation.Annotation;

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
@@ -39,7 +39,7 @@ public interface FrankClass extends FrankType {
 	/**
 	 * Assumes that this object models a Java interface and get the non-abstract interface implementations.
 	 */
-	List<FrankClass> getInterfaceImplementations() throws DocletReflectiveOperationException;
+	List<FrankClass> getInterfaceImplementations() throws FrankDocException;
 
 	FrankMethod[] getDeclaredMethods();
 	FrankMethod[] getDeclaredAndInheritedMethods();

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
@@ -1,0 +1,28 @@
+package nl.nn.adapterframework.doc.doclet;
+
+import java.util.List;
+
+public interface FrankClass extends FrankType {
+	@Override
+	default boolean isPrimitive() {
+		return false;
+	}
+
+	@Override
+	default boolean isAnnotation() {
+		return false;
+	}
+
+	String getSimpleName();
+	FrankClass getSuperclass();
+	boolean isAbstract();
+	boolean isInterface();
+	boolean isPublic();
+
+	/**
+	 * Assumes that this object models a Java interface and get the non-abstract interface implementations.
+	 */
+	List<FrankClass> getInterfaceImplementations() throws DocletReflectiveOperationException;
+
+	FrankMethod[] getDeclaredMethods();
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
@@ -31,6 +31,7 @@ public interface FrankClass extends FrankType {
 
 	String getSimpleName();
 	FrankClass getSuperclass();
+	FrankClass[] getInterfaces();
 	boolean isAbstract();
 	boolean isInterface();
 	boolean isPublic();
@@ -42,4 +43,6 @@ public interface FrankClass extends FrankType {
 
 	FrankMethod[] getDeclaredMethods();
 	FrankMethod[] getDeclaredAndInheritedMethods();
+
+	String[] getEnumConstants();
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClass.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 import java.util.List;
@@ -25,4 +41,5 @@ public interface FrankClass extends FrankType {
 	List<FrankClass> getInterfaceImplementations() throws DocletReflectiveOperationException;
 
 	FrankMethod[] getDeclaredMethods();
+	FrankMethod[] getDeclaredAndInheritedMethods();
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
@@ -1,0 +1,105 @@
+package nl.nn.adapterframework.doc.doclet;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.objects.SpringBean;
+
+class FrankClassReflect implements FrankClass {
+	private final Class<?> clazz;
+	private final Map<String, FrankAnnotation> annotations;
+
+	FrankClassReflect(Class<?> clazz) {
+		this.clazz = clazz;
+		Annotation[] reflectAnnotations = clazz.getAnnotations();
+		annotations = new HashMap<>();
+		for(Annotation r: reflectAnnotations) {
+			FrankAnnotation frankAnnotation = new FrankAnnotationReflect(r);
+			annotations.put(frankAnnotation.getName(), frankAnnotation);
+		}
+	}
+
+	@Override
+	public String getName() {
+		return clazz.getName();
+	}
+
+	@Override
+	public String getSimpleName() {
+		return clazz.getSimpleName();
+	}
+
+	@Override
+	public FrankClass getSuperclass() {
+		Class<?> superClazz = clazz.getSuperclass();
+		if(superClazz == null) {
+			return null;
+		} else {
+			return new FrankClassReflect(superClazz);
+		}
+	}
+
+	@Override
+	public boolean isAbstract() {
+		return Modifier.isAbstract(clazz.getModifiers());
+	}
+
+	@Override
+	public boolean isPublic() {
+		return Modifier.isPublic(clazz.getModifiers());		
+	}
+
+	@Override
+	public boolean isInterface() {
+		return clazz.isInterface();
+	}
+
+	@Override
+	public List<FrankClass> getInterfaceImplementations() throws DocletReflectiveOperationException {
+		List<SpringBean> springBeans;
+		try {
+			springBeans = Utils.getSpringBeans(clazz.getName());
+		} catch(ReflectiveOperationException e) {
+			throw new DocletReflectiveOperationException(String.format("Could not get interface implementations of Java class [%s]", getName()), e);
+		}
+		// We sort here to make the order deterministic.
+		Collections.sort(springBeans);
+		return springBeans.stream()
+				.map(SpringBean::getClazz)
+				.map(FrankClassReflect::new)
+				.collect(Collectors.toList());
+	}
+
+	@Override
+	public FrankAnnotation[] getAnnotations() {
+		List<FrankAnnotation> annotationList = new ArrayList<>(annotations.values());
+		FrankAnnotation[] result = new FrankAnnotation[annotationList.size()];
+		for(int i = 0; i < annotationList.size(); ++i) {
+			result[i] = (FrankAnnotation) annotationList.get(i);
+		}
+		return result;
+	}
+
+	@Override
+	public FrankAnnotation getAnnotation(String name) {
+		return annotations.get(name);
+	}
+
+	@Override
+	public FrankMethod[] getDeclaredMethods() {
+		Method[] rawDeclaredMethods = clazz.getDeclaredMethods();
+		FrankMethod[] result = new FrankMethod[rawDeclaredMethods.length];
+		for(int i = 0; i < rawDeclaredMethods.length; ++i) {
+			result[i] = new FrankMethodReflect(rawDeclaredMethods[i]);
+		}
+		return result;
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
@@ -42,7 +42,6 @@ import org.springframework.core.type.filter.AssignableTypeFilter;
 import org.springframework.core.type.filter.RegexPatternTypeFilter;
 import org.springframework.util.Assert;
 
-import nl.nn.adapterframework.doc.objects.SpringBean;
 import nl.nn.adapterframework.util.LogUtil;
 
 class FrankClassReflect implements FrankClass {

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
@@ -134,12 +134,12 @@ class FrankClassReflect implements FrankClass {
 	}
 
 	@Override
-	public List<FrankClass> getInterfaceImplementations() throws DocletReflectiveOperationException {
+	public List<FrankClass> getInterfaceImplementations() throws FrankDocException {
 		List<SpringBean> springBeans;
 		try {
 			springBeans = getSpringBeans(clazz.getName());
 		} catch(ReflectiveOperationException e) {
-			throw new DocletReflectiveOperationException(String.format("Could not get interface implementations of Java class [%s]", getName()), e);
+			throw new FrankDocException(String.format("Could not get interface implementations of Java class [%s]", getName()), e);
 		}
 		// We sort here to make the order deterministic.
 		Collections.sort(springBeans);

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassReflect.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 import java.lang.annotation.Annotation;
@@ -96,10 +112,20 @@ class FrankClassReflect implements FrankClass {
 	@Override
 	public FrankMethod[] getDeclaredMethods() {
 		Method[] rawDeclaredMethods = clazz.getDeclaredMethods();
+		return wrapReflectMethodsInArray(rawDeclaredMethods);
+	}
+
+	private FrankMethod[] wrapReflectMethodsInArray(Method[] rawDeclaredMethods) {
 		FrankMethod[] result = new FrankMethod[rawDeclaredMethods.length];
 		for(int i = 0; i < rawDeclaredMethods.length; ++i) {
 			result[i] = new FrankMethodReflect(rawDeclaredMethods[i]);
 		}
 		return result;
+	}
+
+	@Override
+	public FrankMethod[] getDeclaredAndInheritedMethods() {
+		Method[] rawDeclaredMethods = clazz.getMethods();
+		return wrapReflectMethodsInArray(rawDeclaredMethods);		
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepository.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepository.java
@@ -17,5 +17,9 @@ limitations under the License.
 package nl.nn.adapterframework.doc.doclet;
 
 public interface FrankClassRepository {
+	static FrankClassRepository getReflectInstance() {
+		return new FrankClassRepositoryReflect();
+	}
+
 	FrankClass findClass(String fullName) throws DocletReflectiveOperationException;
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepository.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepository.java
@@ -16,9 +16,6 @@ limitations under the License.
 
 package nl.nn.adapterframework.doc.doclet;
 
-public interface FrankProgramElement {
-	String getName();
-	boolean isPublic();
-	FrankAnnotation[] getAnnotations();
-	FrankAnnotation getAnnotation(String name);
+public interface FrankClassRepository {
+	FrankClass findClass(String fullName) throws DocletReflectiveOperationException;
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepository.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepository.java
@@ -21,5 +21,5 @@ public interface FrankClassRepository {
 		return new FrankClassRepositoryReflect();
 	}
 
-	FrankClass findClass(String fullName) throws DocletReflectiveOperationException;
+	FrankClass findClass(String fullName) throws FrankDocException;
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepositoryReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepositoryReflect.java
@@ -18,11 +18,11 @@ package nl.nn.adapterframework.doc.doclet;
 
 class FrankClassRepositoryReflect implements FrankClassRepository {
 	@Override
-	public FrankClass findClass(String fullName) throws DocletReflectiveOperationException {
+	public FrankClass findClass(String fullName) throws FrankDocException {
 		try {
 			return new FrankClassReflect(Class.forName(fullName));
 		} catch(ClassNotFoundException e) {
-			throw new DocletReflectiveOperationException(String.format("Could not find class [%s]", fullName), e);
+			throw new FrankDocException(String.format("Could not find class [%s]", fullName), e);
 		}
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepositoryReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankClassRepositoryReflect.java
@@ -16,9 +16,13 @@ limitations under the License.
 
 package nl.nn.adapterframework.doc.doclet;
 
-public interface FrankProgramElement {
-	String getName();
-	boolean isPublic();
-	FrankAnnotation[] getAnnotations();
-	FrankAnnotation getAnnotation(String name);
+class FrankClassRepositoryReflect implements FrankClassRepository {
+	@Override
+	public FrankClass findClass(String fullName) throws DocletReflectiveOperationException {
+		try {
+			return new FrankClassReflect(Class.forName(fullName));
+		} catch(ClassNotFoundException e) {
+			throw new DocletReflectiveOperationException(String.format("Could not find class [%s]", fullName), e);
+		}
+	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankDocException.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankDocException.java
@@ -16,10 +16,10 @@ limitations under the License.
 
 package nl.nn.adapterframework.doc.doclet;
 
-public class DocletReflectiveOperationException extends Exception {
+public class FrankDocException extends Exception {
 	private static final long serialVersionUID = -3398857271185515294L;
 
-	public DocletReflectiveOperationException(String msg, Throwable cause) {
+	public FrankDocException(String msg, Throwable cause) {
 		super(msg, cause);
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankDocletConstants.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankDocletConstants.java
@@ -16,45 +16,11 @@ limitations under the License.
 
 package nl.nn.adapterframework.doc.doclet;
 
-public class FrankPrimitiveType implements FrankType {
-	private final String name;
+public class FrankDocletConstants {
+	public static final String DEPRECATED = "java.lang.Deprecated";
+	public static final String IBISDOC = "nl.nn.adapterframework.doc.IbisDoc";
+	public static final String IBISDOCREF = "nl.nn.adapterframework.doc.IbisDocRef";
 
-	FrankPrimitiveType(String name) {
-		this.name = name;
-	}
-
-	@Override
-	public String getName() {
-		return name;
-	}
-
-	@Override
-	public boolean isPublic() {
-		return true;
-	}
-
-	@Override
-	public boolean isPrimitive() {
-		return true;
-	}
-
-	@Override
-	public boolean isAnnotation() {
-		return false;
-	}
-
-	@Override
-	public FrankAnnotation[] getAnnotations() {
-		return new FrankAnnotation[] {};
-	}
-
-	@Override
-	public FrankAnnotation getAnnotation(String name) {
-		return null;
-	}
-
-	@Override
-	public boolean isEnum() {
-		return false;
+	private FrankDocletConstants() {
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
@@ -17,6 +17,7 @@ limitations under the License.
 package nl.nn.adapterframework.doc.doclet;
 
 public interface FrankMethod extends FrankProgramElement {
+	FrankClass getDeclaringClass();
 	/**
 	 * If the return type is void, return a {@link FrankPrimitiveType} wrapping "void".
 	 */

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 public interface FrankMethod extends FrankProgramElement {

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
@@ -24,5 +24,5 @@ public interface FrankMethod extends FrankProgramElement {
 	FrankType getReturnType();
 	int getParameterCount();
 	FrankType[] getParameterTypes();
-	FrankAnnotation getAnnotationInludingInherited(String name) throws DocletReflectiveOperationException;
+	FrankAnnotation getAnnotationInludingInherited(String name) throws FrankDocException;
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethod.java
@@ -1,0 +1,11 @@
+package nl.nn.adapterframework.doc.doclet;
+
+public interface FrankMethod extends FrankProgramElement {
+	/**
+	 * If the return type is void, return a {@link FrankPrimitiveType} wrapping "void".
+	 */
+	FrankType getReturnType();
+	int getParameterCount();
+	FrankType[] getParameterTypes();
+	FrankAnnotation getAnnotationInludingInherited(String name) throws DocletReflectiveOperationException;
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflect.java
@@ -99,14 +99,14 @@ class FrankMethodReflect implements FrankMethod {
 	}
 
 	@Override
-	public FrankAnnotation getAnnotationInludingInherited(String name) throws DocletReflectiveOperationException {
+	public FrankAnnotation getAnnotationInludingInherited(String name) throws FrankDocException {
 		Annotation rawAnnotation = null;
 		try {
 			@SuppressWarnings("unchecked")
 			Class<? extends Annotation> annotationClass = (Class<? extends Annotation>) Class.forName(name);
 			rawAnnotation = AnnotationUtils.findAnnotation(method, annotationClass);
 		} catch(Exception e) {
-			throw new DocletReflectiveOperationException(String.format("Could not get annotation [%s] including inherited", name), e);
+			throw new FrankDocException(String.format("Could not get annotation [%s] including inherited", name), e);
 		}
 		if(rawAnnotation == null) {
 			return null;

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflect.java
@@ -16,10 +16,6 @@ limitations under the License.
 
 package nl.nn.adapterframework.doc.doclet;
 
-import org.springframework.core.annotation.AnnotationUtils;
-
-import nl.nn.adapterframework.doc.Utils;
-
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
@@ -28,12 +24,16 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.core.annotation.AnnotationUtils;
+
 class FrankMethodReflect implements FrankMethod {
 	private final Method method;
+	private final FrankClass declaringClass;
 	private final Map<String, FrankAnnotation> annotations;
 
-	FrankMethodReflect(Method method) {
+	FrankMethodReflect(Method method, FrankClass declaringClass) {
 		this.method = method;
+		this.declaringClass = declaringClass;
 		annotations = new HashMap<>();
 		for(Annotation r: method.getAnnotations()) {
 			FrankAnnotation frankAnnotation = new FrankAnnotationReflect(r);
@@ -44,6 +44,11 @@ class FrankMethodReflect implements FrankMethod {
 	@Override
 	public String getName() {
 		return method.getName();
+	}
+
+	@Override
+	public FrankClass getDeclaringClass() {
+		return declaringClass;
 	}
 
 	@Override
@@ -98,7 +103,7 @@ class FrankMethodReflect implements FrankMethod {
 		Annotation rawAnnotation = null;
 		try {
 			@SuppressWarnings("unchecked")
-			Class<? extends Annotation> annotationClass = (Class<? extends Annotation>) Utils.getClass(name);
+			Class<? extends Annotation> annotationClass = (Class<? extends Annotation>) Class.forName(name);
 			rawAnnotation = AnnotationUtils.findAnnotation(method, annotationClass);
 		} catch(Exception e) {
 			throw new DocletReflectiveOperationException(String.format("Could not get annotation [%s] including inherited", name), e);

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflect.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflect.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 import org.springframework.core.annotation.AnnotationUtils;

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankPrimitiveType.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankPrimitiveType.java
@@ -1,0 +1,39 @@
+package nl.nn.adapterframework.doc.doclet;
+
+public class FrankPrimitiveType implements FrankType {
+	private final String name;
+
+	FrankPrimitiveType(String name) {
+		this.name = name;
+	}
+
+	@Override
+	public String getName() {
+		return name;
+	}
+
+	@Override
+	public boolean isPublic() {
+		return true;
+	}
+
+	@Override
+	public boolean isPrimitive() {
+		return true;
+	}
+
+	@Override
+	public boolean isAnnotation() {
+		return false;
+	}
+
+	@Override
+	public FrankAnnotation[] getAnnotations() {
+		return new FrankAnnotation[] {};
+	}
+
+	@Override
+	public FrankAnnotation getAnnotation(String name) {
+		return null;
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankPrimitiveType.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankPrimitiveType.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 public class FrankPrimitiveType implements FrankType {

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankProgramElement.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankProgramElement.java
@@ -1,0 +1,8 @@
+package nl.nn.adapterframework.doc.doclet;
+
+public interface FrankProgramElement {
+	String getName();
+	boolean isPublic();
+	FrankAnnotation[] getAnnotations();
+	FrankAnnotation getAnnotation(String name);
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankType.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankType.java
@@ -19,4 +19,5 @@ package nl.nn.adapterframework.doc.doclet;
 public interface FrankType extends FrankProgramElement {
 	boolean isPrimitive();
 	boolean isAnnotation();
+	boolean isEnum();
 }

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankType.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankType.java
@@ -1,3 +1,19 @@
+/* 
+Copyright 2021 WeAreFrank! 
+
+Licensed under the Apache License, Version 2.0 (the "License"); 
+you may not use this file except in compliance with the License. 
+You may obtain a copy of the License at 
+
+    http://www.apache.org/licenses/LICENSE-2.0 
+
+Unless required by applicable law or agreed to in writing, software 
+distributed under the License is distributed on an "AS IS" BASIS, 
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+See the License for the specific language governing permissions and 
+limitations under the License. 
+*/
+
 package nl.nn.adapterframework.doc.doclet;
 
 public interface FrankType extends FrankProgramElement {

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankType.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/FrankType.java
@@ -1,0 +1,6 @@
+package nl.nn.adapterframework.doc.doclet;
+
+public interface FrankType extends FrankProgramElement {
+	boolean isPrimitive();
+	boolean isAnnotation();
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/doclet/SpringBean.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/doclet/SpringBean.java
@@ -1,0 +1,38 @@
+/*
+Copyright 2019, 2020 WeAreFrank!
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nl.nn.adapterframework.doc.doclet;
+
+import lombok.Getter;
+
+public class SpringBean implements Comparable<SpringBean> {
+	private @Getter String name;
+	private @Getter Class<?> clazz;
+
+	public SpringBean(String name, Class<?> clazz) {
+		this.name = name;
+		this.clazz = clazz;
+	}
+
+	public int compareTo(SpringBean s) {
+		return name.compareTo(s.name);
+	}
+
+	@Override
+	public String toString() {
+		return name + "[" + clazz.getName() + "]";
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/AttributeValuesFactory.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/AttributeValuesFactory.java
@@ -24,13 +24,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import nl.nn.adapterframework.doc.doclet.FrankClass;
+
 class AttributeValuesFactory {
 	private Map<String, AttributeValues> allAttributeValuesInstances = new LinkedHashMap<>();
 	private Map<String, Integer> lastAssignedSeq = new HashMap<>();
 
-	AttributeValues findOrCreateAttributeValues(Class<? extends Enum<?>> clazz) {
+	AttributeValues findOrCreateAttributeValues(FrankClass clazz) {
 		List<String> values = Arrays.asList(clazz.getEnumConstants()).stream()
-				.map(c -> c.name())
 				.collect(Collectors.toList());
 		return findOrCreateAttributeValues(clazz.getName(), clazz.getSimpleName(), values);
 	}

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/ConfigChild.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/ConfigChild.java
@@ -40,23 +40,23 @@ public class ConfigChild extends ElementChild implements Comparable<ConfigChild>
 
 	static final class SortNode implements Comparable<SortNode> {
 		private static final Comparator<SortNode> SORT_NODE_COMPARATOR =
-				Comparator.comparing(SortNode::getName).thenComparing(sn -> sn.getElementTypeClass().getName());
+				Comparator.comparing(SortNode::getName).thenComparing(sn -> sn.getElementType().getName());
 
 		private @Getter String name;
 		private @Getter boolean documented;
 		private @Getter boolean deprecated;
-		private @Getter FrankType elementTypeClass;
+		private @Getter FrankType elementType;
 		private @Getter FrankAnnotation ibisDoc;
 
 		SortNode(FrankMethod method) {
 			this.name = method.getName();
 			this.documented = (method.getAnnotation(FrankDocletConstants.IBISDOC) != null);
 			this.deprecated = isDeprecated(method);
-			this.elementTypeClass = method.getParameterTypes()[0];
+			this.elementType = method.getParameterTypes()[0];
 			try {
 				this.ibisDoc = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 			} catch(DocletReflectiveOperationException e) {
-				log.warn("Could not @IbisDoc annotation");
+				log.warn("Could not @IbisDoc annotation", e);
 			}
 		}
 

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/ConfigChild.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/ConfigChild.java
@@ -28,7 +28,7 @@ import org.apache.logging.log4j.Logger;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
-import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankDocException;
 import nl.nn.adapterframework.doc.doclet.FrankAnnotation;
 import nl.nn.adapterframework.doc.doclet.FrankDocletConstants;
 import nl.nn.adapterframework.doc.doclet.FrankMethod;
@@ -66,7 +66,7 @@ public class ConfigChild extends ElementChild implements Comparable<ConfigChild>
 			this.elementType = method.getParameterTypes()[0];
 			try {
 				this.ibisDoc = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
-			} catch(DocletReflectiveOperationException e) {
+			} catch(FrankDocException e) {
 				log.warn("Could not @IbisDoc annotation", e);
 			}
 		}

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/ElementChild.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/ElementChild.java
@@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
 import lombok.Getter;
 import lombok.Setter;
 import nl.nn.adapterframework.doc.DocWriterNew;
-import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankDocException;
 import nl.nn.adapterframework.doc.doclet.FrankAnnotation;
 import nl.nn.adapterframework.util.LogUtil;
 
@@ -131,7 +131,7 @@ public abstract class ElementChild {
 		String[] ibisDocValues = null;
 		try {
 			ibisDocValues = (String[]) ibisDoc.getValue();
-		} catch(DocletReflectiveOperationException e) {
+		} catch(FrankDocException e) {
 			log.warn("Could not parse FrankAnnotation of @IbisDoc", e);
 		}
 		boolean isIbisDocHasOrder = false;

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/ElementChild.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/ElementChild.java
@@ -23,7 +23,8 @@ import org.apache.logging.log4j.Logger;
 import lombok.Getter;
 import lombok.Setter;
 import nl.nn.adapterframework.doc.DocWriterNew;
-import nl.nn.adapterframework.doc.IbisDoc;
+import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankAnnotation;
 import nl.nn.adapterframework.util.LogUtil;
 
 /**
@@ -109,8 +110,13 @@ public abstract class ElementChild {
 		}
 	}
 
-	boolean parseIbisDocAnnotation(IbisDoc ibisDoc) {
-		String[] ibisDocValues = ibisDoc.value();
+	boolean parseIbisDocAnnotation(FrankAnnotation ibisDoc) {
+		String[] ibisDocValues = null;
+		try {
+			ibisDocValues = (String[]) ibisDoc.getValue();
+		} catch(DocletReflectiveOperationException e) {
+			log.warn("Could not parse FrankAnnotation of @IbisDoc", e);
+		}
 		boolean isIbisDocHasOrder = false;
 		description = "";
 		try {

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/ElementType.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/ElementType.java
@@ -28,6 +28,7 @@ import org.apache.logging.log4j.Logger;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import nl.nn.adapterframework.doc.doclet.FrankClass;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.Misc;
 
@@ -52,11 +53,11 @@ public class ElementType {
 		private @Getter String simpleName;
 		private @Getter Map<String, InterfaceHierarchyItem> parentInterfaces = new TreeMap<>();
 
-		InterfaceHierarchyItem(Class<?> clazz) {
+		InterfaceHierarchyItem(FrankClass clazz) {
 			this.fullName = clazz.getName();
 			this.simpleName = clazz.getSimpleName();
 			if(clazz.isInterface()) {
-				for(Class<?> superInterface: clazz.getInterfaces()) {
+				for(FrankClass superInterface: clazz.getInterfaces()) {
 					InterfaceHierarchyItem superInterfaceHierarchyItem = new InterfaceHierarchyItem(superInterface);
 					parentInterfaces.put(superInterfaceHierarchyItem.getFullName(), superInterfaceHierarchyItem);
 				}
@@ -79,7 +80,7 @@ public class ElementType {
 	private final InterfaceHierarchyItem interfaceHierarchy;
 	private @Getter ElementType highestCommonInterface;
 
-	ElementType(Class<?> clazz) {
+	ElementType(FrankClass clazz) {
 		interfaceHierarchy = new InterfaceHierarchyItem(clazz);
 		members = new ArrayList<>();
 		this.fromJavaInterface = clazz.isInterface();

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/FrankDocModel.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/FrankDocModel.java
@@ -356,8 +356,7 @@ public class FrankDocModel {
 		try {
 			values = (String[]) ibisDocRef.getValue();
 		} catch(DocletReflectiveOperationException e) {
-			// TODO: Improve this message
-			log.warn("Could not parse IbisDocRef annotation");
+			log.warn("IbisDocRef annotation did not have a value", e);
 			return result;
 		}
 		String methodString = null;
@@ -405,7 +404,7 @@ public class FrankDocModel {
 			}
 			return null;
 		} catch (DocletReflectiveOperationException e) {
-			log.warn("Super class [{}] was not found!", className);
+			log.warn("Super class [{}] was not found!", className, e);
 			return null;
 		}
 	}
@@ -423,7 +422,7 @@ public class FrankDocModel {
 			configChild.setMandatory(configChildDescriptor.isMandatory());
 			log.trace("For FrankElement [{}] method [{}], going to search element role", () -> parent.getFullName(), () -> sortNode.getName());
 			configChild.setElementRole(findOrCreateElementRole(
-					(FrankClass) sortNode.getElementTypeClass(), configChildDescriptor.getRoleName()));
+					(FrankClass) sortNode.getElementType(), configChildDescriptor.getRoleName()));
 			log.trace("For FrankElement [{}] method [{}], have the element role", () -> parent.getFullName(), () -> sortNode.getName());
 			if(sortNode.getIbisDoc() == null) {
 				log.warn("No @IbisDoc annotation for config child [{}] of FrankElement [{}]", () -> configChild.getKey().toString(), () -> parent.getFullName());

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/FrankDocModel.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/FrankDocModel.java
@@ -42,7 +42,7 @@ import nl.nn.adapterframework.configuration.digester.DigesterRule;
 import nl.nn.adapterframework.configuration.digester.DigesterRulesHandler;
 import nl.nn.adapterframework.core.Resource;
 import nl.nn.adapterframework.doc.Utils;
-import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankDocException;
 import nl.nn.adapterframework.doc.doclet.FrankAnnotation;
 import nl.nn.adapterframework.doc.doclet.FrankClass;
 import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
@@ -167,7 +167,7 @@ public class FrankDocModel {
 		return allTypes.containsKey(typeName);
 	}
 
-	FrankElement findOrCreateFrankElement(String fullClassName) throws DocletReflectiveOperationException {
+	FrankElement findOrCreateFrankElement(String fullClassName) throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(fullClassName);
 		log.trace("FrankElement requested for class name [{}]", () -> clazz.getName());
 		if(allElements.containsKey(clazz.getName())) {
@@ -190,7 +190,7 @@ public class FrankDocModel {
 		return allElements.get(fullName);
 	}
 
-	List<FrankAttribute> createAttributes(FrankClass clazz, FrankElement attributeOwner) throws DocletReflectiveOperationException {
+	List<FrankAttribute> createAttributes(FrankClass clazz, FrankElement attributeOwner) throws FrankDocException {
 		log.trace("Creating attributes for FrankElement [{}]", () -> attributeOwner.getFullName());
 		FrankMethod[] methods = clazz.getDeclaredMethods();
 		Map<String, FrankMethod> enumGettersByAttributeName = getEnumGettersByAttributeName(clazz);
@@ -301,7 +301,7 @@ public class FrankDocModel {
 		}
 	}
 
-	private void documentAttribute(FrankAttribute attribute, FrankMethod method, FrankElement attributeOwner) throws DocletReflectiveOperationException {
+	private void documentAttribute(FrankAttribute attribute, FrankMethod method, FrankElement attributeOwner) throws FrankDocException {
 		attribute.setDeprecated(method.getAnnotation(FrankDocletConstants.DEPRECATED) != null);
 		attribute.setDocumented(
 				(method.getAnnotation(FrankDocletConstants.IBISDOC) != null)
@@ -356,7 +356,7 @@ public class FrankDocModel {
 		String[] values = null;
 		try {
 			values = (String[]) ibisDocRef.getValue();
-		} catch(DocletReflectiveOperationException e) {
+		} catch(FrankDocException e) {
 			log.warn("IbisDocRef annotation did not have a value", e);
 			return result;
 		}
@@ -404,13 +404,13 @@ public class FrankDocModel {
 				}
 			}
 			return null;
-		} catch (DocletReflectiveOperationException e) {
+		} catch (FrankDocException e) {
 			log.warn("Super class [{}] was not found!", className, e);
 			return null;
 		}
 	}
 
-	private List<ConfigChild> createConfigChildren(FrankMethod[] methods, FrankElement parent) throws DocletReflectiveOperationException {
+	private List<ConfigChild> createConfigChildren(FrankMethod[] methods, FrankElement parent) throws FrankDocException {
 		log.trace("Creating config children of FrankElement [{}]", () -> parent.getFullName());
 		List<ConfigChild> result = new ArrayList<>();
 		for(ConfigChild.SortNode sortNode: createSortNodes(methods, parent)) {
@@ -462,7 +462,7 @@ public class FrankDocModel {
 		return sortNodes;
 	}
 
-	ElementRole findOrCreateElementRole(FrankClass elementTypeClass, String roleName) throws DocletReflectiveOperationException {
+	ElementRole findOrCreateElementRole(FrankClass elementTypeClass, String roleName) throws FrankDocException {
 		log.trace("ElementRole requested for elementTypeClass [{}] and roleName [{}]. Going to get the ElementType", () -> elementTypeClass.getName(), () -> roleName);
 		ElementType elementType = findOrCreateElementType(elementTypeClass);
 		ElementRole.Key key = new ElementRole.Key(elementTypeClass.getName(), roleName);
@@ -490,7 +490,7 @@ public class FrankDocModel {
 		return allElementRoles.get(new ElementRole.Key(fullElementTypeName, roleName));
 	}
 
-	ElementType findOrCreateElementType(FrankClass clazz) throws DocletReflectiveOperationException {
+	ElementType findOrCreateElementType(FrankClass clazz) throws FrankDocException {
 		log.trace("Requested ElementType for class [{}]", () -> clazz.getName());
 		if(allTypes.containsKey(clazz.getName())) {
 			log.trace("Already present");

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/FrankDocModel.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/FrankDocModel.java
@@ -19,8 +19,6 @@ package nl.nn.adapterframework.doc.model;
 import static nl.nn.adapterframework.doc.model.ElementChild.ALL;
 
 import java.io.IOException;
-import java.lang.reflect.Method;
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -36,7 +34,6 @@ import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.xml.sax.SAXException;
 
 import lombok.Getter;
@@ -44,10 +41,13 @@ import lombok.Setter;
 import nl.nn.adapterframework.configuration.digester.DigesterRule;
 import nl.nn.adapterframework.configuration.digester.DigesterRulesHandler;
 import nl.nn.adapterframework.core.Resource;
-import nl.nn.adapterframework.doc.IbisDoc;
-import nl.nn.adapterframework.doc.IbisDocRef;
 import nl.nn.adapterframework.doc.Utils;
-import nl.nn.adapterframework.doc.objects.SpringBean;
+import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankAnnotation;
+import nl.nn.adapterframework.doc.doclet.FrankClass;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+import nl.nn.adapterframework.doc.doclet.FrankDocletConstants;
+import nl.nn.adapterframework.doc.doclet.FrankMethod;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.XmlUtils;
 
@@ -56,6 +56,8 @@ public class FrankDocModel {
 	private static String ENUM = "Enum";
 	private static final String DIGESTER_RULES = "digester-rules.xml";
 	static final String OTHER = "Other";
+
+	private FrankClassRepository classRepository;
 
 	private @Getter Map<String, ConfigChildSetterDescriptor> configChildDescriptors = new HashMap<>();
 	
@@ -77,21 +79,25 @@ public class FrankDocModel {
 	private Map<Set<ElementRole.Key>, ElementRoleSet> allElementRoleSets = new HashMap<>();
 	private AttributeValuesFactory attributeValuesFactory = new AttributeValuesFactory();
 
+	FrankDocModel(FrankClassRepository classRepository) {
+		this.classRepository = classRepository;
+	}
+
 	/**
 	 * Get the FrankDocModel needed in production. This is just a first draft. The
 	 * present version does not have groups yet. It will be improved in future
 	 * pull requests. 
 	 */
-	public static FrankDocModel populate() {
-		return FrankDocModel.populate(DIGESTER_RULES, "nl.nn.adapterframework.configuration.Configuration");
+	public static FrankDocModel populate(FrankClassRepository classRepository) {
+		return FrankDocModel.populate(DIGESTER_RULES, "nl.nn.adapterframework.configuration.Configuration", classRepository);
 	}
 
-	public static FrankDocModel populate(final String digesterRulesFileName, final String rootClassName) {
-		FrankDocModel result = new FrankDocModel();
+	public static FrankDocModel populate(final String digesterRulesFileName, final String rootClassName, FrankClassRepository classRepository) {
+		FrankDocModel result = new FrankDocModel(classRepository);
 		try {
 			log.trace("Populating FrankDocModel");
 			result.createConfigChildDescriptorsFrom(digesterRulesFileName);
-			result.findOrCreateFrankElement(Utils.getClass(rootClassName));
+			result.findOrCreateFrankElement(rootClassName);
 			result.calculateHighestCommonInterfaces();
 			result.setOverriddenFrom();
 			result.setHighestCommonInterface();
@@ -161,7 +167,8 @@ public class FrankDocModel {
 		return allTypes.containsKey(typeName);
 	}
 
-	FrankElement findOrCreateFrankElement(Class<?> clazz) throws ReflectiveOperationException {
+	FrankElement findOrCreateFrankElement(String fullClassName) throws DocletReflectiveOperationException {
+		FrankClass clazz = classRepository.findClass(fullClassName);
 		log.trace("FrankElement requested for class name [{}]", () -> clazz.getName());
 		if(allElements.containsKey(clazz.getName())) {
 			log.trace("Already present");
@@ -170,8 +177,8 @@ public class FrankDocModel {
 		log.trace("Creating FrankElement for class name [{}]", () -> clazz.getName());
 		FrankElement current = new FrankElement(clazz);
 		allElements.put(clazz.getName(), current);
-		Class<?> superClass = clazz.getSuperclass();
-		FrankElement parent = superClass == null ? null : findOrCreateFrankElement(superClass);
+		FrankClass superClass = clazz.getSuperclass();
+		FrankElement parent = superClass == null ? null : findOrCreateFrankElement(superClass.getName());
 		current.setParent(parent);
 		current.setAttributes(createAttributes(clazz, current));
 		current.setConfigChildren(createConfigChildren(clazz.getDeclaredMethods(), current));
@@ -183,26 +190,24 @@ public class FrankDocModel {
 		return allElements.get(fullName);
 	}
 
-	List<FrankAttribute> createAttributes(Class<?> clazz, FrankElement attributeOwner) throws ReflectiveOperationException {
+	List<FrankAttribute> createAttributes(FrankClass clazz, FrankElement attributeOwner) throws DocletReflectiveOperationException {
 		log.trace("Creating attributes for FrankElement [{}]", () -> attributeOwner.getFullName());
-		Method[] methods = clazz.getDeclaredMethods();
-		Map<String, Method> enumGettersByAttributeName = getEnumGettersByAttributeName(clazz);
-		Map<String, Method> setterAttributes = getAttributeToMethodMap(methods, "set");
-		Map<String, Method> getterAttributes = getGetterAndIsserAttributes(methods, attributeOwner);
+		FrankMethod[] methods = clazz.getDeclaredMethods();
+		Map<String, FrankMethod> enumGettersByAttributeName = getEnumGettersByAttributeName(clazz);
+		Map<String, FrankMethod> setterAttributes = getAttributeToMethodMap(methods, "set");
+		Map<String, FrankMethod> getterAttributes = getGetterAndIsserAttributes(methods, attributeOwner);
 		List<FrankAttribute> result = new ArrayList<>();
-		for(Entry<String, Method> entry: setterAttributes.entrySet()) {
+		for(Entry<String, FrankMethod> entry: setterAttributes.entrySet()) {
 			String attributeName = entry.getKey();
 			log.trace("Attribute [{}]", attributeName);
-			Method method = entry.getValue();
+			FrankMethod method = entry.getValue();
 			if(getterAttributes.containsKey(attributeName)) {
 				checkForTypeConflict(method, getterAttributes.get(attributeName), attributeOwner);
 			}
 			FrankAttribute attribute = new FrankAttribute(attributeName, attributeOwner);
 			documentAttribute(attribute, method, attributeOwner);
 			if(enumGettersByAttributeName.containsKey(attributeName)) {
-				@SuppressWarnings("unchecked")
-				Class<? extends Enum<?>> restrictClass = (Class<? extends Enum<?>>) enumGettersByAttributeName.get(attributeName).getReturnType();
-				attribute.setAttributeValues(findOrCreateAttributeValues(restrictClass));
+				attribute.setAttributeValues(findOrCreateAttributeValues((FrankClass) enumGettersByAttributeName.get(attributeName).getReturnType()));
 			}
 			result.add(attribute);
 			log.trace("Attribute [{}] done", attributeName);
@@ -212,9 +217,9 @@ public class FrankDocModel {
 		return result;
 	}
 
-	private Map<String, Method> getGetterAndIsserAttributes(Method[] methods, FrankElement attributeOwner) {
-		Map<String, Method> getterAttributes = getAttributeToMethodMap(methods, "get");
-		Map<String, Method> isserAttributes = getAttributeToMethodMap(methods, "is");
+	private Map<String, FrankMethod> getGetterAndIsserAttributes(FrankMethod[] methods, FrankElement attributeOwner) {
+		Map<String, FrankMethod> getterAttributes = getAttributeToMethodMap(methods, "get");
+		Map<String, FrankMethod> isserAttributes = getAttributeToMethodMap(methods, "is");
 		for(String isserAttributeName : isserAttributes.keySet()) {
 			if(getterAttributes.containsKey(isserAttributeName)) {
 				log.warn("For FrankElement [{}], attribute [{}] has both a getX and an isX method", () -> attributeOwner.getSimpleName(), () -> isserAttributeName);
@@ -229,17 +234,17 @@ public class FrankDocModel {
      * The original order of the methods is preserved, which you get when you iterate
      * over the entrySet() of the returned Map.
 	 */
-	static Map<String, Method> getAttributeToMethodMap(Method[] methods, String prefix) {
-		List<Method> methodList = Arrays.asList(methods);
+	static Map<String, FrankMethod> getAttributeToMethodMap(FrankMethod[] methods, String prefix) {
+		List<FrankMethod> methodList = Arrays.asList(methods);
 		methodList = methodList.stream()
-				.filter(m -> Modifier.isPublic(m.getModifiers()))
+				.filter(FrankMethod::isPublic)
 				.filter(Utils::isAttributeGetterOrSetter)
 				.filter(m -> m.getName().startsWith(prefix) && (m.getName().length() > prefix.length()))
 				.collect(Collectors.toList());
 		// The sort order determines the creation order of AttributeValues instances.
-		Collections.sort(methodList, Comparator.comparing(Method::getName));
-		Map<String, Method> result = new LinkedHashMap<>();
-		for(Method method: methodList) {
+		Collections.sort(methodList, Comparator.comparing(FrankMethod::getName));
+		Map<String, FrankMethod> result = new LinkedHashMap<>();
+		for(FrankMethod method: methodList) {
 			String attributeName = attributeOf(method.getName(), prefix);
 			result.put(attributeName, method);
 		}
@@ -252,29 +257,29 @@ public class FrankDocModel {
 		return attributeName;
 	}
 
-	static Map<String, Method> getEnumGettersByAttributeName(Class<?> clazz) {
-		Method[] rawMethods = clazz.getMethods();
-		List<Method> methods = Arrays.asList(rawMethods).stream()
+	static Map<String, FrankMethod> getEnumGettersByAttributeName(FrankClass clazz) {
+		FrankMethod[] rawMethods = clazz.getDeclaredAndInheritedMethods();
+		List<FrankMethod> methods = Arrays.asList(rawMethods).stream()
 				.filter(m -> m.getName().endsWith(ENUM))
 				.filter(m -> m.getReturnType().isEnum())
 				.filter(m -> m.getParameterCount() == 0)
 				// This filter cannot be covered with tests, because getMethods
 				// does not include a non-public method in the test classes.
-				.filter(m -> m.getModifiers() == Modifier.PUBLIC)
+				.filter(FrankMethod::isPublic)
 				.collect(Collectors.toList());
-		Map<String, Method> result = new HashMap<>();
-		for(Method m: methods) {
+		Map<String, FrankMethod> result = new HashMap<>();
+		for(FrankMethod m: methods) {
 			result.put(enumAttributeOf(m), m);
 		}
 		return result;
 	}
 
-	private static String enumAttributeOf(Method method) {
+	private static String enumAttributeOf(FrankMethod method) {
 		String nameWithoutEnum = method.getName().substring(0, method.getName().length() - ENUM.length());
 		return attributeOf(nameWithoutEnum, "get");
 	}
 
-	private void checkForTypeConflict(Method setter, Method getter, FrankElement attributeOwner) {
+	private void checkForTypeConflict(FrankMethod setter, FrankMethod getter, FrankElement attributeOwner) {
 		log.trace("Checking for type conflict with getter or isser [{}]", () -> getter.getName());
 		String setterType = setter.getParameterTypes()[0].getName();
 		String getterType = getter.getReturnType().getName();
@@ -295,21 +300,21 @@ public class FrankDocModel {
 		}
 	}
 
-	private void documentAttribute(FrankAttribute attribute, Method method, FrankElement attributeOwner) throws ReflectiveOperationException {
-		attribute.setDeprecated(method.getAnnotation(Deprecated.class) != null);
+	private void documentAttribute(FrankAttribute attribute, FrankMethod method, FrankElement attributeOwner) throws DocletReflectiveOperationException {
+		attribute.setDeprecated(method.getAnnotation(FrankDocletConstants.DEPRECATED) != null);
 		attribute.setDocumented(
-				(method.getAnnotation(IbisDoc.class) != null)
-				|| (method.getAnnotation(IbisDocRef.class) != null));
+				(method.getAnnotation(FrankDocletConstants.IBISDOC) != null)
+				|| (method.getAnnotation(FrankDocletConstants.IBISDOCREF) != null));
 		log.trace("Attribute: deprecated = [{}], documented = [{}]", () -> attribute.isDeprecated(), () -> attribute.isDocumented());
-		IbisDocRef ibisDocRef = AnnotationUtils.findAnnotation(method, IbisDocRef.class);
+		FrankAnnotation ibisDocRef = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOCREF);
 		if(ibisDocRef != null) {
 			log.trace("Found @IbisDocRef annotation");
 			ParsedIbisDocRef parsed = parseIbisDocRef(ibisDocRef, method);
-			IbisDoc ibisDoc = null;
+			FrankAnnotation ibisDoc = null;
 			if(parsed.getReferredMethod() != null) {
-				ibisDoc = AnnotationUtils.findAnnotation(parsed.getReferredMethod(), IbisDoc.class);
+				ibisDoc = parsed.getReferredMethod().getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 				if(ibisDoc != null) {
-					attribute.setDescribingElement(findOrCreateFrankElement(parsed.getReferredMethod().getDeclaringClass()));
+					attribute.setDescribingElement(findOrCreateFrankElement(parsed.getReferredMethod().getDeclaringClass().getName()));
 					log.trace("Describing element of attribute [{}].[{}] is [{}]",
 							() -> attributeOwner.getFullName(), () -> attribute.getName(), () -> attribute.getDescribingElement().getFullName());
 					if(! attribute.parseIbisDocAnnotation(ibisDoc)) {
@@ -326,7 +331,7 @@ public class FrankDocModel {
 				log.warn("@IbisDocRef of Frank elelement [{}] attribute [{}] points to non-existent method", () -> attributeOwner.getSimpleName(), () -> attribute.getName());
 			}
 		}
-		IbisDoc ibisDoc = AnnotationUtils.findAnnotation(method, IbisDoc.class);
+		FrankAnnotation ibisDoc = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		if(ibisDoc != null) {
 			log.trace("For attribute [{}], have @IbisDoc without @IbisDocRef", attribute);
 			attribute.parseIbisDocAnnotation(ibisDoc);
@@ -341,23 +346,31 @@ public class FrankDocModel {
 	private class ParsedIbisDocRef {
 		private @Getter @Setter boolean hasOrder;
 		private @Getter @Setter int order;
-		private @Getter @Setter Method referredMethod;
+		private @Getter @Setter FrankMethod referredMethod;
 	}
 
-	private ParsedIbisDocRef parseIbisDocRef(IbisDocRef ibisDocRef, Method originalMethod) {
+	private ParsedIbisDocRef parseIbisDocRef(FrankAnnotation ibisDocRef, FrankMethod originalMethod) {
 		ParsedIbisDocRef result = new ParsedIbisDocRef();
 		result.setHasOrder(false);
-		String[] values = ibisDocRef.value();
+		String[] values = null;
+		try {
+			values = (String[]) ibisDocRef.getValue();
+		} catch(DocletReflectiveOperationException e) {
+			// TODO: Improve this message
+			log.warn("Could not parse IbisDocRef annotation");
+			return result;
+		}
 		String methodString = null;
 		if (values.length == 1) {
-			methodString = ibisDocRef.value()[0];
+			methodString = values[0];
 		} else if (values.length == 2) {
-			methodString = ibisDocRef.value()[1];
+			methodString = values[1];
 			try {
-				result.setOrder(Integer.parseInt(ibisDocRef.value()[0]));
+				result.setOrder(Integer.parseInt(values[0]));
 				result.setHasOrder(true);
 			} catch (Throwable t) {
-				log.warn("Could not parse order in @IbisDocRef annotation: [{}]", () -> ibisDocRef.value()[0]);
+				final String[] finalValues = values;
+				log.warn("Could not parse order in @IbisDocRef annotation: [{}]", () -> finalValues[0]);
 			}
 		}
 		else {
@@ -368,7 +381,7 @@ public class FrankDocModel {
 		return result;
 	}
 
-	private static Method getReferredMethod(String methodString, Method originalMethod) {
+	private FrankMethod getReferredMethod(String methodString, FrankMethod originalMethod) {
 		String lastNameComponent = methodString.substring(methodString.lastIndexOf(".") + 1).trim();
 		char firstLetter = lastNameComponent.toCharArray()[0];
 		String fullClassName = methodString;
@@ -382,22 +395,22 @@ public class FrankDocModel {
 		return getParentMethod(fullClassName, methodName);
 	}
 
-	private static Method getParentMethod(String className, String methodName) {
+	private FrankMethod getParentMethod(String className, String methodName) {
 		try {
-			Class<?> parentClass = Class.forName(className);
-			for (Method parentMethod : parentClass.getMethods()) {
+			FrankClass parentClass = classRepository.findClass(className);
+			for (FrankMethod parentMethod : parentClass.getDeclaredAndInheritedMethods()) {
 				if (parentMethod.getName().equals(methodName)) {
 					return parentMethod;
 				}
 			}
 			return null;
-		} catch (ClassNotFoundException e) {
+		} catch (DocletReflectiveOperationException e) {
 			log.warn("Super class [{}] was not found!", className);
 			return null;
 		}
 	}
 
-	private List<ConfigChild> createConfigChildren(Method[] methods, FrankElement parent) throws ReflectiveOperationException {
+	private List<ConfigChild> createConfigChildren(FrankMethod[] methods, FrankElement parent) throws DocletReflectiveOperationException {
 		log.trace("Creating config children of FrankElement [{}]", () -> parent.getFullName());
 		List<ConfigChild> result = new ArrayList<>();
 		for(ConfigChild.SortNode sortNode: createSortNodes(methods, parent)) {
@@ -410,7 +423,7 @@ public class FrankDocModel {
 			configChild.setMandatory(configChildDescriptor.isMandatory());
 			log.trace("For FrankElement [{}] method [{}], going to search element role", () -> parent.getFullName(), () -> sortNode.getName());
 			configChild.setElementRole(findOrCreateElementRole(
-					sortNode.getElementTypeClass(), configChildDescriptor.getRoleName()));
+					(FrankClass) sortNode.getElementTypeClass(), configChildDescriptor.getRoleName()));
 			log.trace("For FrankElement [{}] method [{}], have the element role", () -> parent.getFullName(), () -> sortNode.getName());
 			if(sortNode.getIbisDoc() == null) {
 				log.warn("No @IbisDoc annotation for config child [{}] of FrankElement [{}]", () -> configChild.getKey().toString(), () -> parent.getFullName());
@@ -428,14 +441,14 @@ public class FrankDocModel {
 		return result;
 	}
 
-	private List<ConfigChild.SortNode> createSortNodes(Method[] methods, FrankElement parent) {
-		List<Method> configChildSetters = Arrays.asList(methods).stream()
-				.filter(m -> Modifier.isPublic(m.getModifiers()))
+	private List<ConfigChild.SortNode> createSortNodes(FrankMethod[] methods, FrankElement parent) {
+		List<FrankMethod> configChildSetters = Arrays.asList(methods).stream()
+				.filter(FrankMethod::isPublic)
 				.filter(Utils::isConfigChildSetter)
 				.filter(m -> configChildDescriptors.get(m.getName()) != null)
 				.collect(Collectors.toList());
 		List<ConfigChild.SortNode> sortNodes = new ArrayList<>();
-		for(Method setter: configChildSetters) {
+		for(FrankMethod setter: configChildSetters) {
 			ConfigChild.SortNode sortNode = new ConfigChild.SortNode(setter);
 			sortNodes.add(sortNode);
 		}
@@ -443,7 +456,7 @@ public class FrankDocModel {
 		return sortNodes;
 	}
 
-	ElementRole findOrCreateElementRole(Class<?> elementTypeClass, String roleName) throws ReflectiveOperationException {
+	ElementRole findOrCreateElementRole(FrankClass elementTypeClass, String roleName) throws DocletReflectiveOperationException {
 		log.trace("ElementRole requested for elementTypeClass [{}] and roleName [{}]. Going to get the ElementType", () -> elementTypeClass.getName(), () -> roleName);
 		ElementType elementType = findOrCreateElementType(elementTypeClass);
 		ElementRole.Key key = new ElementRole.Key(elementTypeClass.getName(), roleName);
@@ -471,7 +484,7 @@ public class FrankDocModel {
 		return allElementRoles.get(new ElementRole.Key(fullElementTypeName, roleName));
 	}
 
-	ElementType findOrCreateElementType(Class<?> clazz) throws ReflectiveOperationException {
+	ElementType findOrCreateElementType(FrankClass clazz) throws DocletReflectiveOperationException {
 		log.trace("Requested ElementType for class [{}]", () -> clazz.getName());
 		if(allTypes.containsKey(clazz.getName())) {
 			log.trace("Already present");
@@ -483,16 +496,16 @@ public class FrankDocModel {
 		allTypes.put(result.getFullName(), result);
 		if(result.isFromJavaInterface()) {
 			log.trace("Class [{}] is a Java interface, going to create all member FrankElement", () -> clazz.getName());
-			List<SpringBean> springBeans = Utils.getSpringBeans(clazz.getName());
+			List<FrankClass> memberClasses = clazz.getInterfaceImplementations();
 			// We sort here to make the order deterministic.
-			Collections.sort(springBeans);
-			for(SpringBean b: springBeans) {
-				FrankElement frankElement = findOrCreateFrankElement(b.getClazz());
+			Collections.sort(memberClasses, Comparator.comparing(FrankClass::getName));
+			for(FrankClass memberClass: memberClasses) {
+				FrankElement frankElement = findOrCreateFrankElement(memberClass.getName());
 				result.addMember(frankElement);
 			}
 		} else {
 			log.trace("Class [{}] is not a Java interface, creating its FrankElement", () -> clazz.getName());
-			result.addMember(findOrCreateFrankElement(clazz));
+			result.addMember(findOrCreateFrankElement(clazz.getName()));
 		}
 		log.trace("Done creating ElementType for class [{}]", () -> clazz.getName());
 		return result;
@@ -696,7 +709,7 @@ public class FrankDocModel {
 		log.trace("Leave for roles [{}] and recursion depth [{}]", () -> ElementRole.describeCollection(roleGroup), () -> recursionDepth);
 	}
 
-	AttributeValues findOrCreateAttributeValues(Class<? extends Enum<?>> clazz) {
+	AttributeValues findOrCreateAttributeValues(FrankClass clazz) {
 		return attributeValuesFactory.findOrCreateAttributeValues(clazz);
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/doc/model/FrankElement.java
+++ b/core/src/main/java/nl/nn/adapterframework/doc/model/FrankElement.java
@@ -16,7 +16,6 @@ limitations under the License.
 
 package nl.nn.adapterframework.doc.model;
 
-import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -34,6 +33,8 @@ import org.apache.logging.log4j.Logger;
 
 import lombok.Getter;
 import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.doclet.FrankClass;
+import nl.nn.adapterframework.doc.doclet.FrankDocletConstants;
 import nl.nn.adapterframework.doc.model.ElementChild.AbstractKey;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.Misc;
@@ -57,9 +58,9 @@ public class FrankElement implements Comparable<FrankElement> {
 	private @Getter FrankElementStatistics statistics;
 	private LinkedHashMap<String, ConfigChildSet> configChildSets;
 
-	FrankElement(Class<?> clazz) {
-		this(clazz.getName(), clazz.getSimpleName(), Modifier.isAbstract(clazz.getModifiers()));
-		isDeprecated = clazz.getAnnotation(Deprecated.class) != null;
+	FrankElement(FrankClass clazz) {
+		this(clazz.getName(), clazz.getSimpleName(), clazz.isAbstract());
+		isDeprecated = clazz.getAnnotation(FrankDocletConstants.DEPRECATED) != null;
 		configChildSets = new LinkedHashMap<>();
 	}
 

--- a/core/src/test/java/nl/nn/adapterframework/doc/DocWriterNewAndJsonGenerationExamplesTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/DocWriterNewAndJsonGenerationExamplesTest.java
@@ -28,6 +28,7 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 import nl.nn.adapterframework.doc.model.FrankDocModel;
 import nl.nn.adapterframework.testutil.TestAssertions;
 import nl.nn.adapterframework.testutil.TestFileUtils;
@@ -67,7 +68,7 @@ public class DocWriterNewAndJsonGenerationExamplesTest {
 
 	private FrankDocModel createModel() throws Exception {
 		return FrankDocModel.populate(
-				getDigesterRulesPath(digesterRulesFileName), startClassName);
+				getDigesterRulesPath(digesterRulesFileName), startClassName, FrankClassRepository.getReflectInstance());
 	}
 
 	private String getDigesterRulesPath(String fileName) {

--- a/core/src/test/java/nl/nn/adapterframework/doc/DocWriterNewIntegrationTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/DocWriterNewIntegrationTest.java
@@ -32,10 +32,12 @@ import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
 import org.apache.logging.log4j.Logger;
+import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import nl.nn.adapterframework.core.Resource;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 import nl.nn.adapterframework.doc.model.FrankDocModel;
 import nl.nn.adapterframework.doc.model.FrankElement;
 import nl.nn.adapterframework.doc.model.FrankElementStatistics;
@@ -45,6 +47,13 @@ import nl.nn.adapterframework.util.LogUtil;
 public class DocWriterNewIntegrationTest {
 	private static Logger log = LogUtil.getLogger(DocWriterNewIntegrationTest.class);
 	private static final String TEST_CONFIGURATION_FILE = "testConfiguration.xml";
+
+	private FrankClassRepository classRepository;
+
+	@Before
+	public void setUp() {
+		classRepository = FrankClassRepository.getReflectInstance();
+	}
 
 	@Test
 	public void testStrict() throws Exception {
@@ -61,7 +70,7 @@ public class DocWriterNewIntegrationTest {
 	}
 
 	String generateXsd(XsdVersion version) throws IOException {
-		FrankDocModel model = FrankDocModel.populate();
+		FrankDocModel model = FrankDocModel.populate(classRepository);
 		DocWriterNew docWriter = new DocWriterNew(model);
 		docWriter.init(version);
 		String xsdString = docWriter.getSchema();
@@ -95,7 +104,7 @@ public class DocWriterNewIntegrationTest {
 	}
 
 	private String generateXsd(XsdVersion version, final String digesterRulesFileName, final String rootClassName, String outputSchemaFileName) throws IOException {
-		FrankDocModel model = FrankDocModel.populate(digesterRulesFileName, rootClassName);
+		FrankDocModel model = FrankDocModel.populate(digesterRulesFileName, rootClassName, classRepository);
 		DocWriterNew docWriter = new DocWriterNew(model);
 		docWriter.init(rootClassName, version);
 		String xsdString = docWriter.getSchema();
@@ -114,7 +123,7 @@ public class DocWriterNewIntegrationTest {
 	@Ignore
 	@Test
 	public void testJsonForWebsite() throws Exception {
-		FrankDocModel model = FrankDocModel.populate();
+		FrankDocModel model = FrankDocModel.populate(classRepository);
 		FrankDocJsonFactory jsonFactory = new FrankDocJsonFactory(model);
 		JsonObject jsonObject = jsonFactory.getJson();
 		String jsonText = jsonPretty(jsonObject.toString());
@@ -132,7 +141,7 @@ public class DocWriterNewIntegrationTest {
 	@Ignore
 	@Test
 	public void testStatistics() throws IOException {
-		FrankDocModel model = FrankDocModel.populate();
+		FrankDocModel model = FrankDocModel.populate(classRepository);
 		File output = new File("testStatistics.csv");
 		System.out.println("Output file of test statistics: " + output.getAbsolutePath());
 		Writer writer = new BufferedWriter(new FileWriter(output));

--- a/core/src/test/java/nl/nn/adapterframework/doc/UtilsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/UtilsTest.java
@@ -20,42 +20,43 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Method;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
 import org.junit.Test;
 
-import nl.nn.adapterframework.doc.objects.SpringBean;
+import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankClass;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+import nl.nn.adapterframework.doc.doclet.FrankMethod;
  
 public class UtilsTest {
 	private static final String SIMPLE = "nl.nn.adapterframework.doc.testtarget.simple";
 
 	@Test
-	public void testGetSpringBeans() throws ReflectiveOperationException {
-		List<SpringBean> actual = Utils.getSpringBeans(SIMPLE + ".IListener");
-		actual.sort((b1, b2) -> b1.compareTo(b2));
+	public void testGetSpringBeans() throws DocletReflectiveOperationException {
+		List<FrankClass> actual = FrankClassRepository.getReflectInstance().findClass(SIMPLE + ".IListener").getInterfaceImplementations();
+		Collections.sort(actual, Comparator.comparing(FrankClass::getName));
 		assertEquals(4, actual.size());
-		for(SpringBean a: actual) {
-			assertEquals(a.getClazz().getName(), a.getName());					
-		}
-		Iterator<SpringBean> it = actual.iterator();
-		SpringBean first = it.next();
+		Iterator<FrankClass> it = actual.iterator();
+		FrankClass first = it.next();
 		assertEquals(SIMPLE + ".ListenerChild", first.getName());
-		SpringBean second = it.next();
+		FrankClass second = it.next();
 		assertEquals(SIMPLE + ".ListenerGrandChild", second.getName());
-		SpringBean third = it.next();
+		FrankClass third = it.next();
 		assertEquals(SIMPLE + ".ListenerParent", third.getName());
 	}
 
 	@Test
-	public void whenMethodIsConfigChildSetterThenRecognized() {
+	public void whenMethodIsConfigChildSetterThenRecognized() throws DocletReflectiveOperationException {
 		assertTrue(isConfigChildSetter(getTestMethod("setListener")));
 	}
 
-	private Method getTestMethod(String name) {
-		Class<?> listenerChildClass = Utils.getClass(SIMPLE + ".ListenerChild");
-		for(Method m: listenerChildClass.getMethods()) {
+	private FrankMethod getTestMethod(String name) throws DocletReflectiveOperationException {
+		FrankClass listenerChildClass = FrankClassRepository.getReflectInstance().findClass(SIMPLE + ".ListenerChild");
+		for(FrankMethod m: listenerChildClass.getDeclaredAndInheritedMethods()) {
 			if(m.getName().equals(name)) {
 				return m;
 			}
@@ -64,22 +65,22 @@ public class UtilsTest {
 	}
 
 	@Test
-	public void whenAttributeSetterThenNotConfigChildSetter() {
+	public void whenAttributeSetterThenNotConfigChildSetter() throws DocletReflectiveOperationException {
 		assertFalse(isConfigChildSetter(getTestMethod("setChildAttribute")));
 	}
 
 	@Test
-	public void whenMethodHasTwoArgsThenNotConfigChildSetter() {
+	public void whenMethodHasTwoArgsThenNotConfigChildSetter() throws DocletReflectiveOperationException {
 		assertFalse(isConfigChildSetter(getTestMethod("invalidConfigChildSetterTwoArgs")));
 	}
 
 	@Test
-	public void whenMethodReturnsPrimitiveThenNotConfigChildSetter() {
+	public void whenMethodReturnsPrimitiveThenNotConfigChildSetter() throws DocletReflectiveOperationException {
 		assertFalse(isConfigChildSetter(getTestMethod("invalidConfigChildSetterReturnsInt")));
 	}
 
 	@Test
-	public void whenMethodReturnsStringThenNotConfigChildSetter() {
+	public void whenMethodReturnsStringThenNotConfigChildSetter()  throws DocletReflectiveOperationException {
 		assertFalse(isConfigChildSetter(getTestMethod("invalidConfigChildSetterReturnsString")));
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/doc/UtilsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/UtilsTest.java
@@ -27,7 +27,7 @@ import java.util.List;
 
 import org.junit.Test;
 
-import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankDocException;
 import nl.nn.adapterframework.doc.doclet.FrankClass;
 import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 import nl.nn.adapterframework.doc.doclet.FrankMethod;
@@ -36,7 +36,7 @@ public class UtilsTest {
 	private static final String SIMPLE = "nl.nn.adapterframework.doc.testtarget.simple";
 
 	@Test
-	public void testGetSpringBeans() throws DocletReflectiveOperationException {
+	public void testGetSpringBeans() throws FrankDocException {
 		List<FrankClass> actual = FrankClassRepository.getReflectInstance().findClass(SIMPLE + ".IListener").getInterfaceImplementations();
 		Collections.sort(actual, Comparator.comparing(FrankClass::getName));
 		assertEquals(4, actual.size());
@@ -50,11 +50,11 @@ public class UtilsTest {
 	}
 
 	@Test
-	public void whenMethodIsConfigChildSetterThenRecognized() throws DocletReflectiveOperationException {
+	public void whenMethodIsConfigChildSetterThenRecognized() throws FrankDocException {
 		assertTrue(isConfigChildSetter(getTestMethod("setListener")));
 	}
 
-	private FrankMethod getTestMethod(String name) throws DocletReflectiveOperationException {
+	private FrankMethod getTestMethod(String name) throws FrankDocException {
 		FrankClass listenerChildClass = FrankClassRepository.getReflectInstance().findClass(SIMPLE + ".ListenerChild");
 		for(FrankMethod m: listenerChildClass.getDeclaredAndInheritedMethods()) {
 			if(m.getName().equals(name)) {
@@ -65,22 +65,22 @@ public class UtilsTest {
 	}
 
 	@Test
-	public void whenAttributeSetterThenNotConfigChildSetter() throws DocletReflectiveOperationException {
+	public void whenAttributeSetterThenNotConfigChildSetter() throws FrankDocException {
 		assertFalse(isConfigChildSetter(getTestMethod("setChildAttribute")));
 	}
 
 	@Test
-	public void whenMethodHasTwoArgsThenNotConfigChildSetter() throws DocletReflectiveOperationException {
+	public void whenMethodHasTwoArgsThenNotConfigChildSetter() throws FrankDocException {
 		assertFalse(isConfigChildSetter(getTestMethod("invalidConfigChildSetterTwoArgs")));
 	}
 
 	@Test
-	public void whenMethodReturnsPrimitiveThenNotConfigChildSetter() throws DocletReflectiveOperationException {
+	public void whenMethodReturnsPrimitiveThenNotConfigChildSetter() throws FrankDocException {
 		assertFalse(isConfigChildSetter(getTestMethod("invalidConfigChildSetterReturnsInt")));
 	}
 
 	@Test
-	public void whenMethodReturnsStringThenNotConfigChildSetter()  throws DocletReflectiveOperationException {
+	public void whenMethodReturnsStringThenNotConfigChildSetter()  throws FrankDocException {
 		assertFalse(isConfigChildSetter(getTestMethod("invalidConfigChildSetterReturnsString")));
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflectTest.java
@@ -3,23 +3,28 @@ package nl.nn.adapterframework.doc.doclet;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
+import org.junit.Before;
 import org.junit.Test;
-
-import nl.nn.adapterframework.doc.Utils;
 
 public class FrankAnnotationReflectTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.doclet.";
-	private static final String IBISDOC = "nl.nn.adapterframework.doc.IbisDoc";
+
+	private FrankClassRepository classRepository;
+
+	@Before
+	public void setUp() {
+		classRepository = FrankClassRepository.getReflectInstance();
+	}
 
 	@Test
 	public void whenArrayAnnotationValueProvidedAsScalarThenStillFetchable() throws DocletReflectiveOperationException {
-		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Parent"));
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Parent");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertEquals("setInherited", setter.getName());
 		FrankAnnotation[] annotations = setter.getAnnotations();
 		assertEquals(1, annotations.length);
 		FrankAnnotation annotation = annotations[0];
-		assertEquals(IBISDOC, annotation.getName());
+		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 		Object rawValue = annotation.getValue();
 		String[] value = (String[]) rawValue;
 		assertArrayEquals(new String[] {"50"}, value);
@@ -27,11 +32,11 @@ public class FrankAnnotationReflectTest {
 
 	@Test
 	public void whenArrayAnnotaionValueProvidedAsArrayThenFetchable() throws DocletReflectiveOperationException {
-		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "DeprecatedChild"));
+		FrankClass clazz = classRepository.findClass(PACKAGE + "DeprecatedChild");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "someSetter");
 		assertEquals("someSetter", setter.getName());
-		FrankAnnotation annotation = setter.getAnnotation(IBISDOC);
-		assertEquals(IBISDOC, annotation.getName());
+		FrankAnnotation annotation = setter.getAnnotation(FrankDocletConstants.IBISDOC);
+		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 		assertArrayEquals(new String[] {"100", "Some description", "0"}, (String[]) annotation.getValue());
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflectTest.java
@@ -17,7 +17,7 @@ public class FrankAnnotationReflectTest {
 	}
 
 	@Test
-	public void whenArrayAnnotationValueProvidedAsScalarThenStillFetchable() throws DocletReflectiveOperationException {
+	public void whenArrayAnnotationValueProvidedAsScalarThenStillFetchable() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Parent");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertEquals("setInherited", setter.getName());
@@ -31,7 +31,7 @@ public class FrankAnnotationReflectTest {
 	}
 
 	@Test
-	public void whenArrayAnnotaionValueProvidedAsArrayThenFetchable() throws DocletReflectiveOperationException {
+	public void whenArrayAnnotaionValueProvidedAsArrayThenFetchable() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "DeprecatedChild");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "someSetter");
 		assertEquals("someSetter", setter.getName());

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankAnnotationReflectTest.java
@@ -1,0 +1,37 @@
+package nl.nn.adapterframework.doc.doclet;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import nl.nn.adapterframework.doc.Utils;
+
+public class FrankAnnotationReflectTest {
+	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.doclet.";
+	private static final String IBISDOC = "nl.nn.adapterframework.doc.IbisDoc";
+
+	@Test
+	public void whenArrayAnnotationValueProvidedAsScalarThenStillFetchable() throws DocletReflectiveOperationException {
+		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Parent"));
+		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
+		assertEquals("setInherited", setter.getName());
+		FrankAnnotation[] annotations = setter.getAnnotations();
+		assertEquals(1, annotations.length);
+		FrankAnnotation annotation = annotations[0];
+		assertEquals(IBISDOC, annotation.getName());
+		Object rawValue = annotation.getValue();
+		String[] value = (String[]) rawValue;
+		assertArrayEquals(new String[] {"50"}, value);
+	}
+
+	@Test
+	public void whenArrayAnnotaionValueProvidedAsArrayThenFetchable() throws DocletReflectiveOperationException {
+		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "DeprecatedChild"));
+		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "someSetter");
+		assertEquals("someSetter", setter.getName());
+		FrankAnnotation annotation = setter.getAnnotation(IBISDOC);
+		assertEquals(IBISDOC, annotation.getName());
+		assertArrayEquals(new String[] {"100", "Some description", "0"}, (String[]) annotation.getValue());
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
@@ -30,7 +30,7 @@ public class FrankClassReflectTest {
 	}
 
 	@Test
-	public void testChildClass() throws DocletReflectiveOperationException {
+	public void testChildClass() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		assertEquals(PACKAGE + "Child", instance.getName());
 		assertTrue(instance.isPublic());
@@ -43,13 +43,13 @@ public class FrankClassReflectTest {
 	}
 
 	@Test
-	public void whenClassIsPackagePrivateThenNotPublic() throws DocletReflectiveOperationException {
+	public void whenClassIsPackagePrivateThenNotPublic() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "PackagePrivateClass");
 		assertFalse(instance.isPublic());
 	}
 
 	@Test
-	public void testClassAnnotations() throws DocletReflectiveOperationException {
+	public void testClassAnnotations() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "DeprecatedChild");
 		FrankAnnotation[] annotations = instance.getAnnotations();
 		assertEquals(1, annotations.length);
@@ -61,27 +61,27 @@ public class FrankClassReflectTest {
 	}
 
 	@Test
-	public void classObjectHasSuperclassNull() throws DocletReflectiveOperationException {
+	public void classObjectHasSuperclassNull() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(OBJECT);
 		assertNull(instance.getSuperclass());
 	}
 
 	@Test
-	public void interfaceCanGiveItsImplementations() throws DocletReflectiveOperationException {
+	public void interfaceCanGiveItsImplementations() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "MyInterface");
 		List<FrankClass> implementations = instance.getInterfaceImplementations();
 		assertEquals(1, implementations.size());
 		assertEquals("Child", implementations.get(0).getSimpleName());
 	}
 
-	@Test(expected = DocletReflectiveOperationException.class)
-	public void nonInterfaceCannotGiveItsImplementations() throws DocletReflectiveOperationException {
+	@Test(expected = FrankDocException.class)
+	public void nonInterfaceCannotGiveItsImplementations() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		instance.getInterfaceImplementations();
 	}
 
 	@Test
-	public void getDeclaredMethodsDoesNotIncludeInheritedMethods() throws DocletReflectiveOperationException {
+	public void getDeclaredMethodsDoesNotIncludeInheritedMethods() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod[] declaredMethods = instance.getDeclaredMethods();
 		final Set<String> actualMethodNames = new TreeSet<>();
@@ -100,7 +100,7 @@ public class FrankClassReflectTest {
 	 * </ul>
 	 */
 	@Test
-	public void testGetDeclaredAndInheritedMethods() throws DocletReflectiveOperationException {
+	public void testGetDeclaredAndInheritedMethods() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod[] methods = instance.getDeclaredAndInheritedMethods();
 		final Set<String> methodNames = new TreeSet<>();

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
@@ -1,0 +1,87 @@
+package nl.nn.adapterframework.doc.doclet;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.junit.Test;
+
+import nl.nn.adapterframework.doc.Utils;
+
+public class FrankClassReflectTest {
+	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.doclet.";
+	private static final String DEPRECATED = "java.lang.Deprecated";
+	private static final String OBJECT = "java.lang.Object";
+
+	@Test
+	public void testChildClass() {
+		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		assertEquals(PACKAGE + "Child", instance.getName());
+		assertTrue(instance.isPublic());
+		assertEquals(0, instance.getAnnotations().length);
+		assertNull(instance.getAnnotation(DEPRECATED));
+		assertFalse(instance.isAbstract());
+		assertEquals("Child", instance.getSimpleName());
+		assertEquals("Parent", instance.getSuperclass().getSimpleName());
+		assertFalse(instance.isInterface());
+	}
+
+	@Test
+	public void whenClassIsPackagePrivateThenNotPublic() {
+		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "PackagePrivateClass"));
+		assertFalse(instance.isPublic());
+	}
+
+	@Test
+	public void testClassAnnotations() {
+		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "DeprecatedChild"));
+		FrankAnnotation[] annotations = instance.getAnnotations();
+		assertEquals(1, annotations.length);
+		FrankAnnotation annotation = annotations[0];
+		assertEquals(DEPRECATED, annotation.getName());
+		annotation = instance.getAnnotation(DEPRECATED);
+		assertNotNull(annotation);
+		assertEquals(DEPRECATED, annotation.getName());
+	}
+
+	@Test
+	public void classObjectHasSuperclassNull() {
+		FrankClass instance = new FrankClassReflect(Utils.getClass(OBJECT));
+		assertNull(instance.getSuperclass());
+	}
+
+	@Test
+	public void interfaceCanGiveItsImplementations() throws DocletReflectiveOperationException {
+		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "MyInterface"));
+		List<FrankClass> implementations = instance.getInterfaceImplementations();
+		assertEquals(1, implementations.size());
+		assertEquals("Child", implementations.get(0).getSimpleName());
+	}
+
+	@Test(expected = DocletReflectiveOperationException.class)
+	public void nonInterfaceCannotGiveItsImplementations() throws DocletReflectiveOperationException {
+		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		instance.getInterfaceImplementations();
+	}
+
+	@Test
+	public void getDeclaredMethodsDoesNotIncludeInheritedMethods() {
+		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		FrankMethod[] declaredMethods = instance.getDeclaredMethods();
+		final Set<String> actualMethodNames = new TreeSet<>();
+		Arrays.asList(declaredMethods).forEach(m -> actualMethodNames.add(m.getName()));
+		List<String> sortedActualMethodNames = new ArrayList<>(actualMethodNames);
+		sortedActualMethodNames = sortedActualMethodNames.stream().filter(name -> ! name.contains("jacoco")).collect(Collectors.toList());
+		assertArrayEquals(new String[] {"packagePrivateMethod", "setInherited"}, sortedActualMethodNames.toArray());
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
@@ -117,4 +117,18 @@ public class FrankClassReflectTest {
 			assertEquals(String.format("Duplicate method name [%s]", name), 1, methodsByName.get(name).size());
 		}
 	}
+
+	@Test
+	public void whenInterfaceDoesNotExtendOthersThenGetInterfacesReturnsEmptyArray() throws Exception{
+		FrankClass instance = classRepository.findClass(PACKAGE + "MyInterfaceParent");
+		assertEquals(0, instance.getInterfaces().length);
+	}
+
+	@Test
+	public void whenInterfaceExtendsOtherInterfaceThenReturnedByGetInterfaces() throws Exception {
+		FrankClass instance = classRepository.findClass(PACKAGE + "MyInterface");
+		FrankClass[] implementedInterfaces = instance.getInterfaces();
+		assertEquals(1, implementedInterfaces.length);
+		assertEquals("MyInterfaceParent", implementedInterfaces[0].getSimpleName());
+	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankClassReflectTest.java
@@ -15,22 +15,27 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import org.junit.Before;
 import org.junit.Test;
-
-import nl.nn.adapterframework.doc.Utils;
 
 public class FrankClassReflectTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.doclet.";
-	private static final String DEPRECATED = "java.lang.Deprecated";
 	private static final String OBJECT = "java.lang.Object";
 
+	private FrankClassRepository classRepository;
+
+	@Before
+	public void setUp() {
+		classRepository = FrankClassRepository.getReflectInstance();
+	}
+
 	@Test
-	public void testChildClass() {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+	public void testChildClass() throws DocletReflectiveOperationException {
+		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		assertEquals(PACKAGE + "Child", instance.getName());
 		assertTrue(instance.isPublic());
 		assertEquals(0, instance.getAnnotations().length);
-		assertNull(instance.getAnnotation(DEPRECATED));
+		assertNull(instance.getAnnotation(FrankDocletConstants.DEPRECATED));
 		assertFalse(instance.isAbstract());
 		assertEquals("Child", instance.getSimpleName());
 		assertEquals("Parent", instance.getSuperclass().getSimpleName());
@@ -38,32 +43,32 @@ public class FrankClassReflectTest {
 	}
 
 	@Test
-	public void whenClassIsPackagePrivateThenNotPublic() {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "PackagePrivateClass"));
+	public void whenClassIsPackagePrivateThenNotPublic() throws DocletReflectiveOperationException {
+		FrankClass instance = classRepository.findClass(PACKAGE + "PackagePrivateClass");
 		assertFalse(instance.isPublic());
 	}
 
 	@Test
-	public void testClassAnnotations() {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "DeprecatedChild"));
+	public void testClassAnnotations() throws DocletReflectiveOperationException {
+		FrankClass instance = classRepository.findClass(PACKAGE + "DeprecatedChild");
 		FrankAnnotation[] annotations = instance.getAnnotations();
 		assertEquals(1, annotations.length);
 		FrankAnnotation annotation = annotations[0];
-		assertEquals(DEPRECATED, annotation.getName());
-		annotation = instance.getAnnotation(DEPRECATED);
+		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
+		annotation = instance.getAnnotation(FrankDocletConstants.DEPRECATED);
 		assertNotNull(annotation);
-		assertEquals(DEPRECATED, annotation.getName());
+		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
 	}
 
 	@Test
-	public void classObjectHasSuperclassNull() {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(OBJECT));
+	public void classObjectHasSuperclassNull() throws DocletReflectiveOperationException {
+		FrankClass instance = classRepository.findClass(OBJECT);
 		assertNull(instance.getSuperclass());
 	}
 
 	@Test
 	public void interfaceCanGiveItsImplementations() throws DocletReflectiveOperationException {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "MyInterface"));
+		FrankClass instance = classRepository.findClass(PACKAGE + "MyInterface");
 		List<FrankClass> implementations = instance.getInterfaceImplementations();
 		assertEquals(1, implementations.size());
 		assertEquals("Child", implementations.get(0).getSimpleName());
@@ -71,13 +76,13 @@ public class FrankClassReflectTest {
 
 	@Test(expected = DocletReflectiveOperationException.class)
 	public void nonInterfaceCannotGiveItsImplementations() throws DocletReflectiveOperationException {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		instance.getInterfaceImplementations();
 	}
 
 	@Test
-	public void getDeclaredMethodsDoesNotIncludeInheritedMethods() {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+	public void getDeclaredMethodsDoesNotIncludeInheritedMethods() throws DocletReflectiveOperationException {
+		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod[] declaredMethods = instance.getDeclaredMethods();
 		final Set<String> actualMethodNames = new TreeSet<>();
 		Arrays.asList(declaredMethods).forEach(m -> actualMethodNames.add(m.getName()));
@@ -95,8 +100,8 @@ public class FrankClassReflectTest {
 	 * </ul>
 	 */
 	@Test
-	public void testGetDeclaredAndInheritedMethods() {
-		FrankClass instance = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+	public void testGetDeclaredAndInheritedMethods() throws DocletReflectiveOperationException {
+		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod[] methods = instance.getDeclaredAndInheritedMethods();
 		final Set<String> methodNames = new TreeSet<>();
 		Arrays.asList(methods).stream()

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
@@ -1,0 +1,73 @@
+package nl.nn.adapterframework.doc.doclet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import nl.nn.adapterframework.doc.Utils;
+
+public class FrankMethodReflectTest {
+	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.doclet.";
+	private static final String IBISDOC = "nl.nn.adapterframework.doc.IbisDoc";
+	private static final String STRING = "java.lang.String";
+
+	@Test
+	public void testMethod() throws DocletReflectiveOperationException {
+		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Parent"));
+		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
+		assertEquals("setInherited", setter.getName());
+		assertTrue(setter.isPublic());
+		FrankAnnotation[] annotations = setter.getAnnotations();
+		assertEquals(1, annotations.length);
+		FrankAnnotation annotation = annotations[0];
+		assertEquals(IBISDOC, annotation.getName());
+		annotation = setter.getAnnotation(IBISDOC);
+		assertNotNull(annotation);
+		assertEquals(IBISDOC, annotation.getName());
+		FrankType returnType = setter.getReturnType();
+		assertNotNull(returnType);
+		assertTrue(returnType.isPrimitive());
+		assertEquals("void", returnType.getName());
+		assertEquals(1, setter.getParameterCount());
+		FrankType[] parameters = setter.getParameterTypes();
+		assertEquals(1, parameters.length);
+		FrankType parameter = parameters[0];
+		assertFalse(parameter.isPrimitive());
+		assertEquals(STRING, parameter.getName());
+		annotation = setter.getAnnotationInludingInherited(IBISDOC);
+		assertNotNull(annotation);
+		assertEquals(IBISDOC, annotation.getName());
+	}
+
+	@Test
+	public void whenMethodIsPackagePrivateThenNotPublic() {
+		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "packagePrivateMethod");
+		assertNotNull(method);
+		assertFalse(method.isPublic());
+	}
+
+	@Test
+	public void whenNoAnnotationsThenNullReturned() {
+		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "packagePrivateMethod");
+		assertEquals(0, method.getAnnotations().length);
+		assertNull(method.getAnnotation(IBISDOC));
+	}
+
+	@Test
+	public void whenInheritedAnnotationsRequestedThenInheritedAnnotationsIncluded() throws DocletReflectiveOperationException {
+		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
+		assertNotNull(method);
+		FrankAnnotation annotation = method.getAnnotation(IBISDOC);
+		assertNull(annotation);
+		annotation = method.getAnnotationInludingInherited(IBISDOC);
+		assertNotNull(annotation);
+		assertEquals(IBISDOC, annotation.getName());
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
@@ -6,28 +6,33 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import org.junit.Before;
 import org.junit.Test;
-
-import nl.nn.adapterframework.doc.Utils;
 
 public class FrankMethodReflectTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.doclet.";
-	private static final String IBISDOC = "nl.nn.adapterframework.doc.IbisDoc";
 	private static final String STRING = "java.lang.String";
+
+	private FrankClassRepository classRepository;
+
+	@Before
+	public void setUp() {
+		classRepository = FrankClassRepository.getReflectInstance();
+	}
 
 	@Test
 	public void testMethod() throws DocletReflectiveOperationException {
-		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Parent"));
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Parent");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertEquals("setInherited", setter.getName());
 		assertTrue(setter.isPublic());
 		FrankAnnotation[] annotations = setter.getAnnotations();
 		assertEquals(1, annotations.length);
 		FrankAnnotation annotation = annotations[0];
-		assertEquals(IBISDOC, annotation.getName());
-		annotation = setter.getAnnotation(IBISDOC);
+		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
+		annotation = setter.getAnnotation(FrankDocletConstants.IBISDOC);
 		assertNotNull(annotation);
-		assertEquals(IBISDOC, annotation.getName());
+		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 		FrankType returnType = setter.getReturnType();
 		assertNotNull(returnType);
 		assertTrue(returnType.isPrimitive());
@@ -38,36 +43,36 @@ public class FrankMethodReflectTest {
 		FrankType parameter = parameters[0];
 		assertFalse(parameter.isPrimitive());
 		assertEquals(STRING, parameter.getName());
-		annotation = setter.getAnnotationInludingInherited(IBISDOC);
+		annotation = setter.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		assertNotNull(annotation);
-		assertEquals(IBISDOC, annotation.getName());
+		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 	}
 
 	@Test
-	public void whenMethodIsPackagePrivateThenNotPublic() {
-		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+	public void whenMethodIsPackagePrivateThenNotPublic() throws DocletReflectiveOperationException {
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "packagePrivateMethod");
 		assertNotNull(method);
 		assertFalse(method.isPublic());
 	}
 
 	@Test
-	public void whenNoAnnotationsThenNullReturned() {
-		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+	public void whenNoAnnotationsThenNullReturned() throws DocletReflectiveOperationException {
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "packagePrivateMethod");
 		assertEquals(0, method.getAnnotations().length);
-		assertNull(method.getAnnotation(IBISDOC));
+		assertNull(method.getAnnotation(FrankDocletConstants.IBISDOC));
 	}
 
 	@Test
 	public void whenInheritedAnnotationsRequestedThenInheritedAnnotationsIncluded() throws DocletReflectiveOperationException {
-		FrankClass clazz = new FrankClassReflect(Utils.getClass(PACKAGE + "Child"));
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertNotNull(method);
-		FrankAnnotation annotation = method.getAnnotation(IBISDOC);
+		FrankAnnotation annotation = method.getAnnotation(FrankDocletConstants.IBISDOC);
 		assertNull(annotation);
-		annotation = method.getAnnotationInludingInherited(IBISDOC);
+		annotation = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		assertNotNull(annotation);
-		assertEquals(IBISDOC, annotation.getName());
+		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
@@ -25,7 +25,7 @@ public class FrankMethodReflectTest {
 	}
 
 	@Test
-	public void testMethod() throws DocletReflectiveOperationException {
+	public void testMethod() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Parent");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertEquals("setInherited", setter.getName());
@@ -53,7 +53,7 @@ public class FrankMethodReflectTest {
 	}
 
 	@Test
-	public void whenMethodIsPackagePrivateThenNotPublic() throws DocletReflectiveOperationException {
+	public void whenMethodIsPackagePrivateThenNotPublic() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "packagePrivateMethod");
 		assertNotNull(method);
@@ -61,7 +61,7 @@ public class FrankMethodReflectTest {
 	}
 
 	@Test
-	public void whenNoAnnotationsThenNullReturned() throws DocletReflectiveOperationException {
+	public void whenNoAnnotationsThenNullReturned() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "packagePrivateMethod");
 		assertEquals(0, method.getAnnotations().length);
@@ -69,7 +69,7 @@ public class FrankMethodReflectTest {
 	}
 
 	@Test
-	public void whenInheritedAnnotationsRequestedThenInheritedAnnotationsIncluded() throws DocletReflectiveOperationException {
+	public void whenInheritedAnnotationsRequestedThenInheritedAnnotationsIncluded() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertNotNull(method);

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/FrankMethodReflectTest.java
@@ -6,6 +6,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.Before;
 import org.junit.Test;
 
@@ -74,5 +78,28 @@ public class FrankMethodReflectTest {
 		annotation = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		assertNotNull(annotation);
 		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
+	}
+
+	@Test
+	public void overriddenMethodHasOverriderAsDeclaringClass() throws Exception {
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
+		FrankMethod setter = getMethodFromDeclaredAndInheritedMethods(clazz, "setInherited");
+		assertEquals("Child", setter.getDeclaringClass().getSimpleName());
+	}
+
+	@Test
+	public void inheritedMethodHasAncestorAsDeclaringClass() throws Exception{
+		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
+		FrankMethod getter = getMethodFromDeclaredAndInheritedMethods(clazz, "getInherited");
+		assertEquals("Parent", getter.getDeclaringClass().getSimpleName());
+	}
+
+	private FrankMethod getMethodFromDeclaredAndInheritedMethods(FrankClass clazz, String methodName) {
+		FrankMethod[] methods = clazz.getDeclaredAndInheritedMethods();
+		List<FrankMethod> getters = Arrays.asList(methods).stream()
+				.filter(m -> m.getName().equals(methodName))
+				.collect(Collectors.toList());
+		assertEquals(1, getters.size());
+		return getters.get(0);
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/doc/doclet/TestUtil.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/doclet/TestUtil.java
@@ -1,0 +1,16 @@
+package nl.nn.adapterframework.doc.doclet;
+
+final class TestUtil {
+	private TestUtil() {
+	}
+
+	static FrankMethod getDeclaredMethodOf(FrankClass clazz, String methodName) {
+		FrankMethod[] methods = clazz.getDeclaredMethods();
+		for(FrankMethod m: methods) {
+			if(m.getName().equals(methodName)) {
+				return m;
+			}
+		}
+		return null;
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/AncestorKindsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/AncestorKindsTest.java
@@ -24,6 +24,8 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 /**
  * Class {@link FrankElement} has many different method to get children
  * and to search ancestors that have children. The tests in this class
@@ -38,7 +40,7 @@ public class AncestorKindsTest {
 
 	@Before
 	public void setUp() {
-		model = FrankDocModel.populate("doc/sparse-digester-rules.xml", PACKAGE + "ContainerChild");
+		model = FrankDocModel.populate("doc/sparse-digester-rules.xml", PACKAGE + "ContainerChild", FrankClassRepository.getReflectInstance());
 	}
 
 	@Test

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/ChildRejectorTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/ChildRejectorTest.java
@@ -16,8 +16,8 @@ limitations under the License.
 package nl.nn.adapterframework.doc.model;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 
 import org.junit.Test;
 
-import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 
 public class ChildRejectorTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.walking";
@@ -37,7 +37,7 @@ public class ChildRejectorTest {
 
 	private void init(String modelPopulateClassSimpleName, Predicate<ElementChild> selector, Predicate<ElementChild> rejector, String subject) throws Exception {
 		String rootClassName = PACKAGE + "." + modelPopulateClassSimpleName;
-		model = FrankDocModel.populate("doc/empty-digester-rules.xml", rootClassName);
+		model = FrankDocModel.populate("doc/empty-digester-rules.xml", rootClassName, FrankClassRepository.getReflectInstance());
 		instance = new ChildRejector<FrankAttribute>(
 				selector, rejector, FrankAttribute.class);
 		instance.init(getElement(subject));
@@ -45,7 +45,7 @@ public class ChildRejectorTest {
 
 	private FrankElement getElement(String simpleName) throws Exception {
 		String rootClassName = PACKAGE + "." + simpleName;
-		return model.findOrCreateFrankElement(Utils.getClass(rootClassName));
+		return model.findOrCreateFrankElement(rootClassName);
 	}
 
 	private Set<String> childNames(String frankElementSimpleName) throws Exception {

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/ConfigChildTechnicalOverrideTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/ConfigChildTechnicalOverrideTest.java
@@ -10,6 +10,8 @@ import java.util.stream.Collectors;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 public class ConfigChildTechnicalOverrideTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.technical.override.";
 	private static final String DIGESTER_RULES = "doc/technical-override-digester-rules.xml";
@@ -18,7 +20,7 @@ public class ConfigChildTechnicalOverrideTest {
 
 	@BeforeClass
 	public static void setUp() {
-		model = FrankDocModel.populate(DIGESTER_RULES, PACKAGE + "Master");
+		model = FrankDocModel.populate(DIGESTER_RULES, PACKAGE + "Master", FrankClassRepository.getReflectInstance());
 	}
 
 	@Test

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/ElementRoleIntegrationTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/ElementRoleIntegrationTest.java
@@ -21,6 +21,8 @@ import static org.junit.Assert.assertNotNull;
 import org.junit.Before;
 import org.junit.Test;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 public class ElementRoleIntegrationTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.role.";
 
@@ -28,7 +30,7 @@ public class ElementRoleIntegrationTest {
 
 	@Before
 	public void setUp() {
-		model = FrankDocModel.populate("doc/role-digester-rules.xml", PACKAGE + "Master");
+		model = FrankDocModel.populate("doc/role-digester-rules.xml", PACKAGE + "Master", FrankClassRepository.getReflectInstance());
 	}
 
 	@Test

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelConfigChildrenDetailTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelConfigChildrenDetailTest.java
@@ -27,12 +27,14 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 public class FrankDocModelConfigChildrenDetailTest {
 	private FrankDocModel instance;
 
 	@Before
 	public void setUp() throws SAXException, IOException {
-		instance = new FrankDocModel();
+		instance = new FrankDocModel(FrankClassRepository.getReflectInstance());
 		instance.createConfigChildDescriptorsFrom("doc/fake-digester-rules.xml");
 	}
 

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelConfigChildrenTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelConfigChildrenTest.java
@@ -31,7 +31,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
-import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 
 public class FrankDocModelConfigChildrenTest {
 	private static String CONTAINER = "nl.nn.adapterframework.doc.testtarget.children.Container";
@@ -39,16 +40,18 @@ public class FrankDocModelConfigChildrenTest {
 	private static String CONTAINER_OTHER = "nl.nn.adapterframework.doc.testtarget.children.ContainerOther";
 	
 	private FrankDocModel instance;
+	private FrankClassRepository classRepository;
 	private List<ConfigChild> configChildren;
 	private List<ConfigChild> configChildrenOfDerived;
 
 	@Before
-	public void setUp() throws SAXException, IOException, ReflectiveOperationException {
-		instance = new FrankDocModel();
+	public void setUp() throws SAXException, IOException, DocletReflectiveOperationException {
+		classRepository = FrankClassRepository.getReflectInstance();
+		instance = new FrankDocModel(classRepository);
 		instance.createConfigChildDescriptorsFrom("doc/simple-digester-rules.xml");
-		instance.findOrCreateElementType(Utils.getClass(CONTAINER));
-		instance.findOrCreateElementType(Utils.getClass(CONTAINER_DERIVED));
-		instance.findOrCreateElementType(Utils.getClass(CONTAINER_OTHER));
+		instance.findOrCreateElementType(classRepository.findClass(CONTAINER));
+		instance.findOrCreateElementType(classRepository.findClass(CONTAINER_DERIVED));
+		instance.findOrCreateElementType(classRepository.findClass(CONTAINER_OTHER));
 		instance.setOverriddenFrom();
 		configChildren = instance.getAllElements().get(CONTAINER).getConfigChildren(ALL);
 		configChildrenOfDerived = instance.getAllElements().get(CONTAINER_DERIVED).getConfigChildren(ALL);
@@ -200,7 +203,7 @@ public class FrankDocModelConfigChildrenTest {
 
 	@Test
 	public void whenInheritedConfigChildNotDeprecatedInheritedFromDeprecatedThenNotDeprecated() throws Exception {
-		ConfigChild theConfigChild = instance.findOrCreateFrankElement(Utils.getClass(CONTAINER_OTHER))
+		ConfigChild theConfigChild = instance.findOrCreateFrankElement(CONTAINER_OTHER)
 				.getConfigChildren(c -> ((ConfigChild)c).getOrder() == 110).get(0);
 		assertFalse(theConfigChild.isDeprecated());
 	}

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelConfigChildrenTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelConfigChildrenTest.java
@@ -31,7 +31,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
-import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankDocException;
 import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 
 public class FrankDocModelConfigChildrenTest {
@@ -45,7 +45,7 @@ public class FrankDocModelConfigChildrenTest {
 	private List<ConfigChild> configChildrenOfDerived;
 
 	@Before
-	public void setUp() throws SAXException, IOException, DocletReflectiveOperationException {
+	public void setUp() throws SAXException, IOException, FrankDocException {
 		classRepository = FrankClassRepository.getReflectInstance();
 		instance = new FrankDocModel(classRepository);
 		instance.createConfigChildDescriptorsFrom("doc/simple-digester-rules.xml");

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelEnumAttributeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelEnumAttributeTest.java
@@ -5,20 +5,28 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Method;
 import java.util.Map;
 
+import org.junit.Before;
 import org.junit.Test;
 
-import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+import nl.nn.adapterframework.doc.doclet.FrankMethod;
 
 public class FrankDocModelEnumAttributeTest {
 	private static final String CHILD = "nl.nn.adapterframework.doc.testtarget.enumattr.Child";
 	private static final String MY_ENUM = "nl.nn.adapterframework.doc.testtarget.enumattr.MyEnum";
 
+	private FrankClassRepository classRepository;
+
+	@Before
+	public void setUp() {
+		classRepository = FrankClassRepository.getReflectInstance();
+	}
+
 	@Test
-	public void testGetEnumGettersByAttributeName() {
-		Map<String, Method> actual = FrankDocModel.getEnumGettersByAttributeName(Utils.getClass(CHILD));
+	public void testGetEnumGettersByAttributeName() throws Exception {
+		Map<String, FrankMethod> actual = FrankDocModel.getEnumGettersByAttributeName(classRepository.findClass(CHILD));
 		assertTrue(actual.containsKey("parentAttribute"));
 		assertTrue(actual.containsKey("childAttribute"));
 		assertEquals(2, actual.size());
@@ -26,7 +34,7 @@ public class FrankDocModelEnumAttributeTest {
 
 	@Test
 	public void testPopulate() {
-		FrankDocModel model = FrankDocModel.populate("doc/empty-digester-rules.xml", CHILD);
+		FrankDocModel model = FrankDocModel.populate("doc/empty-digester-rules.xml", CHILD, classRepository);
 		FrankElement child = model.findFrankElement(CHILD);
 		assertNotNull(child);
 		AttributeValues myEnum = model.findAttributeValues(MY_ENUM);

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelGroupsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelGroupsTest.java
@@ -26,6 +26,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 public class FrankDocModelGroupsTest {
 	private static final String I_GROUP_CONTAINER = "nl.nn.adapterframework.doc.testtarget.groups.IGroupContainer";
 
@@ -33,7 +35,8 @@ public class FrankDocModelGroupsTest {
 	
 	@Before
 	public void setUp() throws SAXException, IOException, ReflectiveOperationException {
-		instance = FrankDocModel.populate("doc/fake-group-digester-rules.xml", "nl.nn.adapterframework.doc.testtarget.groups.GroupContainer");
+		FrankClassRepository r = FrankClassRepository.getReflectInstance();
+		instance = FrankDocModel.populate("doc/fake-group-digester-rules.xml", "nl.nn.adapterframework.doc.testtarget.groups.GroupContainer", r);
 	}
 
 	@Test

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelPopulateTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelPopulateTest.java
@@ -24,6 +24,8 @@ import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 @Ignore("Test takes a long time to run, and gives little information")
 public class FrankDocModelPopulateTest {
 	private FrankDocModel instance;
@@ -32,7 +34,7 @@ public class FrankDocModelPopulateTest {
 
 	@Before
 	public void setUp() {
-		instance = FrankDocModel.populate();
+		instance = FrankDocModel.populate(FrankClassRepository.getReflectInstance());
 		actualTypeSimpleNames = instance.getAllTypes().values().stream()
 				.map(ElementType::getSimpleName).collect(Collectors.toSet());
 		actualElementSimpleNames = instance.getAllElements().values().stream()

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -34,7 +33,9 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+import nl.nn.adapterframework.doc.doclet.FrankMethod;
 
 public class FrankDocModelTest {
 	private static final String SIMPLE = "nl.nn.adapterframework.doc.testtarget.simple";
@@ -51,26 +52,28 @@ public class FrankDocModelTest {
 	private static final String REFERRER = "nl.nn.adapterframework.doc.testtarget.ibisdocref.Referrer";
 	private static final String REFERRER_CHILD = "nl.nn.adapterframework.doc.testtarget.ibisdocref.ReferrerChild";
 
+	private FrankClassRepository classRepository;
 	private FrankDocModel instance;
 	private FrankElement fakeAttributeOwner;
 
 	@Before
 	public void setUp() {
-		instance = new FrankDocModel();
+		classRepository = FrankClassRepository.getReflectInstance();
+		instance = new FrankDocModel(classRepository);
 		fakeAttributeOwner = null;
 	}
 
 	@Test
-	public void whenInterfaceTypeAndSingletonTypeThenCorrectElements() throws ReflectiveOperationException {
-		ElementType listenerType = instance.findOrCreateElementType(Utils.getClass(LISTENER));
-		ElementType childType = instance.findOrCreateElementType(Utils.getClass(SIMPLE_CHILD));
+	public void whenInterfaceTypeAndSingletonTypeThenCorrectElements() throws DocletReflectiveOperationException {
+		ElementType listenerType = instance.findOrCreateElementType(classRepository.findClass(LISTENER));
+		ElementType childType = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
 		checkModelTypes(listenerType, childType);
 	}
 
 	@Test
-	public void whenSingletonTypeAndInterfaceTypeThenCorrectElements() throws ReflectiveOperationException {
-		ElementType childType = instance.findOrCreateElementType(Utils.getClass(SIMPLE_CHILD));
-		ElementType listenerType = instance.findOrCreateElementType(Utils.getClass(LISTENER));
+	public void whenSingletonTypeAndInterfaceTypeThenCorrectElements() throws DocletReflectiveOperationException {
+		ElementType childType = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
+		ElementType listenerType = instance.findOrCreateElementType(classRepository.findClass(LISTENER));
 		checkModelTypes(listenerType, childType);		
 	}
 
@@ -111,26 +114,26 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenTypeRequestedTwiceThenSameInstanceReturned() throws ReflectiveOperationException {
-		ElementType first = instance.findOrCreateElementType(Utils.getClass(SIMPLE_CHILD));
-		ElementType second = instance.findOrCreateElementType(Utils.getClass(SIMPLE_CHILD));
+	public void whenTypeRequestedTwiceThenSameInstanceReturned() throws DocletReflectiveOperationException {
+		ElementType first = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
+		ElementType second = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
 		assertSame(first, second);
 	}
 
 	@Test
-	public void whenChildElementAddedBeforeParentThenCorrectModel() throws ReflectiveOperationException {
-		FrankElement child = instance.findOrCreateFrankElement(Utils.getClass(SIMPLE_CHILD));
-		FrankElement parent = instance.findOrCreateFrankElement(Utils.getClass(SIMPLE_PARENT));
-		instance.findOrCreateFrankElement(Utils.getClass(SIMPLE_GRNAD_CHILD));
+	public void whenChildElementAddedBeforeParentThenCorrectModel() throws DocletReflectiveOperationException {
+		FrankElement child = instance.findOrCreateFrankElement(SIMPLE_CHILD);
+		FrankElement parent = instance.findOrCreateFrankElement(SIMPLE_PARENT);
+		instance.findOrCreateFrankElement(SIMPLE_GRNAD_CHILD);
 		instance.setOverriddenFrom();
 		checkModelAfterChildAndParentAdded(parent, child);
 	}
 
 	@Test
-	public void whenParentElementAddedBeforeChildThenCorrectModel() throws ReflectiveOperationException {
-		FrankElement parent = instance.findOrCreateFrankElement(Utils.getClass(SIMPLE_PARENT));
-		FrankElement child = instance.findOrCreateFrankElement(Utils.getClass(SIMPLE_CHILD));
-		instance.findOrCreateFrankElement(Utils.getClass(SIMPLE_GRNAD_CHILD));
+	public void whenParentElementAddedBeforeChildThenCorrectModel() throws DocletReflectiveOperationException {
+		FrankElement parent = instance.findOrCreateFrankElement(SIMPLE_PARENT);
+		FrankElement child = instance.findOrCreateFrankElement(SIMPLE_CHILD);
+		instance.findOrCreateFrankElement(SIMPLE_GRNAD_CHILD);
 		instance.setOverriddenFrom();
 		checkModelAfterChildAndParentAdded(parent, child);
 	}
@@ -198,18 +201,18 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenSetterAndGetterThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterAndGetterThenAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeCreated("attributeSetterGetter");
 	}
 
-	private FrankAttribute checkReflectAttributeCreated(String attributeName) throws ReflectiveOperationException {
+	private FrankAttribute checkReflectAttributeCreated(String attributeName) throws DocletReflectiveOperationException {
 		Map<String, FrankAttribute> actual = getReflectInvestigatedFrankAttributes();
 		assertTrue(actual.containsKey(attributeName));
 		assertEquals(attributeName, actual.get(attributeName).getName());
 		return actual.get(attributeName);
 	}
 
-	private Map<String, FrankAttribute> getReflectInvestigatedFrankAttributes() throws ReflectiveOperationException {
+	private Map<String, FrankAttribute> getReflectInvestigatedFrankAttributes() throws DocletReflectiveOperationException {
 		return getAttributesOfClass("nl.nn.adapterframework.doc.testtarget.reflect.FrankAttributeTarget");
 	}
 
@@ -218,72 +221,72 @@ public class FrankDocModelTest {
 	 * of a class. A dummy FrankElement is supplied as attribute owner, so the
 	 * describingElement is only correct if it is parsed from an @IbisDocRef annotation.
 	 */
-	private Map<String, FrankAttribute> getAttributesOfClass(final String className) throws ReflectiveOperationException {
+	private Map<String, FrankAttribute> getAttributesOfClass(final String className) throws DocletReflectiveOperationException {
 		fakeAttributeOwner = new FrankElement("dummy.Dummy", "Dummy", false);
-		final List<FrankAttribute> attributes = instance.createAttributes(Utils.getClass(className), fakeAttributeOwner);
+		final List<FrankAttribute> attributes = instance.createAttributes(classRepository.findClass(className), fakeAttributeOwner);
 		return attributes.stream().collect(Collectors.toMap(att -> att.getName(), att -> att));		
 	}
 
 	@Test
-	public void whenSetterAndIsThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterAndIsThenAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeCreated("attributeSetterIs");
 	}
 
 	@Test
-	public void whenOnlySetterThenAttribute() throws ReflectiveOperationException {
+	public void whenOnlySetterThenAttribute() throws DocletReflectiveOperationException {
 		FrankAttribute attribute = checkReflectAttributeCreated("attributeOnlySetter");
 		assertFalse(attribute.isDocumented());
 	}
 
 	@Test
-	public void whenSetterHasPrimitiveTypeThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterHasPrimitiveTypeThenAttribute() throws DocletReflectiveOperationException {
 		FrankAttribute attribute = checkReflectAttributeCreated("attributeOnlySetterInt");
 		assertFalse(attribute.isDocumented());
 	}
 
 	@Test
-	public void whenSetterHasBoxedIntTypeThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterHasBoxedIntTypeThenAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeCreated("attributeOnlySetterIntBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedBoolTypeThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterHasBoxedBoolTypeThenAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeCreated("attributeOnlySetterBoolBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedLongTypeThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterHasBoxedLongTypeThenAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeCreated("attributeOnlySetterLongBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedByteTypeThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterHasBoxedByteTypeThenAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeCreated("attributeOnlySetterByteBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedShortTypeThenAttribute() throws ReflectiveOperationException {
+	public void whenSetterHasBoxedShortTypeThenAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeCreated("attributeOnlySetterShortBoxed");
 	}
 
-	private void checkReflectAttributeOmitted(String attributeName) throws ReflectiveOperationException {
+	private void checkReflectAttributeOmitted(String attributeName) throws DocletReflectiveOperationException {
 		Map<String, FrankAttribute> actual = getReflectInvestigatedFrankAttributes();
 		assertFalse(actual.containsKey(attributeName));
 	}
 	
 	@Test
-	public void whenMethodsHaveWrongTypeThenNoAttribute() throws ReflectiveOperationException {
+	public void whenMethodsHaveWrongTypeThenNoAttribute() throws DocletReflectiveOperationException {
 		checkReflectAttributeOmitted("noAttributeComplexType");
 	}
 
 	@Test
-	public void whenAttributeNameMissesPrefixThenFilteredOutOfAttributes() {
+	public void whenAttributeNameMissesPrefixThenFilteredOutOfAttributes() throws DocletReflectiveOperationException {
 		assertFalse(getAttributeNameMap("get").containsKey("Prefix"));
 	}
 
-	Map<String, String> getAttributeNameMap(String prefix) {
-		Map<String, Method> attributeToMethodMap = FrankDocModel.getAttributeToMethodMap(
-				Utils.getClass("nl.nn.adapterframework.doc.testtarget.reflect.FrankAttributeTarget").getDeclaredMethods(), prefix);
+	Map<String, String> getAttributeNameMap(String prefix) throws DocletReflectiveOperationException {
+		Map<String, FrankMethod> attributeToMethodMap = FrankDocModel.getAttributeToMethodMap(
+				classRepository.findClass("nl.nn.adapterframework.doc.testtarget.reflect.FrankAttributeTarget").getDeclaredMethods(), prefix);
 		Map<String, String> result = new HashMap<>();
 		for(String attributeName: attributeToMethodMap.keySet()) {
 			result.put(attributeName, attributeToMethodMap.get(attributeName).getName());
@@ -292,22 +295,22 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenAttributeNameEqualsPrefixThenFilteredOutOfAttributes() {
+	public void whenAttributeNameEqualsPrefixThenFilteredOutOfAttributes() throws DocletReflectiveOperationException {
 		assertFalse(getAttributeNameMap("get").containsKey(""));
 	}
 
 	@Test
-	public void whenSetterTakesTwoValuesThenNotSetter() {
+	public void whenSetterTakesTwoValuesThenNotSetter() throws DocletReflectiveOperationException {
 		assertFalse(getAttributeNameMap("set").containsKey("invalidSetter"));
 	}
 
 	@Test
-	public void whenSetterTakesNoValuesThenNoSetter() {
+	public void whenSetterTakesNoValuesThenNoSetter() throws DocletReflectiveOperationException {
 		assertFalse(getAttributeNameMap("set").containsKey("invalidSetterNoParams"));
 	}
 
 	@Test
-	public void testIbisDockedOnlyDescription() throws ReflectiveOperationException {
+	public void testIbisDockedOnlyDescription() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedOnlyDescription");
 		assertTrue(actual.isDocumented());
 		assertEquals(Integer.MAX_VALUE, actual.getOrder());
@@ -317,7 +320,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedOrderDescription() throws ReflectiveOperationException {
+	public void testIbisDockedOrderDescription() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedOrderDescription");
 		assertTrue(actual.isDocumented());
 		assertEquals(3, actual.getOrder());
@@ -327,7 +330,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedDescriptionDefault() throws ReflectiveOperationException {
+	public void testIbisDockedDescriptionDefault() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals(Integer.MAX_VALUE, actual.getOrder());
@@ -338,7 +341,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedOrderDescriptionDefault() throws ReflectiveOperationException {
+	public void testIbisDockedOrderDescriptionDefault() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedOrderDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals(5, actual.getOrder());
@@ -348,7 +351,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedDeprecated() throws ReflectiveOperationException {
+	public void testIbisDockedDeprecated() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedDeprecated");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of ibisDockedDeprecated", actual.getDescription());
@@ -357,7 +360,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDocRefAddsFrankElementsForReferredClassHierarchy() throws ReflectiveOperationException {
+	public void testIbisDocRefAddsFrankElementsForReferredClassHierarchy() throws DocletReflectiveOperationException {
 		checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault");
 		assertEquals(3, instance.getAllElements().size());
 		assertTrue(instance.getAllElements().containsKey(REFERRED_CHILD));
@@ -365,46 +368,46 @@ public class FrankDocModelTest {
 		assertTrue(instance.getAllElements().containsKey("java.lang.Object"));
 	}
 
-	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName) throws ReflectiveOperationException {
+	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName) throws DocletReflectiveOperationException {
 		return checkIbisdocrefInvestigatedFrankAttribute(attributeName, REFERRER);
 	}
 
-	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName, String targetClassName) throws ReflectiveOperationException {
+	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName, String targetClassName) throws DocletReflectiveOperationException {
 		Map<String, FrankAttribute> attributeMap = getAttributesOfClass(targetClassName);
 		assertTrue(attributeMap.containsKey(attributeName));
 		return attributeMap.get(attributeName);
 	}
 
 	@Test
-	public void testReferredIbisDocDescriptionAppearsInFrankAttribute() throws ReflectiveOperationException {
+	public void testReferredIbisDocDescriptionAppearsInFrankAttribute() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault", actual.getDescription());
 	}
 
 	@Test
-	public void testReferredIbisDocDescriptionOtherMethodAppearsInFrankAttribute() throws ReflectiveOperationException {
+	public void testReferredIbisDocDescriptionOtherMethodAppearsInFrankAttribute() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocReffMethodNoOrderRefersIbisDocOrderDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of otherMethod", actual.getDescription());
 	}
 
 	@Test
-	public void testReferredIbisDocDescriptiondWithOrderAndInheritance() throws ReflectiveOperationException {
+	public void testReferredIbisDocDescriptiondWithOrderAndInheritance() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited", actual.getDescription());
 	}
 
 	@Test
-	public void testOrderInsideIbisDocRefHasPreferenceOverReferredIbisDocOrder() throws ReflectiveOperationException {
+	public void testOrderInsideIbisDocRefHasPreferenceOverReferredIbisDocOrder() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited");
 		assertTrue(actual.isDocumented());
 		assertEquals(10, actual.getOrder());
 	}
 
 	@Test
-	public void whenIbisDocRefThenDescribingElementAdjusted() throws ReflectiveOperationException {
+	public void whenIbisDocRefThenDescribingElementAdjusted() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited");
 		assertTrue(actual.isDocumented());
 		assertSame(instance.getAllElements().get(REFERRED_PARENT), actual.getDescribingElement());
@@ -412,7 +415,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenMethodOverriddenWithoutDocThenDocumentedFalseButIbisDocRefInfoInherited() throws ReflectiveOperationException {
+	public void whenMethodOverriddenWithoutDocThenDocumentedFalseButIbisDocRefInfoInherited() throws DocletReflectiveOperationException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault", REFERRER_CHILD);
 		assertFalse(actual.isDocumented());
 		assertEquals("Description of ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault", actual.getDescription());
@@ -420,7 +423,7 @@ public class FrankDocModelTest {
 
 	@Test
 	public void testFrankElementDeprecatedAttribute() throws Exception {
-		FrankElement element = instance.findOrCreateFrankElement(Utils.getClass(SIMPLE + ".NonDeprecatedDescendant"));
+		FrankElement element = instance.findOrCreateFrankElement(SIMPLE + ".NonDeprecatedDescendant");
 		assertNotNull(element);
 		assertFalse(element.isDeprecated());
 		assertTrue(element.getParent().isDeprecated());

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankDocModelTest.java
@@ -33,7 +33,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import nl.nn.adapterframework.doc.doclet.DocletReflectiveOperationException;
+import nl.nn.adapterframework.doc.doclet.FrankDocException;
 import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 import nl.nn.adapterframework.doc.doclet.FrankMethod;
 
@@ -64,14 +64,14 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenInterfaceTypeAndSingletonTypeThenCorrectElements() throws DocletReflectiveOperationException {
+	public void whenInterfaceTypeAndSingletonTypeThenCorrectElements() throws FrankDocException {
 		ElementType listenerType = instance.findOrCreateElementType(classRepository.findClass(LISTENER));
 		ElementType childType = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
 		checkModelTypes(listenerType, childType);
 	}
 
 	@Test
-	public void whenSingletonTypeAndInterfaceTypeThenCorrectElements() throws DocletReflectiveOperationException {
+	public void whenSingletonTypeAndInterfaceTypeThenCorrectElements() throws FrankDocException {
 		ElementType childType = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
 		ElementType listenerType = instance.findOrCreateElementType(classRepository.findClass(LISTENER));
 		checkModelTypes(listenerType, childType);		
@@ -114,14 +114,14 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenTypeRequestedTwiceThenSameInstanceReturned() throws DocletReflectiveOperationException {
+	public void whenTypeRequestedTwiceThenSameInstanceReturned() throws FrankDocException {
 		ElementType first = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
 		ElementType second = instance.findOrCreateElementType(classRepository.findClass(SIMPLE_CHILD));
 		assertSame(first, second);
 	}
 
 	@Test
-	public void whenChildElementAddedBeforeParentThenCorrectModel() throws DocletReflectiveOperationException {
+	public void whenChildElementAddedBeforeParentThenCorrectModel() throws FrankDocException {
 		FrankElement child = instance.findOrCreateFrankElement(SIMPLE_CHILD);
 		FrankElement parent = instance.findOrCreateFrankElement(SIMPLE_PARENT);
 		instance.findOrCreateFrankElement(SIMPLE_GRNAD_CHILD);
@@ -130,7 +130,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenParentElementAddedBeforeChildThenCorrectModel() throws DocletReflectiveOperationException {
+	public void whenParentElementAddedBeforeChildThenCorrectModel() throws FrankDocException {
 		FrankElement parent = instance.findOrCreateFrankElement(SIMPLE_PARENT);
 		FrankElement child = instance.findOrCreateFrankElement(SIMPLE_CHILD);
 		instance.findOrCreateFrankElement(SIMPLE_GRNAD_CHILD);
@@ -202,18 +202,18 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenSetterAndGetterThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterAndGetterThenAttribute() throws FrankDocException {
 		checkReflectAttributeCreated("attributeSetterGetter");
 	}
 
-	private FrankAttribute checkReflectAttributeCreated(String attributeName) throws DocletReflectiveOperationException {
+	private FrankAttribute checkReflectAttributeCreated(String attributeName) throws FrankDocException {
 		Map<String, FrankAttribute> actual = getReflectInvestigatedFrankAttributes();
 		assertTrue(actual.containsKey(attributeName));
 		assertEquals(attributeName, actual.get(attributeName).getName());
 		return actual.get(attributeName);
 	}
 
-	private Map<String, FrankAttribute> getReflectInvestigatedFrankAttributes() throws DocletReflectiveOperationException {
+	private Map<String, FrankAttribute> getReflectInvestigatedFrankAttributes() throws FrankDocException {
 		return getAttributesOfClass("nl.nn.adapterframework.doc.testtarget.reflect.FrankAttributeTarget");
 	}
 
@@ -222,70 +222,70 @@ public class FrankDocModelTest {
 	 * of a class. A dummy FrankElement is supplied as attribute owner, so the
 	 * describingElement is only correct if it is parsed from an @IbisDocRef annotation.
 	 */
-	private Map<String, FrankAttribute> getAttributesOfClass(final String className) throws DocletReflectiveOperationException {
+	private Map<String, FrankAttribute> getAttributesOfClass(final String className) throws FrankDocException {
 		fakeAttributeOwner = new FrankElement("dummy.Dummy", "Dummy", false);
 		final List<FrankAttribute> attributes = instance.createAttributes(classRepository.findClass(className), fakeAttributeOwner);
 		return attributes.stream().collect(Collectors.toMap(att -> att.getName(), att -> att));		
 	}
 
 	@Test
-	public void whenSetterAndIsThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterAndIsThenAttribute() throws FrankDocException {
 		checkReflectAttributeCreated("attributeSetterIs");
 	}
 
 	@Test
-	public void whenOnlySetterThenAttribute() throws DocletReflectiveOperationException {
+	public void whenOnlySetterThenAttribute() throws FrankDocException {
 		FrankAttribute attribute = checkReflectAttributeCreated("attributeOnlySetter");
 		assertFalse(attribute.isDocumented());
 	}
 
 	@Test
-	public void whenSetterHasPrimitiveTypeThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterHasPrimitiveTypeThenAttribute() throws FrankDocException {
 		FrankAttribute attribute = checkReflectAttributeCreated("attributeOnlySetterInt");
 		assertFalse(attribute.isDocumented());
 	}
 
 	@Test
-	public void whenSetterHasBoxedIntTypeThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterHasBoxedIntTypeThenAttribute() throws FrankDocException {
 		checkReflectAttributeCreated("attributeOnlySetterIntBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedBoolTypeThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterHasBoxedBoolTypeThenAttribute() throws FrankDocException {
 		checkReflectAttributeCreated("attributeOnlySetterBoolBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedLongTypeThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterHasBoxedLongTypeThenAttribute() throws FrankDocException {
 		checkReflectAttributeCreated("attributeOnlySetterLongBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedByteTypeThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterHasBoxedByteTypeThenAttribute() throws FrankDocException {
 		checkReflectAttributeCreated("attributeOnlySetterByteBoxed");
 	}
 
 	@Test
-	public void whenSetterHasBoxedShortTypeThenAttribute() throws DocletReflectiveOperationException {
+	public void whenSetterHasBoxedShortTypeThenAttribute() throws FrankDocException {
 		checkReflectAttributeCreated("attributeOnlySetterShortBoxed");
 	}
 
-	private void checkReflectAttributeOmitted(String attributeName) throws DocletReflectiveOperationException {
+	private void checkReflectAttributeOmitted(String attributeName) throws FrankDocException {
 		Map<String, FrankAttribute> actual = getReflectInvestigatedFrankAttributes();
 		assertFalse(actual.containsKey(attributeName));
 	}
 	
 	@Test
-	public void whenMethodsHaveWrongTypeThenNoAttribute() throws DocletReflectiveOperationException {
+	public void whenMethodsHaveWrongTypeThenNoAttribute() throws FrankDocException {
 		checkReflectAttributeOmitted("noAttributeComplexType");
 	}
 
 	@Test
-	public void whenAttributeNameMissesPrefixThenFilteredOutOfAttributes() throws DocletReflectiveOperationException {
+	public void whenAttributeNameMissesPrefixThenFilteredOutOfAttributes() throws FrankDocException {
 		assertFalse(getAttributeNameMap("get").containsKey("Prefix"));
 	}
 
-	Map<String, String> getAttributeNameMap(String prefix) throws DocletReflectiveOperationException {
+	Map<String, String> getAttributeNameMap(String prefix) throws FrankDocException {
 		Map<String, FrankMethod> attributeToMethodMap = FrankDocModel.getAttributeToMethodMap(
 				classRepository.findClass("nl.nn.adapterframework.doc.testtarget.reflect.FrankAttributeTarget").getDeclaredMethods(), prefix);
 		Map<String, String> result = new HashMap<>();
@@ -296,22 +296,22 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenAttributeNameEqualsPrefixThenFilteredOutOfAttributes() throws DocletReflectiveOperationException {
+	public void whenAttributeNameEqualsPrefixThenFilteredOutOfAttributes() throws FrankDocException {
 		assertFalse(getAttributeNameMap("get").containsKey(""));
 	}
 
 	@Test
-	public void whenSetterTakesTwoValuesThenNotSetter() throws DocletReflectiveOperationException {
+	public void whenSetterTakesTwoValuesThenNotSetter() throws FrankDocException {
 		assertFalse(getAttributeNameMap("set").containsKey("invalidSetter"));
 	}
 
 	@Test
-	public void whenSetterTakesNoValuesThenNoSetter() throws DocletReflectiveOperationException {
+	public void whenSetterTakesNoValuesThenNoSetter() throws FrankDocException {
 		assertFalse(getAttributeNameMap("set").containsKey("invalidSetterNoParams"));
 	}
 
 	@Test
-	public void testIbisDockedOnlyDescription() throws DocletReflectiveOperationException {
+	public void testIbisDockedOnlyDescription() throws FrankDocException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedOnlyDescription");
 		assertTrue(actual.isDocumented());
 		assertEquals(Integer.MAX_VALUE, actual.getOrder());
@@ -321,7 +321,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedOrderDescription() throws DocletReflectiveOperationException {
+	public void testIbisDockedOrderDescription() throws FrankDocException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedOrderDescription");
 		assertTrue(actual.isDocumented());
 		assertEquals(3, actual.getOrder());
@@ -331,7 +331,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedDescriptionDefault() throws DocletReflectiveOperationException {
+	public void testIbisDockedDescriptionDefault() throws FrankDocException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals(Integer.MAX_VALUE, actual.getOrder());
@@ -342,7 +342,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedOrderDescriptionDefault() throws DocletReflectiveOperationException {
+	public void testIbisDockedOrderDescriptionDefault() throws FrankDocException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedOrderDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals(5, actual.getOrder());
@@ -352,7 +352,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDockedDeprecated() throws DocletReflectiveOperationException {
+	public void testIbisDockedDeprecated() throws FrankDocException {
 		FrankAttribute actual = checkReflectAttributeCreated("ibisDockedDeprecated");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of ibisDockedDeprecated", actual.getDescription());
@@ -361,7 +361,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void testIbisDocRefAddsFrankElementsForReferredClassHierarchy() throws DocletReflectiveOperationException {
+	public void testIbisDocRefAddsFrankElementsForReferredClassHierarchy() throws FrankDocException {
 		checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault");
 		assertEquals(3, instance.getAllElements().size());
 		assertTrue(instance.getAllElements().containsKey(REFERRED_CHILD));
@@ -369,46 +369,46 @@ public class FrankDocModelTest {
 		assertTrue(instance.getAllElements().containsKey("java.lang.Object"));
 	}
 
-	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName) throws DocletReflectiveOperationException {
+	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName) throws FrankDocException {
 		return checkIbisdocrefInvestigatedFrankAttribute(attributeName, REFERRER);
 	}
 
-	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName, String targetClassName) throws DocletReflectiveOperationException {
+	private FrankAttribute checkIbisdocrefInvestigatedFrankAttribute(String attributeName, String targetClassName) throws FrankDocException {
 		Map<String, FrankAttribute> attributeMap = getAttributesOfClass(targetClassName);
 		assertTrue(attributeMap.containsKey(attributeName));
 		return attributeMap.get(attributeName);
 	}
 
 	@Test
-	public void testReferredIbisDocDescriptionAppearsInFrankAttribute() throws DocletReflectiveOperationException {
+	public void testReferredIbisDocDescriptionAppearsInFrankAttribute() throws FrankDocException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault", actual.getDescription());
 	}
 
 	@Test
-	public void testReferredIbisDocDescriptionOtherMethodAppearsInFrankAttribute() throws DocletReflectiveOperationException {
+	public void testReferredIbisDocDescriptionOtherMethodAppearsInFrankAttribute() throws FrankDocException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocReffMethodNoOrderRefersIbisDocOrderDescriptionDefault");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of otherMethod", actual.getDescription());
 	}
 
 	@Test
-	public void testReferredIbisDocDescriptiondWithOrderAndInheritance() throws DocletReflectiveOperationException {
+	public void testReferredIbisDocDescriptiondWithOrderAndInheritance() throws FrankDocException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited");
 		assertTrue(actual.isDocumented());
 		assertEquals("Description of ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited", actual.getDescription());
 	}
 
 	@Test
-	public void testOrderInsideIbisDocRefHasPreferenceOverReferredIbisDocOrder() throws DocletReflectiveOperationException {
+	public void testOrderInsideIbisDocRefHasPreferenceOverReferredIbisDocOrder() throws FrankDocException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited");
 		assertTrue(actual.isDocumented());
 		assertEquals(10, actual.getOrder());
 	}
 
 	@Test
-	public void whenIbisDocRefThenDescribingElementAdjusted() throws DocletReflectiveOperationException {
+	public void whenIbisDocRefThenDescribingElementAdjusted() throws FrankDocException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassWithOrderRefersIbisDocOrderDescriptionDefaultInherited");
 		assertTrue(actual.isDocumented());
 		assertSame(instance.getAllElements().get(REFERRED_PARENT), actual.getDescribingElement());
@@ -416,7 +416,7 @@ public class FrankDocModelTest {
 	}
 
 	@Test
-	public void whenMethodOverriddenWithoutDocThenDocumentedFalseButIbisDocRefInfoInherited() throws DocletReflectiveOperationException {
+	public void whenMethodOverriddenWithoutDocThenDocumentedFalseButIbisDocRefInfoInherited() throws FrankDocException {
 		FrankAttribute actual = checkIbisdocrefInvestigatedFrankAttribute("ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault", REFERRER_CHILD);
 		assertFalse(actual.isDocumented());
 		assertEquals("Description of ibisDocRefClassNoOrderRefersIbisDocOrderDescriptionDefault", actual.getDescription());

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/FrankElementXsdElementNameTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/FrankElementXsdElementNameTest.java
@@ -21,26 +21,28 @@ import static org.junit.Assert.assertEquals;
 import org.junit.Before;
 import org.junit.Test;
 
-import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 
 public class FrankElementXsdElementNameTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.simple.";
 	private static final String CONTAINER = PACKAGE + "Container";
 	private static final String DIGESTER_RULES = "doc/xsd-element-name-digester-rules.xml";
 
+	private FrankClassRepository classRepository;
 	private FrankDocModel model;
 
 	@Before
 	public void setUp() {
-		model = FrankDocModel.populate(DIGESTER_RULES, CONTAINER);
+		classRepository = FrankClassRepository.getReflectInstance();
+		model = FrankDocModel.populate(DIGESTER_RULES, CONTAINER, classRepository);
 	}
 
 	@Test
 	public void whenNameDoesNotEndWithInterfaceNameThenGroupRoleNameAppended() throws Exception {
 		String className = PACKAGE + "ListenerParent";
 		String typeName = PACKAGE + "IListener";
-		FrankElement instance = model.findOrCreateFrankElement(Utils.getClass(className));
-		ElementType elementType = model.findOrCreateElementType(Utils.getClass(typeName));
+		FrankElement instance = model.findOrCreateFrankElement(className);
+		ElementType elementType = model.findOrCreateElementType(classRepository.findClass(typeName));
 		String actual = instance.getXsdElementName(elementType, "testListener");
 		assertEquals("ListenerParentTestListener", actual);
 	}
@@ -49,8 +51,8 @@ public class FrankElementXsdElementNameTest {
 	public void whenNameEndsWithInterfaceNameThenRemovedAndGroupRoleNameAppended() throws Exception {
 		String className = PACKAGE + "ParentListener";
 		String typeName = PACKAGE + "IListener";
-		FrankElement instance = model.findOrCreateFrankElement(Utils.getClass(className));
-		ElementType elementType = model.findOrCreateElementType(Utils.getClass(typeName));
+		FrankElement instance = model.findOrCreateFrankElement(className);
+		ElementType elementType = model.findOrCreateElementType(classRepository.findClass(typeName));
 		String actual = instance.getXsdElementName(elementType, "testListener");
 		assertEquals("ParentTestListener", actual);
 	}
@@ -58,8 +60,8 @@ public class FrankElementXsdElementNameTest {
 	@Test
 	public void whenElementTypeIsNotInterfaceThenRoleNameBecomesElementName() throws Exception {
 		String classAndTypeName = PACKAGE + "ListenerParent";
-		FrankElement instance = model.findOrCreateFrankElement(Utils.getClass(classAndTypeName));
-		ElementType elementType = model.findOrCreateElementType(Utils.getClass(classAndTypeName));
+		FrankElement instance = model.findOrCreateFrankElement(classAndTypeName);
+		ElementType elementType = model.findOrCreateElementType(classRepository.findClass(classAndTypeName));
 		String actual = instance.getXsdElementName(elementType, "someName");
 		assertEquals("SomeName", actual);
 	}

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/HighestCommonInterfaceTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/HighestCommonInterfaceTest.java
@@ -22,6 +22,8 @@ import static org.junit.Assert.assertSame;
 import org.junit.Before;
 import org.junit.Test;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 public class HighestCommonInterfaceTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.role.inherit.";
 	private FrankDocModel model;
@@ -32,7 +34,7 @@ public class HighestCommonInterfaceTest {
 
 	@Before
 	public void setUp() {
-		model = FrankDocModel.populate("doc/role-inherit-digester-rules.xml", PACKAGE + "Master");
+		model = FrankDocModel.populate("doc/role-inherit-digester-rules.xml", PACKAGE + "Master", FrankClassRepository.getReflectInstance());
 		founder = model.findElementType(PACKAGE + "IFounder");
 		interfaceParent = model.findElementType(PACKAGE + "IInterfaceParent");
 		interfaceElementType = model.findElementType(PACKAGE + "IInterface");

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/NavigationCumulativeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/NavigationCumulativeTest.java
@@ -34,6 +34,8 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
+
 @RunWith(Parameterized.class)
 public class NavigationCumulativeTest {
 	private static final String PACKAGE = "nl.nn.adapterframework.doc.testtarget.walking";
@@ -68,7 +70,7 @@ public class NavigationCumulativeTest {
 	@Test
 	public void test() {
 		String rootClassName = PACKAGE + "." + simpleClassName;
-		FrankDocModel model = FrankDocModel.populate("doc/empty-digester-rules.xml", rootClassName);
+		FrankDocModel model = FrankDocModel.populate("doc/empty-digester-rules.xml", rootClassName, FrankClassRepository.getReflectInstance());
 		FrankElement subject = model.findFrankElement(rootClassName);
 		List<String> actual = subject.getCumulativeAttributes(childSelector, childRejector).stream()
 				.map(a -> a.getName()).collect(Collectors.toList());

--- a/core/src/test/java/nl/nn/adapterframework/doc/model/NavigationTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/model/NavigationTest.java
@@ -18,8 +18,8 @@ package nl.nn.adapterframework.doc.model;
 import static java.util.Arrays.asList;
 import static nl.nn.adapterframework.doc.model.ElementChild.ALL;
 import static nl.nn.adapterframework.doc.model.ElementChild.DEPRECATED;
-import static nl.nn.adapterframework.doc.model.ElementChild.NONE;
 import static nl.nn.adapterframework.doc.model.ElementChild.IN_XSD;
+import static nl.nn.adapterframework.doc.model.ElementChild.NONE;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
@@ -35,7 +35,7 @@ import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 import lombok.EqualsAndHashCode;
-import nl.nn.adapterframework.doc.Utils;
+import nl.nn.adapterframework.doc.doclet.FrankClassRepository;
 
 @RunWith(Parameterized.class)
 public class NavigationTest {
@@ -109,8 +109,8 @@ public class NavigationTest {
 	@Test
 	public void test() throws Exception {
 		String rootClassName = PACKAGE + "." + simpleClassName;
-		FrankDocModel model = FrankDocModel.populate("doc/empty-digester-rules.xml", rootClassName);
-		FrankElement walkFrom = model.findOrCreateFrankElement(Utils.getClass(rootClassName));
+		FrankDocModel model = FrankDocModel.populate("doc/empty-digester-rules.xml", rootClassName, FrankClassRepository.getReflectInstance());
+		FrankElement walkFrom = model.findFrankElement(rootClassName);
 		walkFrom.walkCumulativeAttributes(new CumulativeChildHandler<FrankAttribute>() {
 			@Override
 			public void handleSelectedChildren(List<FrankAttribute> children, FrankElement owner) {

--- a/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/Child.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/Child.java
@@ -1,0 +1,11 @@
+package nl.nn.adapterframework.doc.testtarget.doclet;
+
+public class Child extends Parent implements MyInterface {
+	@Override
+	public void setInherited(String value) {
+	}
+
+	String packagePrivateMethod() {
+		return null;
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/DeprecatedChild.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/DeprecatedChild.java
@@ -1,0 +1,14 @@
+package nl.nn.adapterframework.doc.testtarget.doclet;
+
+import nl.nn.adapterframework.doc.IbisDoc;
+
+@Deprecated
+public class DeprecatedChild extends Parent {
+	@Deprecated
+	@IbisDoc({"100", "Some description", "0"})
+	public void someSetter(int value) {
+	}
+
+	void packagePrivateMethod() {
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/MyInterface.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/MyInterface.java
@@ -1,0 +1,5 @@
+package nl.nn.adapterframework.doc.testtarget.doclet;
+
+public interface MyInterface {
+
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/MyInterfaceParent.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/MyInterfaceParent.java
@@ -1,5 +1,5 @@
 package nl.nn.adapterframework.doc.testtarget.doclet;
 
-public interface MyInterface extends MyInterfaceParent {
+public interface MyInterfaceParent {
 
 }

--- a/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/PackagePrivateClass.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/PackagePrivateClass.java
@@ -1,0 +1,5 @@
+package nl.nn.adapterframework.doc.testtarget.doclet;
+
+class PackagePrivateClass {
+
+}

--- a/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/Parent.java
+++ b/core/src/test/java/nl/nn/adapterframework/doc/testtarget/doclet/Parent.java
@@ -1,0 +1,13 @@
+package nl.nn.adapterframework.doc.testtarget.doclet;
+
+import nl.nn.adapterframework.doc.IbisDoc;
+
+public class Parent {
+	@IbisDoc("50")
+	public void setInherited(String value) {
+	}
+
+	public String getInherited() {
+		return null;
+	}
+}


### PR DESCRIPTION
Package nl.nn.adapterframework.doc.doclet holds an API that can wrap both reflection objects (e.g. java.lang.Class) and doclet objects (e.g. ClassDoc). The model works with interface FrankClass, which has implementations FrankClassReflect and which will have implementation FrankClassDoclet. Implementation FrankClassDoclet has not been created in this pull request yet, because this can best be done when the Frank!Doc model will have been moved to a separate subproject of the iaf repository.