### PR TITLE
Fix #1292 Avoid recursion explosion in IbisException.getMessage()

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/core/IbisException.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/IbisException.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden
+   Copyright 2013 Nationale-Nederlanden, 2021 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,6 +16,8 @@
 package nl.nn.adapterframework.core;
 
 import java.sql.SQLException;
+import java.util.LinkedList;
+import java.util.List;
 
 import javax.mail.internet.AddressException;
 import javax.xml.transform.SourceLocator;
@@ -23,23 +25,17 @@ import javax.xml.transform.TransformerException;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.builder.ToStringBuilder;
-import org.apache.commons.lang.builder.ToStringStyle;
 import org.apache.commons.lang.exception.ExceptionUtils;
-import org.apache.commons.lang.exception.NestableException;
 import org.xml.sax.SAXParseException;
+
+import nl.nn.adapterframework.util.Misc;
 
 /**
  * Base Exception with compact but informative getMessage().
  * 
  * @author Gerrit van Brakel
  */
-public class IbisException extends NestableException {
-//	private Logger log = LogUtil.getLogger(this);
-
-	static {
-		// add methodname to find cause of JMS-Exceptions
-		ExceptionUtils.addCauseMethodName("getLinkedException");
-	}
+public class IbisException extends Exception {
 	
 	public IbisException() {
 		super();
@@ -53,32 +49,18 @@ public class IbisException extends NestableException {
 	public IbisException(Throwable cause) {
 		super(cause);
 	}
-	
-	public String getExceptionType(Throwable t) {
-		return t.getClass().getSimpleName();
-	}
-	
-	public String addPart(String part1, String separator, String part2) {
-		if (StringUtils.isEmpty(part1)) {
-			return part2;
-		}
-		if (StringUtils.isEmpty(part2)) {
-			return part1;
-		}
-		return part1+separator+part2;
-	}
-	
+		
 	public String getExceptionSpecificDetails(Throwable t) {
 		String result=null;
 		if (t instanceof AddressException) { 
 			AddressException ae = (AddressException)t;
 			String parsedString=ae.getRef();
 			if (StringUtils.isNotEmpty(parsedString)) {
-				result = addPart(result, " ", "["+parsedString+"]");
+				result = Misc.concatStrings(result, " ", "["+parsedString+"]");
 			}
 			int column = ae.getPos()+1;
 			if (column>0) {
-				result = addPart(result, " ", "at column ["+column+"]");
+				result = Misc.concatStrings(result, " ", "at column ["+column+"]");
 			}
 		}
 		if (t instanceof SAXParseException) {
@@ -89,15 +71,15 @@ public class IbisException extends NestableException {
 			
 			String locationInfo=null;
 			if (StringUtils.isNotEmpty(sysid)) {
-				locationInfo =  "SystemId ["+sysid+"]";
+				locationInfo = "SystemId ["+sysid+"]";
 			}
 			if (line>=0) {
-				locationInfo =  addPart(locationInfo, " ", "line ["+line+"]");
+				locationInfo = Misc.concatStrings(locationInfo, " ", "line ["+line+"]");
 			}
 			if (col>=0) {
-				locationInfo =  addPart(locationInfo, " ", "column ["+col+"]");
+				locationInfo = Misc.concatStrings(locationInfo, " ", "column ["+col+"]");
 			}
-			result = addPart(locationInfo, ": ", result);
+			result = Misc.concatStrings(locationInfo, ": ", result);
 		} 
 		if (t instanceof TransformerException) {
 			TransformerException te = (TransformerException)t;
@@ -109,15 +91,15 @@ public class IbisException extends NestableException {
 				
 				String locationInfo=null;
 				if (StringUtils.isNotEmpty(sysid)) {
-					locationInfo =  "SystemId ["+sysid+"]";
+					locationInfo = "SystemId ["+sysid+"]";
 				}
 				if (line>=0) {
-					locationInfo =  addPart(locationInfo, " ", "line ["+line+"]");
+					locationInfo = Misc.concatStrings(locationInfo, " ", "line ["+line+"]");
 				}
 				if (col>=0) {
-					locationInfo =  addPart(locationInfo, " ", "column ["+col+"]");
+					locationInfo = Misc.concatStrings(locationInfo, " ", "column ["+col+"]");
 				}
-				result = addPart(locationInfo, ": ", result);
+				result = Misc.concatStrings(locationInfo, ": ", result);
 			}
 		} 
 		if (t instanceof SQLException) {
@@ -125,17 +107,17 @@ public class IbisException extends NestableException {
 			int errorCode = sqle.getErrorCode();
 			String sqlState = sqle.getSQLState();
 			if (errorCode!=0) {
-				result =  addPart("errorCode ["+errorCode+"]", ", ", result);
+				result = Misc.concatStrings("errorCode ["+errorCode+"]", ", ", result);
 			}
 			if (StringUtils.isNotEmpty(sqlState)) {
-				result =  addPart("SQLState ["+sqlState+"]", ", ", result);
+				result = Misc.concatStrings("SQLState ["+sqlState+"]", ", ", result);
 			}
 		} 
 		if (t.getClass().getSimpleName().equals("OracleXAException")) { // do not use instanceof here, to avoid unnessecary dependency on Oracle class
 			oracle.jdbc.xa.OracleXAException oxae = (oracle.jdbc.xa.OracleXAException)t;
 			int xaError = oxae.getXAError();
 			if (xaError != 0) {
-				result =  addPart("xaError ["+xaError +"] xaErrorMessage ["+oracle.jdbc.xa.OracleXAException.getXAErrorMessage(xaError)+"]", ", ", result);
+				result = Misc.concatStrings("xaError ["+xaError +"] xaErrorMessage ["+oracle.jdbc.xa.OracleXAException.getXAErrorMessage(xaError)+"]", ", ", result);
 			}
 		} 
 		return result;
@@ -143,66 +125,70 @@ public class IbisException extends NestableException {
 
 	@Override
 	public String getMessage() {
-		Throwable throwables[]=getThrowables();
-		String result=null;
-		String prev_message=null;
-		Throwable prevThrowable=null;
-
-
-		for(int i=getThrowableCount()-1; i>=0; i--) {
-			
-			String cur_message=getMessage(i);
-			
-//			if (log.isDebugEnabled()) {
-//				log.debug("t["+i+"], ["+ClassUtils.nameOf(throwables[i])+"], cur ["+cur_message+"], prev ["+prev_message+"]");
-//			} 			
-			if (prevThrowable!=null && cur_message!=null && (cur_message.equals(prevThrowable.getMessage()) || cur_message.equals(prevThrowable.toString()))) {
-				cur_message=null;
-			}
-			String newPart=null;
-			
-			// prefix the result with the message of this exception.
-			// if the new message ends with the previous, remove the part that is already known
-			if (StringUtils.isNotEmpty(cur_message)) {
-				newPart = addPart(cur_message, " ", newPart);
-				if (StringUtils.isNotEmpty(newPart) && StringUtils.isNotEmpty(prev_message) && newPart.endsWith(prev_message)) {
-					newPart=newPart.substring(0,newPart.length()-prev_message.length());
-				}
-				if (StringUtils.isNotEmpty(newPart) && newPart.endsWith(": ")) {
-					newPart=newPart.substring(0,newPart.length()-2);
-				}
-				prev_message=cur_message;
-			}
-			String specificDetails = getExceptionSpecificDetails(throwables[i]);
-			if (StringUtils.isNotEmpty(specificDetails) && (result==null || result.indexOf(specificDetails)<0)) {
-				newPart= addPart(specificDetails,": ",newPart);
-			}
-			
-			if (!(throwables[i] instanceof IbisException)) { 
-				String exceptionType = "("+getExceptionType(throwables[i])+")";
-				newPart = addPart(exceptionType, " ", newPart);
-			}
-			result = addPart(newPart, ": ", result);
-			prevThrowable=throwables[i];
+		List<String> msgChain = getMessages(this, super.getMessage());
+		String result = null;
+		Throwable t = this;
+		for(String message:msgChain) {
+			String exceptionType = t instanceof IbisException ? "" : "("+t.getClass().getSimpleName()+")";
+			message = Misc.concatStrings(exceptionType, " ", message);
+			result = Misc.concatStrings(result, ": ", message);
+			t = ExceptionUtils.getCause(t);
 		}
-		
 		if (result==null) {
-//			log.debug("no message found, returning fields by inspection");
 			// do not replace the following with toString(), this causes an endless loop. GvB
-			result="no message, fields of this exception: "+ToStringBuilder.reflectionToString(this,ToStringStyle.MULTI_LINE_STYLE);
+			result="no message, fields of this exception: "+ToStringBuilder.reflectionToString(this);
 		}
 		return result;
 	}
 
-/*
-	public String toString() {
-		String result = super.toString();
-		Throwable t = getCause();
-		if (t != null && !(t instanceof IbisException)) {
-			t=ExceptionUtils.getRootCause(this);
-			result += "\nroot cause:\n"+ToStringBuilder.reflectionToString(t,ToStringStyle.MULTI_LINE_STYLE)+"\n";
+
+
+	public LinkedList<String> getMessages(Throwable t, String message) {
+		Throwable cause = ExceptionUtils.getCause(t);
+		LinkedList<String> result;
+		if (cause !=null) {
+			String causeMessage = cause.getMessage();
+			String causeToString; 
+
+			if (cause instanceof IbisException) {
+				// in case of an IbisException, the recursion already happened in cause.getMessage(), so do not call getMessages() here.
+				result = new LinkedList<>();
+				result.add(causeMessage);
+				causeToString = null; // might be useful to work this out to cater for new Exception(ibisException.toString(), ibisException) case
+			} else {
+				causeMessage = cause.getMessage();
+				result = getMessages(cause, causeMessage);
+				causeToString = cause.toString();
+			}
+			if (StringUtils.isNotEmpty(message) && (message.equals(causeMessage) || message.equals(causeToString))) {
+				message = null;
+			}
+			if (StringUtils.isNotEmpty(message) && StringUtils.isNotEmpty(causeToString) && (message.endsWith(causeToString))) {
+				message=message.substring(0,message.length()-causeToString.length());
+			}
+			if (StringUtils.isNotEmpty(message) && StringUtils.isNotEmpty(causeMessage)  && (message.endsWith(causeMessage))) {
+				message=message.substring(0,message.length()-causeMessage.length());
+			}
+		} else {
+			result = new LinkedList<>();
 		}
+		if (StringUtils.isNotEmpty(message) && (message.endsWith(": "))) {
+			message=message.substring(0,message.length()-2);
+		}
+		String specificDetails = getExceptionSpecificDetails(t);
+		if (StringUtils.isNotEmpty(specificDetails)) {
+			boolean tailContainsDetails=false;
+			for(String part:result) {
+				if (part!=null && part.indexOf(specificDetails)>=0) {
+					tailContainsDetails = true;
+					break;
+				}
+			}
+			if (!tailContainsDetails) {
+				message= Misc.concatStrings(specificDetails, ": ", message);
+			}
+		}
+		result.addFirst(message);
 		return result;
 	}
-	*/
 }

--- a/core/src/main/java/nl/nn/adapterframework/core/IbisException.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/IbisException.java
@@ -158,7 +158,6 @@ public class IbisException extends Exception {
 				result = new LinkedList<>();
 				result.add(causeMessage);
 			} else {
-				causeMessage = cause.getMessage();
 				result = getMessages(cause, causeMessage);
 			}
 			if (StringUtils.isNotEmpty(message) && (message.equals(causeMessage) || message.equals(causeToString))) {

--- a/core/src/main/java/nl/nn/adapterframework/util/DomBuilderException.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/DomBuilderException.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden
+   Copyright 2013 Nationale-Nederlanden, 2021 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,36 +15,23 @@
 */
 package nl.nn.adapterframework.util;
 
-import org.apache.commons.lang.exception.NestableException;
+import nl.nn.adapterframework.core.IbisException;
 
-public class DomBuilderException extends NestableException {
-	
-/**
- * DomBuilderException constructor comment.
- */
-public DomBuilderException() {
-	super();
-}
-/**
- * DomBuilderException constructor comment.
- * @param msg java.lang.String
- */
-public DomBuilderException(String msg) {
-	super(msg);
-}
-/**
- * DomBuilderException constructor comment.
- * @param msg java.lang.String
- * @param nestedException java.lang.Throwable
- */
-public DomBuilderException(String msg, Throwable nestedException) {
-	super(msg, nestedException);
-}
-/**
- * DomBuilderException constructor comment.
- * @param nestedException java.lang.Throwable
- */
-public DomBuilderException(Throwable nestedException) {
-	super(nestedException);
-}
+public class DomBuilderException extends IbisException {
+
+	public DomBuilderException() {
+		super();
+	}
+
+	public DomBuilderException(String msg) {
+		super(msg);
+	}
+
+	public DomBuilderException(String msg, Throwable nestedException) {
+		super(msg, nestedException);
+	}
+
+	public DomBuilderException(Throwable nestedException) {
+		super(nestedException);
+	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/core/IbisExceptionTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/core/IbisExceptionTest.java
@@ -1,0 +1,91 @@
+package nl.nn.adapterframework.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.sql.SQLException;
+
+import javax.mail.internet.AddressException;
+
+import org.junit.Test;
+
+public class IbisExceptionTest {
+
+	@Test
+	public void twoNestedExceptionsWithDifferentMessages() {
+		SenderException exception = new SenderException("Some text here", new NullPointerException("some other text here"));
+		String result = exception.getMessage();
+
+		assertEquals("Some text here: (NullPointerException) some other text here", result);
+	}
+
+	@Test
+	public void twoNestedExceptionsWithTheSameMessage() {
+		SenderException exception = new SenderException("Some text here", new NullPointerException("Some text here"));
+		String result = exception.getMessage();
+
+		assertEquals("(NullPointerException) Some text here", result);
+	}
+
+	@Test
+	public void testRecursiveExceptionMessageSearch() {
+		SenderException exception = new SenderException("IbisLocalSender [CallAdapter-sender] exception calling JavaListener [NestedAdapter_04]: Pipe [CallAdapter] msgId [Test Tool correlation id] caught exception: IbisLocalSender [CallAdapter-sender] exception calling JavaListener [TestErrorAdapter_Stub]: Pipe [StubbedSender] msgId [Test Tool correlation id] caught exception: Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]", 
+				new SenderException("Pipe [CallAdapter] msgId [Test Tool correlation id] caught exception: IbisLocalSender [CallAdapter-sender] exception calling JavaListener [TestErrorAdapter_Stub]: Pipe [StubbedSender] msgId [Test Tool correlation id] caught exception: Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]", 
+				new SenderException("IbisLocalSender [CallAdapter-sender] exception calling JavaListener [TestErrorAdapter_Stub]: Pipe [StubbedSender] msgId [Test Tool correlation id] caught exception: Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]",
+				new SenderException("Pipe [StubbedSender] msgId [Test Tool correlation id] caught exception: Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]", 
+				new SenderException("Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]")))));
+		String result = exception.getMessage();
+
+		assertEquals("IbisLocalSender [CallAdapter-sender] exception calling JavaListener [NestedAdapter_04]: Pipe [CallAdapter] msgId [Test Tool correlation id] caught exception: IbisLocalSender [CallAdapter-sender] exception calling JavaListener [TestErrorAdapter_Stub]: Pipe [StubbedSender] msgId [Test Tool correlation id] caught exception: Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]", result);
+	}
+	
+	@Test
+	public void noMessageInException() {
+		SenderException exception = new SenderException(new SenderException());
+		String result = exception.getMessage();
+
+		assertTrue(result.contains("no message, fields of this exception: nl.nn.adapterframework.core.SenderException"));
+	}
+
+	@Test
+	public void exceptionWithSpecificDetailsEmpty() {
+		SenderException exception = new SenderException(new AddressException("some text"));
+		String result = exception.getMessage();
+
+		assertEquals("(AddressException) some text", result);
+	}
+	
+	@Test
+	public void exceptionWithSpecificDetails() {
+		SenderException exception = new SenderException(new AddressException("test","ref",14));
+		String result = exception.getMessage();
+
+		assertEquals("(AddressException) [ref] at column [15]: test", result);
+	}
+	
+	@Test
+	public void sqlExceptionWithSpecificDetails() {
+		SenderException exception = new SenderException("text" ,new SQLException("reason", "state", new SenderException("test")));
+		String result = exception.getMessage();
+
+		assertEquals("text: (SQLException) SQLState [state]: reason: test", result);
+	}
+	
+	@Test
+	public void sqlExceptionWithSpecificDetailsAsTheMessageOfInnerException() {
+		SenderException exception = new SenderException("SQLState [state]" ,new SQLException("reason", "state", new SenderException("SQLState [state]")));
+		String result = exception.getMessage();
+
+		assertEquals("SQLState [state]: (SQLException) reason: SQLState [state]", result);
+	}
+
+	@Test
+	public void testRecursiveExceptionMessageSearchUseToString() {
+		SenderException exception = new SenderException("IbisLocalSender [CallAdapter-sender] exception calling JavaListener [NestedAdapter_04]: Pipe [CallAdapter] msgId [Test Tool correlation id] caught exception: IbisLocalSender [CallAdapter-sender] exception calling JavaListener [TestErrorAdapter_Stub]: Pipe [StubbedSender] msgId [Test Tool correlation id] caught exception: Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]", 
+				new SenderException("javax.mail.internet.AddressException: Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]", 
+				new AddressException("Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]")));
+		String result = exception.getMessage();
+
+		assertEquals("IbisLocalSender [CallAdapter-sender] exception calling JavaListener [NestedAdapter_04]: Pipe [CallAdapter] msgId [Test Tool correlation id] caught exception: IbisLocalSender [CallAdapter-sender] exception calling JavaListener [TestErrorAdapter_Stub]: Pipe [StubbedSender] msgId [Test Tool correlation id] caught exception: (AddressException) Pipe [StubbedSender] msgId [Test Tool correlation id] exceptionOnResult [[error]]", result);
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/core/IbisExceptionTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/core/IbisExceptionTest.java
@@ -42,7 +42,7 @@ public class IbisExceptionTest {
 		SenderException exception3 = new SenderException(msg3, exception2);
 		String msg4 = "Pipe [CallAdapter] msgId [Test Tool correlation id] caught exception: "+exception3.getMessage();
 		SenderException exception4 = new SenderException(msg4, exception3);
-		String msg5 = "IbisLocalSender [CallAdapter-sender] exception calling JavaListener [NestedAdapter_04]: "+exception4.getMessage();;
+		String msg5 = "IbisLocalSender [CallAdapter-sender] exception calling JavaListener [NestedAdapter_04]: "+exception4.getMessage();
 		SenderException exception5 = new SenderException(msg5, exception4);
 		String result = exception5.getMessage();
 


### PR DESCRIPTION
Should be merged into 7.5 and 7.6 too.