### PR TITLE
Extend transformerParameter type check with Message

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/util/XmlUtils.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/XmlUtils.java
@@ -1639,7 +1639,7 @@ public class XmlUtils {
 		for (String paramName:parameters.keySet()) {
 			Object value = parameters.get(paramName);
 			if (value != null) {
-				if (value instanceof Reader || value instanceof InputStream || value instanceof byte[]) {
+				if (value instanceof Reader || value instanceof InputStream || value instanceof byte[] || value instanceof Message) {
 					value = Message.asString(value);
 				}
 				t.setParameter(paramName, value);

--- a/core/src/test/java/nl/nn/adapterframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/XmlUtilsTest.java
@@ -3,15 +3,25 @@ package nl.nn.adapterframework.util;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.StringReader;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
 
 import org.junit.Test;
 import org.xml.sax.SAXException;
 
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.Resource;
+import nl.nn.adapterframework.stream.Message;
+import nl.nn.adapterframework.testutil.TestFileUtils;
 import nl.nn.adapterframework.testutil.TestScopeProvider;
 import nl.nn.adapterframework.xml.XmlWriter;
 
@@ -117,5 +127,31 @@ public class XmlUtilsTest extends FunctionalTransformerPoolTestBase {
 
 		String errorMessage = "Cannot get resource for publicId [null] with systemId [file:///c:/temp/test.xml] in scope [nl.nn.adapterframework.testutil.TestScopeProvider";
 		assertTrue("SaxParseException should start with [Cannot get resource ...] but is ["+thrown.getMessage()+"]", thrown.getMessage().startsWith(errorMessage));
+	}
+
+	@Test
+	public void testSettingTransformerParameters() throws IOException, TransformerConfigurationException {
+		Map<String, Object> parameters = new HashMap<String, Object>();
+		parameters.put("stringParamKey", "stringParamValue");
+		parameters.put("byteArrayParamKey", "byteArrayParamValue".getBytes());
+		parameters.put("baisParamKey", new ByteArrayInputStream("baisParamValue".getBytes()));
+		parameters.put("readerParamKey", new StringReader("readerParamValue"));
+		parameters.put("nullParamKey", null);
+		parameters.put("messageParamKey", new Message("messageParamValue"));
+		parameters.put("integerParamKey", 3);
+		parameters.put("booleanParamKey", false);
+
+		Transformer transformer = TransformerFactory.newInstance().newTransformer();
+		XmlUtils.setTransformerParameters(transformer, parameters);
+
+		assertTrue(transformer.getParameter("stringParamKey") instanceof String);
+		assertTrue(transformer.getParameter("byteArrayParamKey") instanceof String);
+		assertTrue(transformer.getParameter("baisParamKey") instanceof String);
+		assertTrue(transformer.getParameter("readerParamKey") instanceof String);
+		assertTrue(transformer.getParameter("messageParamKey") instanceof String);
+
+		assertTrue(transformer.getParameter("integerParamKey") instanceof Integer);
+		assertTrue(transformer.getParameter("booleanParamKey") instanceof Boolean);
+
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/util/XmlUtilsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/XmlUtilsTest.java
@@ -6,7 +6,6 @@ import static org.junit.Assert.assertTrue;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.StringReader;
-import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -21,7 +20,6 @@ import org.xml.sax.SAXException;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.Resource;
 import nl.nn.adapterframework.stream.Message;
-import nl.nn.adapterframework.testutil.TestFileUtils;
 import nl.nn.adapterframework.testutil.TestScopeProvider;
 import nl.nn.adapterframework.xml.XmlWriter;
 


### PR DESCRIPTION
Parameters sent to setTransformerParameters method is from Object type. There could be parameters like Boolean and Integer which cannot be Message at the moment. 
Closes #1690 