### PR TITLE
Base groups on Javadoc annotations

### DIFF
--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/FrankDocJsonFactory.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/FrankDocJsonFactory.java
@@ -195,7 +195,6 @@ public class FrankDocJsonFactory {
 		}
 		result.add("multiple", child.isAllowMultiple());
 		result.add("roleName", child.getElementRole().getRoleName());
-		result.add("group", child.getElementRole().getElementType().getFrankDocGroup().getName());
 		addIfNotNull(result, "description", child.getDescription());
 		return result.build();
 	}

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankClassDoclet.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankClassDoclet.java
@@ -88,13 +88,13 @@ class FrankClassDoclet implements FrankClass {
 	}
 
 	@Override
-	public FrankAnnotation[] getAnnotations() {
+	public FrankAnnotation[] getJava5Annotations() {
 		List<FrankAnnotation> values = new ArrayList<>(frankAnnotationsByName.values());
 		return values.toArray(new FrankAnnotation[] {});
 	}
 
 	@Override
-	public FrankAnnotation getAnnotation(String name) {
+	public FrankAnnotation getJava5Annotation(String name) {
 		return frankAnnotationsByName.get(name);
 	}
 

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankClassReflect.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankClassReflect.java
@@ -235,7 +235,7 @@ class FrankClassReflect implements FrankClass {
 	}
 
 	@Override
-	public FrankAnnotation[] getAnnotations() {
+	public FrankAnnotation[] getJava5Annotations() {
 		List<FrankAnnotation> annotationList = new ArrayList<>(annotations.values());
 		FrankAnnotation[] result = new FrankAnnotation[annotationList.size()];
 		for(int i = 0; i < annotationList.size(); ++i) {
@@ -245,7 +245,7 @@ class FrankClassReflect implements FrankClass {
 	}
 
 	@Override
-	public FrankAnnotation getAnnotation(String name) {
+	public FrankAnnotation getJava5Annotation(String name) {
 		return annotations.get(name);
 	}
 

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethod.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethod.java
@@ -17,10 +17,8 @@ limitations under the License.
 package nl.nn.adapterframework.frankdoc.doclet;
 
 public interface FrankMethod extends FrankProgramElement {
-	public static final String JAVADOC_DEFAULT_VALUE_TAG = "@ff.default";
-
-	FrankAnnotation[] getAnnotations();
-	FrankAnnotation getAnnotation(String name);
+	FrankAnnotation[] getJava5Annotations();
+	FrankAnnotation getJava5Annotation(String name);
 	FrankClass getDeclaringClass();
 	/**
 	 * If the return type is void, return a {@link FrankPrimitiveType} wrapping "void".
@@ -29,11 +27,11 @@ public interface FrankMethod extends FrankProgramElement {
 	int getParameterCount();
 	FrankType[] getParameterTypes();
 	boolean isVarargs();
-	FrankAnnotation getAnnotationInludingInherited(String name) throws FrankDocException;
+	FrankAnnotation getJava5AnnotationInludingInherited(String name) throws FrankDocException;
 	String getJavaDoc();
 	String getJavaDocIncludingInherited() throws FrankDocException;
-	String getDefaultValueFromJavadoc();
-	String getDefaultValueFromJavadocIncludingInherited() throws FrankDocException;
+	String getJavaDocAnnotation(String tagName);
+	String getJavaDocAnnotationIncludingInherited(String tagName) throws FrankDocException;
 
 	default String toStringImpl() {
 		return String.format("%s.%s", getDeclaringClass().getSimpleName(), getName());

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodDoclet.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodDoclet.java
@@ -58,12 +58,12 @@ class FrankMethodDoclet implements FrankMethod {
 	}
 
 	@Override
-	public FrankAnnotation[] getAnnotations() {
+	public FrankAnnotation[] getJava5Annotations() {
 		return frankAnnotationsByName.values().toArray(new FrankAnnotation[] {});
 	}
 
 	@Override
-	public FrankAnnotation getAnnotation(String name) {
+	public FrankAnnotation getJava5Annotation(String name) {
 		return frankAnnotationsByName.get(name);
 	}
 
@@ -130,8 +130,8 @@ class FrankMethodDoclet implements FrankMethod {
 	}
 
 	@Override
-	public FrankAnnotation getAnnotationInludingInherited(String name) throws FrankDocException {
-		Function<FrankMethodDoclet, FrankAnnotation> getter = m -> m.getAnnotation(name);
+	public FrankAnnotation getJava5AnnotationInludingInherited(String name) throws FrankDocException {
+		Function<FrankMethodDoclet, FrankAnnotation> getter = m -> m.getJava5Annotation(name);
 		return searchIncludingInherited(getter);
 	}
 
@@ -194,8 +194,8 @@ class FrankMethodDoclet implements FrankMethod {
 	}
 
 	@Override
-	public String getDefaultValueFromJavadoc() {
-		Tag[] tags = method.tags(FrankMethod.JAVADOC_DEFAULT_VALUE_TAG);
+	public String getJavaDocAnnotation(String tagName) {
+		Tag[] tags = method.tags(tagName);
 		if((tags == null) || (tags.length == 0)) {
 			return null;
 		}
@@ -204,8 +204,8 @@ class FrankMethodDoclet implements FrankMethod {
 	}
 
 	@Override
-	public String getDefaultValueFromJavadocIncludingInherited() throws FrankDocException {
-		Function<FrankMethodDoclet, String> getter = m -> m.getDefaultValueFromJavadoc();
+	public String getJavaDocAnnotationIncludingInherited(String tagName) throws FrankDocException {
+		Function<FrankMethodDoclet, String> getter = m -> m.getJavaDocAnnotation(tagName);
 		return searchIncludingInherited(getter);		
 	}
 

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodReflect.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodReflect.java
@@ -89,7 +89,7 @@ class FrankMethodReflect implements FrankMethod {
 	}
 
 	@Override
-	public FrankAnnotation[] getAnnotations() {
+	public FrankAnnotation[] getJava5Annotations() {
 		List<FrankAnnotation> annotationList = new ArrayList<>(annotations.values());
 		FrankAnnotation[] result = new FrankAnnotation[annotationList.size()];
 		for(int i = 0; i < annotationList.size(); ++i) {
@@ -99,12 +99,12 @@ class FrankMethodReflect implements FrankMethod {
 	}
 
 	@Override
-	public FrankAnnotation getAnnotation(String name) {
+	public FrankAnnotation getJava5Annotation(String name) {
 		return annotations.get(name);
 	}
 
 	@Override
-	public FrankAnnotation getAnnotationInludingInherited(String name) throws FrankDocException {
+	public FrankAnnotation getJava5AnnotationInludingInherited(String name) throws FrankDocException {
 		Annotation rawAnnotation = null;
 		try {
 			@SuppressWarnings("unchecked")
@@ -131,12 +131,12 @@ class FrankMethodReflect implements FrankMethod {
 	}
 
 	@Override
-	public String getDefaultValueFromJavadoc() {
+	public String getJavaDocAnnotation(String tagName) {
 		return null;
 	}
 
 	@Override
-	public String getDefaultValueFromJavadocIncludingInherited() {
+	public String getJavaDocAnnotationIncludingInherited(String tagName) {
 		return null;
 	}
 

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankSimpleType.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankSimpleType.java
@@ -34,12 +34,12 @@ abstract class FrankSimpleType implements FrankType {
 	}
 
 	@Override
-	public FrankAnnotation[] getAnnotations() {
+	public FrankAnnotation[] getJava5Annotations() {
 		return new FrankAnnotation[] {};
 	}
 
 	@Override
-	public FrankAnnotation getAnnotation(String name) {
+	public FrankAnnotation getJava5Annotation(String name) {
 		return null;
 	}
 

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankType.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/doclet/FrankType.java
@@ -17,8 +17,8 @@ limitations under the License.
 package nl.nn.adapterframework.frankdoc.doclet;
 
 public interface FrankType extends FrankProgramElement {
-	FrankAnnotation[] getAnnotations();
-	FrankAnnotation getAnnotation(String name);
+	FrankAnnotation[] getJava5Annotations();
+	FrankAnnotation getJava5Annotation(String name);
 	boolean isPrimitive();
 	boolean isEnum();
 }

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/ConfigChild.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/ConfigChild.java
@@ -84,18 +84,18 @@ public class ConfigChild extends ElementChild {
 	}
 
 	private static boolean isDocumented(FrankMethod m) {
-		return (m.getAnnotation(FrankDocletConstants.IBISDOC) != null) || (m.getJavaDoc() != null);
+		return (m.getJava5Annotation(FrankDocletConstants.IBISDOC) != null) || (m.getJavaDoc() != null);
 	}
 
 	private static boolean isDeprecated(FrankMethod m) {
-		FrankAnnotation deprecated = m.getAnnotation(FrankDocletConstants.DEPRECATED);
+		FrankAnnotation deprecated = m.getJava5Annotation(FrankDocletConstants.DEPRECATED);
 		return (deprecated != null);
 	}
 
 	private static FrankAnnotation getIbisDoc(FrankMethod method) {
 		FrankAnnotation result = null;
 		try {
-			result = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
+			result = method.getJava5AnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		} catch(FrankDocException e) {
 			log.warn("Could not @IbisDoc annotation or could not obtain JavaDoc for method {}", method, e);
 		}

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/ElementChild.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/ElementChild.java
@@ -135,7 +135,7 @@ public abstract class ElementChild {
 			if(value != null) {
 				description = value;
 			}
-			value = method.getDefaultValueFromJavadocIncludingInherited();
+			value = method.getJavaDocAnnotationIncludingInherited(FrankAttribute.JAVADOC_DEFAULT_VALUE_TAG);
 			if(value != null) {
 				defaultValue = value;
 			}

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/ElementType.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/ElementType.java
@@ -27,7 +27,6 @@ import org.apache.logging.log4j.Logger;
 
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Setter;
 import nl.nn.adapterframework.frankdoc.doclet.FrankClass;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.Misc;
@@ -46,7 +45,6 @@ public class ElementType {
 	private static Logger log = LogUtil.getLogger(ElementType.class);
 	private @Getter(AccessLevel.PACKAGE) List<FrankElement> members;
 	private @Getter boolean fromJavaInterface;
-	private @Getter @Setter FrankDocGroup frankDocGroup;
 	
 	private static class InterfaceHierarchyItem {
 		private @Getter String fullName;

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankAttribute.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankAttribute.java
@@ -22,6 +22,8 @@ import lombok.Setter;
 import nl.nn.adapterframework.frankdoc.doclet.FrankDocException;
 
 public class FrankAttribute extends ElementChild {
+	static final String JAVADOC_DEFAULT_VALUE_TAG = "@ff.default";
+
 	@EqualsAndHashCode(callSuper = false)
 	static class Key extends AbstractKey {
 		private String name;

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankDocModel.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankDocModel.java
@@ -311,22 +311,22 @@ public class FrankDocModel {
 	}
 
 	private void documentAttribute(FrankAttribute attribute, FrankMethod method, FrankElement attributeOwner) throws FrankDocException {
-		attribute.setDeprecated(method.getAnnotation(FrankDocletConstants.DEPRECATED) != null);
+		attribute.setDeprecated(method.getJava5Annotation(FrankDocletConstants.DEPRECATED) != null);
 		attribute.setDocumented(
-				(method.getAnnotation(FrankDocletConstants.IBISDOC) != null)
-				|| (method.getAnnotation(FrankDocletConstants.IBISDOCREF) != null)
+				(method.getJava5Annotation(FrankDocletConstants.IBISDOC) != null)
+				|| (method.getJava5Annotation(FrankDocletConstants.IBISDOCREF) != null)
 				|| (method.getJavaDoc() != null)
-				|| (method.getDefaultValueFromJavadoc() != null));
+				|| (method.getJavaDocAnnotation(FrankAttribute.JAVADOC_DEFAULT_VALUE_TAG) != null));
 		log.trace("Attribute: deprecated = [{}], documented = [{}]", () -> attribute.isDeprecated(), () -> attribute.isDocumented());
 		attribute.setJavaDocBasedDescriptionAndDefault(method);
-		FrankAnnotation ibisDocRef = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOCREF);
+		FrankAnnotation ibisDocRef = method.getJava5AnnotationInludingInherited(FrankDocletConstants.IBISDOCREF);
 		if(ibisDocRef != null) {
 			log.trace("Found @IbisDocRef annotation");
 			ParsedIbisDocRef parsed = parseIbisDocRef(ibisDocRef, method);
 			FrankAnnotation ibisDoc = null;
 			if((parsed != null) && (parsed.getReferredMethod() != null)) {
 				attribute.setJavaDocBasedDescriptionAndDefault(parsed.getReferredMethod());
-				ibisDoc = parsed.getReferredMethod().getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
+				ibisDoc = parsed.getReferredMethod().getJava5AnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 				if(ibisDoc != null) {
 					attribute.setDescribingElement(findOrCreateFrankElement(parsed.getReferredMethod().getDeclaringClass().getName()));
 					log.trace("Describing element of attribute [{}].[{}] is [{}]",
@@ -339,7 +339,7 @@ public class FrankDocModel {
 				log.warn("@IbisDocRef of Frank elelement [{}] attribute [{}] points to non-existent method", () -> attributeOwner.getSimpleName(), () -> attribute.getName());
 			}
 		}
-		FrankAnnotation ibisDoc = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
+		FrankAnnotation ibisDoc = method.getJava5AnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		if(ibisDoc != null) {
 			log.trace("For attribute [{}], have @IbisDoc without @IbisDocRef", attribute);
 			attribute.parseIbisDocAnnotation(ibisDoc);

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankDocModel.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankDocModel.java
@@ -530,7 +530,6 @@ public class FrankDocModel {
 		for(ElementType elementType: getAllTypes().values()) {
 			if(elementType.isFromJavaInterface()) {
 				FrankDocGroup interfaceBasedGroup = FrankDocGroup.getInstanceFromElementType(elementType);
-				elementType.setFrankDocGroup(interfaceBasedGroup);
 				String groupName = elementType.getGroupName();
 				if(groupsBase.containsKey(groupName)) {
 					groupsBase.get(groupName).add(interfaceBasedGroup);
@@ -559,10 +558,7 @@ public class FrankDocModel {
 			log.warn("Name \"[{}]\" cannot been used for others group because it is the name of an ElementType", OTHER);
 		}
 		else {
-			final FrankDocGroup groupOther = FrankDocGroup.getInstanceFromFrankElements(OTHER, membersOfOther);
-			allTypes.values().stream()
-				.filter(et -> ! et.isFromJavaInterface())
-				.forEach(et -> et.setFrankDocGroup(groupOther));
+			FrankDocGroup groupOther = FrankDocGroup.getInstanceFromFrankElements(OTHER, membersOfOther);
 			groupsBase.put(OTHER, Arrays.asList(groupOther));
 		}
 		for(String groupName: groupsBase.keySet()) {

--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankElement.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankElement.java
@@ -71,7 +71,7 @@ public class FrankElement implements Comparable<FrankElement> {
 
 	FrankElement(FrankClass clazz) {
 		this(clazz.getName(), clazz.getSimpleName(), clazz.isAbstract());
-		isDeprecated = clazz.getAnnotation(FrankDocletConstants.DEPRECATED) != null;
+		isDeprecated = clazz.getJava5Annotation(FrankDocletConstants.DEPRECATED) != null;
 		configChildSets = new LinkedHashMap<>();
 		javadocStrategy.completeFrankElement(this, clazz);
 	}

--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankAnnotationTest.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankAnnotationTest.java
@@ -10,11 +10,11 @@ import org.junit.runners.Parameterized;
 @RunWith(Parameterized.class)
 public class FrankAnnotationTest extends TestBase{
 	@Test
-	public void whenArrayAnnotationValueProvidedAsScalarThenStillFetchable() throws FrankDocException {
+	public void whenArrayJava5AnnotationValueProvidedAsScalarThenStillFetchable() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Parent");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertEquals("setInherited", setter.getName());
-		FrankAnnotation[] annotations = setter.getAnnotations();
+		FrankAnnotation[] annotations = setter.getJava5Annotations();
 		assertEquals(1, annotations.length);
 		FrankAnnotation annotation = annotations[0];
 		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
@@ -24,11 +24,11 @@ public class FrankAnnotationTest extends TestBase{
 	}
 
 	@Test
-	public void whenArrayAnnotaionValueProvidedAsArrayThenFetchable() throws FrankDocException {
+	public void whenArrayJava5AnnotationValueProvidedAsArrayThenFetchable() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "DeprecatedChild");
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "someSetter");
 		assertEquals("someSetter", setter.getName());
-		FrankAnnotation annotation = setter.getAnnotation(FrankDocletConstants.IBISDOC);
+		FrankAnnotation annotation = setter.getJava5Annotation(FrankDocletConstants.IBISDOC);
 		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 		assertArrayEquals(new String[] {"100", "Some description", "0"}, (String[]) annotation.getValue());
 	}

--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankClassTest.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankClassTest.java
@@ -26,8 +26,8 @@ public class FrankClassTest extends TestBase {
 		FrankClass instance = classRepository.findClass(PACKAGE + "Child");
 		assertEquals(PACKAGE + "Child", instance.getName());
 		assertTrue(instance.isPublic());
-		assertEquals(0, instance.getAnnotations().length);
-		assertNull(instance.getAnnotation(FrankDocletConstants.DEPRECATED));
+		assertEquals(0, instance.getJava5Annotations().length);
+		assertNull(instance.getJava5Annotation(FrankDocletConstants.DEPRECATED));
 		assertFalse(instance.isAbstract());
 		assertEquals("Child", instance.getSimpleName());
 		assertEquals("Parent", instance.getSuperclass().getSimpleName());
@@ -43,13 +43,13 @@ public class FrankClassTest extends TestBase {
 	}
 
 	@Test
-	public void testClassAnnotations() throws FrankDocException {
+	public void testClassJava5Annotations() throws FrankDocException {
 		FrankClass instance = classRepository.findClass(PACKAGE + "DeprecatedChild");
-		FrankAnnotation[] annotations = instance.getAnnotations();
+		FrankAnnotation[] annotations = instance.getJava5Annotations();
 		assertEquals(1, annotations.length);
 		FrankAnnotation annotation = annotations[0];
 		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
-		annotation = instance.getAnnotation(FrankDocletConstants.DEPRECATED);
+		annotation = instance.getJava5Annotation(FrankDocletConstants.DEPRECATED);
 		assertNotNull(annotation);
 		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
 	}

--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodDocletTest.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodDocletTest.java
@@ -54,14 +54,14 @@ public class FrankMethodDocletTest {
 	}
 
 	@Test
-	public void whenMethodHasDefaultThenReturnedByGetDefaultValueFromJavadoc() {
+	public void whenMethodHasJavaDocAnnotationThenReturned() {
 		FrankMethod method = getMethodByName(clazz, "setInherited");
-		assertEquals("DefaultValue", method.getDefaultValueFromJavadoc());
+		assertEquals("DefaultValue", method.getJavaDocAnnotation(TestUtil.TEST_JAVADOC_DEFAULT_VALUE_TAG));
 	}
 
 	@Test
-	public void whenMethodInheritsDefaultThenReturnedByGetDefaultValueFromJavadocIncludingInherited() throws FrankDocException {
+	public void whenMethodInheritsJavaDocAnnotationThenReturned() throws FrankDocException {
 		FrankMethod method = getMethodByName(innerClass, "myAnnotatedMethod");
-		assertEquals("InheritedDefault", method.getDefaultValueFromJavadocIncludingInherited());		
+		assertEquals("InheritedDefault", method.getJavaDocAnnotationIncludingInherited(TestUtil.TEST_JAVADOC_DEFAULT_VALUE_TAG));		
 	}
 }

--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodTest.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/FrankMethodTest.java
@@ -24,11 +24,11 @@ public class FrankMethodTest extends TestBase {
 		FrankMethod setter = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertEquals("setInherited", setter.getName());
 		assertTrue(setter.isPublic());
-		FrankAnnotation[] annotations = setter.getAnnotations();
+		FrankAnnotation[] annotations = setter.getJava5Annotations();
 		assertEquals(1, annotations.length);
 		FrankAnnotation annotation = annotations[0];
 		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
-		annotation = setter.getAnnotation(FrankDocletConstants.IBISDOC);
+		annotation = setter.getJava5Annotation(FrankDocletConstants.IBISDOC);
 		assertNotNull(annotation);
 		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 		FrankType returnType = setter.getReturnType();
@@ -41,7 +41,7 @@ public class FrankMethodTest extends TestBase {
 		FrankType parameter = parameters[0];
 		assertFalse(parameter.isPrimitive());
 		assertEquals(FrankDocletConstants.STRING, parameter.getName());
-		annotation = setter.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
+		annotation = setter.getJava5AnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		assertNotNull(annotation);
 		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 	}
@@ -55,21 +55,21 @@ public class FrankMethodTest extends TestBase {
 	}
 
 	@Test
-	public void whenNoAnnotationsThenNullReturned() throws FrankDocException {
+	public void whenNoJava5AnnotationsThenNullReturned() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "packagePrivateMethod");
-		assertEquals(0, method.getAnnotations().length);
-		assertNull(method.getAnnotation(FrankDocletConstants.IBISDOC));
+		assertEquals(0, method.getJava5Annotations().length);
+		assertNull(method.getJava5Annotation(FrankDocletConstants.IBISDOC));
 	}
 
 	@Test
-	public void whenInheritedAnnotationsRequestedThenInheritedAnnotationsIncluded() throws FrankDocException {
+	public void whenInheritedJava5AnnotationsRequestedThenInheritedJava5AnnotationsIncluded() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "setInherited");
 		assertNotNull(method);
-		FrankAnnotation annotation = method.getAnnotation(FrankDocletConstants.IBISDOC);
+		FrankAnnotation annotation = method.getJava5Annotation(FrankDocletConstants.IBISDOC);
 		assertNull(annotation);
-		annotation = method.getAnnotationInludingInherited(FrankDocletConstants.IBISDOC);
+		annotation = method.getJava5AnnotationInludingInherited(FrankDocletConstants.IBISDOC);
 		assertNotNull(annotation);
 		assertEquals(FrankDocletConstants.IBISDOC, annotation.getName());
 	}
@@ -122,10 +122,10 @@ public class FrankMethodTest extends TestBase {
 	}
 
 	@Test
-	public void annotationCanBeInheritedFromImplementedInterface() throws FrankDocException {
+	public void java5AnnotationCanBeInheritedFromImplementedInterface() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "Child");
 		FrankMethod method = TestUtil.getDeclaredMethodOf(clazz, "myAnnotatedMethod");
-		FrankAnnotation annotation = method.getAnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
+		FrankAnnotation annotation = method.getJava5AnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
 		assertNotNull(annotation);
 		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
 	}

--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/InterfaceAndAnnotationTest.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/InterfaceAndAnnotationTest.java
@@ -132,14 +132,14 @@ public class InterfaceAndAnnotationTest {
 	}
 
 	@Test
-	public void whenMatchingInterfaceMethodHasAnnotationThenAnnotationFound() throws FrankDocException {
+	public void whenMatchingInterfaceMethodHasJava5AnnotationThenJava5AnnotationFound() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "DiamondImplementationOfCommonParent");
 		List<FrankMethod> actualDeclaredMethods = getNonJacocoDeclaredMethods(clazz);
 		assertEquals(1, actualDeclaredMethods.size());
 		FrankMethod method = actualDeclaredMethods.get(0);
 		assertEquals("annotatedMethod", method.getName());
-		assertNull(method.getAnnotation(FrankDocletConstants.DEPRECATED));
-		FrankAnnotation annotation = method.getAnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
+		assertNull(method.getJava5Annotation(FrankDocletConstants.DEPRECATED));
+		FrankAnnotation annotation = method.getJava5AnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
 		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
 	}
 
@@ -150,19 +150,19 @@ public class InterfaceAndAnnotationTest {
 	}
 
 	@Test
-	public void whenSuperclassHasMatchingInterfaceMethodWithAnnotationThenAnnotationFound() throws FrankDocException {
+	public void whenSuperclassHasMatchingInterfaceMethodWithJava5AnnotationThenJava5AnnotationFound() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "GrandChild");
 		List<FrankMethod> actualDeclaredMethods = getNonJacocoDeclaredMethods(clazz);
 		assertEquals(1, actualDeclaredMethods.size());
 		FrankMethod method = actualDeclaredMethods.get(0);
 		assertEquals("annotatedMethod", method.getName());
-		assertNull(method.getAnnotation(FrankDocletConstants.DEPRECATED));
-		FrankAnnotation annotation = method.getAnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
+		assertNull(method.getJava5Annotation(FrankDocletConstants.DEPRECATED));
+		FrankAnnotation annotation = method.getJava5AnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
 		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
 	}
 
 	@Test
-	public void whenAbstractSuperclassHasMatchingInterfaceMethodWithAnnotationThenAnnotationFound() throws FrankDocException {
+	public void whenAbstractSuperclassHasMatchingInterfaceMethodWithJava5AnnotationThenJava5AnnotationFound() throws FrankDocException {
 		FrankClass clazz = classRepository.findClass(PACKAGE + "ChildOfAbstractImplementation");
 		List<FrankMethod> actualDeclaredMethods = getNonJacocoDeclaredMethods(clazz);
 		String actualDeclaredMethodsString = actualDeclaredMethods.stream()
@@ -171,8 +171,8 @@ public class InterfaceAndAnnotationTest {
 		assertEquals(String.format("Have methods [%s]",  actualDeclaredMethodsString), 1, actualDeclaredMethods.size());
 		FrankMethod method = actualDeclaredMethods.get(0);
 		assertEquals("annotatedMethod", method.getName());
-		assertNull(method.getAnnotation(FrankDocletConstants.DEPRECATED));
-		FrankAnnotation annotation = method.getAnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
+		assertNull(method.getJava5Annotation(FrankDocletConstants.DEPRECATED));
+		FrankAnnotation annotation = method.getJava5AnnotationInludingInherited(FrankDocletConstants.DEPRECATED);
 		assertEquals(FrankDocletConstants.DEPRECATED, annotation.getName());
 	}
 }

--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/TestUtil.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/TestUtil.java
@@ -14,6 +14,7 @@ import nl.nn.adapterframework.frankdoc.doclet.classdocs.EasyDoclet;
 public final class TestUtil {
 	private static final Properties BUILD_PROPERTIES = new TestUtil().loadBuildProperties();
 	private static final File TEST_SOURCE_DIRECTORY = new File(BUILD_PROPERTIES.getProperty("testSourceDirectory"));
+	static final String TEST_JAVADOC_DEFAULT_VALUE_TAG = "@ff.default";
 
 	private TestUtil() {
 	}

--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/model/FrankDocModelGroupsTest.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/model/FrankDocModelGroupsTest.java
@@ -16,7 +16,6 @@ limitations under the License.
 package nl.nn.adapterframework.frankdoc.model;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
@@ -30,8 +29,6 @@ import nl.nn.adapterframework.frankdoc.doclet.FrankClassRepository;
 import nl.nn.adapterframework.frankdoc.doclet.TestUtil;
 
 public class FrankDocModelGroupsTest {
-	private static final String I_GROUP_CONTAINER = "nl.nn.adapterframework.frankdoc.testtarget.groups.IGroupContainer";
-
 	private FrankDocModel instance;
 	
 	@Before
@@ -48,8 +45,6 @@ public class FrankDocModelGroupsTest {
 		List<FrankElement> elements = group.getElements();
 		assertEquals(1, elements.size());
 		assertEquals("GroupContainer", group.getElements().get(0).getSimpleName());
-		ElementType elementType = instance.getAllTypes().get(I_GROUP_CONTAINER);
-		assertSame(group, elementType.getFrankDocGroup());
 	}
 
 	@Test
@@ -59,7 +54,5 @@ public class FrankDocModelGroupsTest {
 		assertEquals(1, other.getElements().size());
 		FrankElement element = other.getElements().get(0);
 		assertEquals("GroupChild", element.getSimpleName());
-		ElementType elementType = instance.getAllTypes().get("nl.nn.adapterframework.frankdoc.testtarget.groups.GroupChild");
-		assertSame(other, elementType.getFrankDocGroup());
 	}
 }

--- a/frankDoc/src/test/resources/doc/examplesExpected/deprecated.json
+++ b/frankDoc/src/test/resources/doc/examplesExpected/deprecated.json
@@ -27,8 +27,7 @@
                 {
                     "deprecated":true,
                     "multiple":true,
-                    "roleName":"roleNameTChild",
-                    "group":"Other"
+                    "roleName":"roleNameTChild"
                 }
             ]
         },

--- a/frankDoc/src/test/resources/doc/examplesExpected/sequence.json
+++ b/frankDoc/src/test/resources/doc/examplesExpected/sequence.json
@@ -48,23 +48,19 @@
       "children": [
         {
           "multiple": false,
-          "roleName": "roleAlpha",
-          "group": "Proton"
+          "roleName": "roleAlpha"
         },
         {
           "multiple": false,
-          "roleName": "roleBeta",
-          "group": "Mnemonic"
+          "roleName": "roleBeta"
         },
         {
           "multiple": false,
-          "roleName": "roleEpsilon",
-          "group": "Other"
+          "roleName": "roleEpsilon"
         },
         {
           "multiple": false,
-          "roleName": "roleDelta",
-          "group": "Nemesis"
+          "roleName": "roleDelta"
         }
       ]
     },

--- a/frankDoc/src/test/resources/doc/examplesExpected/simple.json
+++ b/frankDoc/src/test/resources/doc/examplesExpected/simple.json
@@ -85,13 +85,11 @@
       "children": [
         {
           "multiple": false,
-          "roleName": "roleNameIChild",
-          "group": "Child"
+          "roleName": "roleNameIChild"
         },
         {
           "multiple": true,
-          "roleName": "roleNameTChild",
-          "group": "Other"
+          "roleName": "roleNameTChild"
         }
       ]
     },


### PR DESCRIPTION
This pull request aims to improve the JSON file used for the Frank!Doc website. The issue being solved is that too many groups are shown. Before this pull request, every Java interface that appeared as the argument of a config child setter introduced a group in the Frank!Doc webapplication. As an example, there was a method SenderPipe.setListener(ICorrelatedPullingListener) that introduced a group CorrelatedPullingListener. We do not want group CorrelatedPullingListener, but only Listener.

We solve this issue by introducing a JavaDoc annotation @ff.group that always has a value that is the name of the group. This is the main purpose of this pull request, but there are some related changes:

* Some method names of FrankType and FrankMethod in the wrapper API were confusing. We had for example getDefaultValueFromJavadoc(). This name was confusing, because interpreting information obtained from Java reflection or from a doclet is a task of the model. The wrapper API should only use either doclets or Java reflection to see which classes, methods, Java 5 annotations and JavaDoc annotations exist. There are also renames to have a clear distinction between Java 5 annotations and JavaDoc annotations.
* The JSON had a "group" field to tell what members were allowed as children of an element. The allowed children depend on a Java interface however that is modeled by an ElementType. The JSON referenced a FrankDocGroup however, causing a link between ElementType and FrankDocGroup that we need to break. The "group" field is removed for now, but before we merge this pull request an alternative may be introduced.