### PR TITLE
Close HTTP ResponseStream

### DIFF
--- a/akamai/src/main/java/nl/nn/adapterframework/extensions/akamai/NetStorageSender.java
+++ b/akamai/src/main/java/nl/nn/adapterframework/extensions/akamai/NetStorageSender.java
@@ -322,7 +322,7 @@ public class NetStorageSender extends HttpSenderBase {
 		String charset = responseHandler.getCharset();
 		if (log.isDebugEnabled()) log.debug(getLogPrefix()+"response body uses charset ["+charset+"]");
 
-		Message response = new Message(responseHandler.getResponse(), charset);
+		Message response = responseHandler.getResponseMessage();
 
 		String responseBody = null;
 		try {

--- a/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpSender.java
+++ b/cmis/src/main/java/nl/nn/adapterframework/extensions/cmis/CmisHttpSender.java
@@ -144,14 +144,17 @@ public class CmisHttpSender extends HttpSenderBase {
 			StatusLine statusline = responseHandler.getStatusLine();
 			responseCode = statusline.getStatusCode();
 
+			Message responseMessage = responseHandler.getResponseMessage();
+			responseMessage.closeOnCloseOf(session);
+
 			InputStream responseStream = null;
 			InputStream errorStream = null;
 			Map<String, List<String>> headerFields = responseHandler.getHeaderFields();
 			if (responseCode == 200 || responseCode == 201 || responseCode == 203 || responseCode == 206) {
-				responseStream = responseHandler.getResponse();
+				responseStream = responseMessage.asInputStream();
 			}
 			else {
-				errorStream = responseHandler.getResponse();
+				errorStream = responseMessage.asInputStream();
 			}
 			Response response = new Response(responseCode, statusline.toString(), headerFields, responseStream, errorStream);
 			session.put("response", response);

--- a/core/src/main/java/nl/nn/adapterframework/http/HttpResponseHandler.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/HttpResponseHandler.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2017-2018, 2020 WeAreFrank!
+   Copyright 2017-2021 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -22,9 +22,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import nl.nn.adapterframework.stream.Message;
-import nl.nn.adapterframework.util.Misc;
-
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpHeaders;
@@ -32,6 +29,9 @@ import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.entity.ContentType;
 import org.apache.http.util.EntityUtils;
+
+import nl.nn.adapterframework.stream.Message;
+import nl.nn.adapterframework.util.StreamUtil;
 
 public class HttpResponseHandler {
 	private HttpResponse httpResponse;
@@ -92,7 +92,7 @@ public class HttpResponseHandler {
 
 	public String getCharset() {
 		ContentType contentType = getContentType();
-		String charSet = Misc.DEFAULT_INPUT_STREAM_ENCODING;
+		String charSet = StreamUtil.DEFAULT_INPUT_STREAM_ENCODING;
 		if(contentType != null && contentType.getCharset() != null)
 			charSet = contentType.getCharset().displayName();
 		return charSet;

--- a/core/src/main/java/nl/nn/adapterframework/http/HttpSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/HttpSender.java
@@ -548,22 +548,24 @@ public class HttpSender extends HttpSenderBase {
 			response = (HttpServletResponse) session.get(PipeLineSession.HTTP_RESPONSE_KEY);
 
 		if (response==null) {
+			Message responseMessage = responseHandler.getResponseMessage();
+			responseMessage.closeOnCloseOf(session);
 			if (StringUtils.isNotEmpty(getStreamResultToFileNameSessionKey())) {
 				try {
 					String fileName = Message.asString(session.get(getStreamResultToFileNameSessionKey()));
 					File file = new File(fileName);
-					Misc.streamToFile(responseHandler.getResponse(), file);
+					Misc.streamToFile(responseMessage.asInputStream(), file);
 					return new Message(fileName);
 				} catch (IOException e) {
 					throw new SenderException("cannot find filename to stream result to", e);
 				}
 			} else if (isBase64()) { //This should be removed in a future iteration
-				return getResponseBodyAsBase64(responseHandler.getResponse());
+				return getResponseBodyAsBase64(responseMessage.asInputStream());
 			} else if (StringUtils.isNotEmpty(getStoreResultAsStreamInSessionKey())) {
-				session.put(getStoreResultAsStreamInSessionKey(), responseHandler.getResponse());
+				session.put(getStoreResultAsStreamInSessionKey(), responseMessage.asInputStream());
 				return Message.nullMessage();
 			} else if (StringUtils.isNotEmpty(getStoreResultAsByteArrayInSessionKey())) {
-				session.put(getStoreResultAsByteArrayInSessionKey(), Misc.streamToBytes(responseHandler.getResponse()));
+				session.put(getStoreResultAsByteArrayInSessionKey(), responseMessage.asByteArray());
 				return Message.nullMessage();
 			} else if (BooleanUtils.isTrue(getMultipartResponse()) || responseHandler.isMultipart()) {
 				if(BooleanUtils.isFalse(getMultipartResponse())) {
@@ -592,9 +594,6 @@ public class HttpSender extends HttpSenderBase {
 			return Message.asMessage(headersXml.toXML());
 		}
 
-		if (responseHandler.isMultipart()) {
-			log.error("message body is not handled as a multipart");
-		}
 		return responseHandler.getResponseMessage();
 	}
 
@@ -606,7 +605,7 @@ public class HttpSender extends HttpSenderBase {
 	/**
 	 * return the first part as Message and put the other parts as InputStream in the PipeLineSession
 	 */
-	public static Message handleMultipartResponse(HttpResponseHandler httpHandler, PipeLineSession session) throws IOException {
+	private static Message handleMultipartResponse(HttpResponseHandler httpHandler, PipeLineSession session) throws IOException {
 		return handleMultipartResponse(httpHandler.getContentType().getMimeType(), httpHandler.getResponse(), session);
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
@@ -15,6 +15,8 @@
 */
 package nl.nn.adapterframework.receivers;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Date;
@@ -1079,7 +1081,14 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IR
 		String messageId = (String)threadContext.get(PipeLineSession.originalMessageIdKey);
 		long endExtractingMessage = System.currentTimeMillis();
 		messageExtractionStatistics.addValue(endExtractingMessage-startExtractingMessage);
-		processMessageInAdapter(rawMessageOrWrapper, message, messageId, technicalCorrelationId, threadContext, waitingDuration, manualRetry);
+		Message output = processMessageInAdapter(rawMessageOrWrapper, message, messageId, technicalCorrelationId, threadContext, waitingDuration, manualRetry);
+		try {
+			if(output.asObject() instanceof Closeable) {
+				((Closeable) output.asObject()).close();
+			}
+		} catch (IOException e) {
+			// Ignore if already closed!
+		}
 	}
 
 	

--- a/core/src/test/java/nl/nn/adapterframework/http/HttpSenderTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/HttpSenderTest.java
@@ -81,7 +81,7 @@ public class HttpSenderTest extends HttpSenderTestBase<HttpSender> {
 		sender.configure();
 		sender.open();
 
-		String result = sender.sendMessage(input, null).asString();
+		String result = sender.sendMessage(input, session).asString();
 		assertEqualsIgnoreCRLF(getFile("simpleMockedHttpGetWithoutPRC.txt"), result.trim());
 	}
 

--- a/core/src/test/resources/nl/nn/adapterframework/http/response/simpleMockedHttpGetWithoutPRC.txt
+++ b/core/src/test/resources/nl/nn/adapterframework/http/response/simpleMockedHttpGetWithoutPRC.txt
@@ -1,1 +1,2 @@
 GET /hallo HTTP/1.1
+Message-Id: testmessageac13ecb1--30fe9225_16caa708707_-7fb1


### PR DESCRIPTION
Also automatically close all IPullingListener responses, this is far from optimal as implementations should do `closeOnClose(PipeLineSession)`.