### PR TITLE
JSON improvements - no empty lists of children

### DIFF
--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/FrankDocJsonFactory.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/FrankDocJsonFactory.java
@@ -111,8 +111,14 @@ public class FrankDocJsonFactory {
 		JsonArrayBuilder xmlElementNames = bf.createArrayBuilder();
 		frankElement.getXmlElementNames().forEach(xmlElementNames::add);
 		result.add("elementNames", xmlElementNames);
-		result.add("attributes", getAttributes(frankElement));
-		result.add("children", getConfigChildren(frankElement));
+		JsonArray attributes = getAttributes(frankElement);
+		if(! attributes.isEmpty()) {
+			result.add("attributes", attributes);
+		}
+		JsonArray configChildren = getConfigChildren(frankElement);
+		if(! configChildren.isEmpty()) {
+			result.add("children", configChildren);
+		}
 		return result.build();
 	}
 

--- a/frankDoc/src/test/resources/doc/examplesExpected/deprecated.json
+++ b/frankDoc/src/test/resources/doc/examplesExpected/deprecated.json
@@ -36,10 +36,6 @@
             "name":"Object",
             "fullName":"java.lang.Object",
             "elementNames":[
-            ],
-            "attributes":[
-            ],
-            "children":[
             ]
         },
         {
@@ -48,10 +44,6 @@
             "deprecated":true,
             "elementNames":[
                 "RoleNameTChild"
-            ],
-            "attributes":[
-            ],
-            "children":[
             ]
         }
     ]

--- a/frankDoc/src/test/resources/doc/examplesExpected/sequence.json
+++ b/frankDoc/src/test/resources/doc/examplesExpected/sequence.json
@@ -79,16 +79,12 @@
     {
       "name": "Object",
       "fullName": "java.lang.Object",
-      "elementNames": [],
-      "attributes": [],
-      "children": []
+      "elementNames": []
     },
     {
       "name": "Opaque",
       "fullName": "nl.nn.adapterframework.frankdoc.testtarget.examples.sequence.Opaque",
-      "elementNames": ["RoleEpsilon"],
-      "attributes": [],
-      "children": []
+      "elementNames": ["RoleEpsilon"]
     }
   ]
 }

--- a/frankDoc/src/test/resources/doc/examplesExpected/simple.json
+++ b/frankDoc/src/test/resources/doc/examplesExpected/simple.json
@@ -23,8 +23,7 @@
       "attributes": [{
         "name": "abstractParentOfStartAttribute",
         "describer": "nl.nn.adapterframework.frankdoc.testtarget.examples.simple.AbstractParentOfStart"
-      }],
-      "children": []
+      }]
     },
     {
       "name": "DescribedPossibleIChild",
@@ -43,8 +42,7 @@
           "describer": "nl.nn.adapterframework.frankdoc.testtarget.examples.simple.DescribedPossibleIChild",
           "description": "Second attribute of DescribedPossibleIChild"
         }
-      ],
-      "children": []
+      ]
     },
     {
       "name": "NotDescribedPossibleIChild",
@@ -68,15 +66,12 @@
           "describer": "nl.nn.adapterframework.frankdoc.testtarget.examples.simple.NotDescribedPossibleIChild",
           "type": "int"
         }
-      ],
-      "children": []
+      ]
     },
     {
       "name": "Object",
       "fullName": "java.lang.Object",
-      "elementNames": [],
-      "attributes": [],
-      "children": []
+      "elementNames": []
     },
     {
       "name": "Start",
@@ -104,9 +99,7 @@
       "name": "TChild",
       "fullName": "nl.nn.adapterframework.frankdoc.testtarget.examples.simple.TChild",
       "descriptionHeader": "This is the header of the JavaDoc of \\\"TChild\\\".",
-      "elementNames": ["RoleNameTChild"],
-      "attributes": [],
-      "children": []
+      "elementNames": ["RoleNameTChild"]
     }
   ]
 }


### PR DESCRIPTION
Frank!Doc - Niels commented in https://github.com/ibissource/iaf/issues/1716 that we have empty lists of attributes and children in the Frank!Doc JSON. This pull request is a fix for that.