### PR TITLE
Add debug logging for output streaming

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/MessageSendingPipe.java
@@ -553,11 +553,10 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 			}
 			if (!wrapResult.isSuccessful()) {
 				return wrapResult;
-			} else {
-				input = wrapResult.getResult();
-				if (messageLog!=null) {
-					preserve(input, session);
-				}
+			}
+			input = wrapResult.getResult();
+			if (messageLog!=null) {
+				preserve(input, session);
 			}
 			log.debug(getLogPrefix(session)+"input after wrapping ("+ClassUtils.nameOf(input)+") [" + input.toString() + "]");
 		}
@@ -815,9 +814,8 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 				throw new PipeRunException(this, getLogPrefix(session) + "caught exception", e);
 			}
 			return new PipeRunResult(forward, "");
-		} else {
-			return new PipeRunResult(forward, result);
 		}
+		return new PipeRunResult(forward, result);
 	}
 
 	private boolean validResult(Object result) throws IOException {
@@ -1025,9 +1023,8 @@ public class MessageSendingPipe extends StreamingPipe implements HasSender, HasS
 	public boolean hasSizeStatistics() {
 		if (!super.hasSizeStatistics()) {
 			return getSender().isSynchronous();
-		} else {
-			return super.hasSizeStatistics();
 		}
+		return super.hasSizeStatistics();
 	}
 
 

--- a/core/src/main/java/nl/nn/adapterframework/stream/MessageOutputStream.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/MessageOutputStream.java
@@ -44,7 +44,7 @@ import nl.nn.adapterframework.xml.PrettyPrintFilter;
 import nl.nn.adapterframework.xml.XmlWriter;
 
 public class MessageOutputStream implements AutoCloseable {
-	protected Logger log = LogUtil.getLogger(this);
+	protected static Logger log = LogUtil.getLogger(MessageOutputStream.class);
 	
 	private INamedObject owner;
 	protected Object requestStream;
@@ -365,9 +365,11 @@ public class MessageOutputStream implements AutoCloseable {
 			}
 		}
 		MessageOutputStream target = nextProvider==null ? null : nextProvider.provideOutputStream(session, null);
-		if (target==null) {
-			target=new MessageOutputStreamCap(owner, next);
+		if (target!=null) {
+			log.debug("OutputStream for {} [{}] is provided by {} [{}]", ()->owner.getClass().getSimpleName(), ()->owner.getName(), ()->next.getClass().getSimpleName(), ()->next.getName());
+			return target;
 		}
-		return target;
+		log.debug("providing MessageOutputStreamCap for {} [{}]", ()->owner.getClass().getSimpleName(), ()->owner.getName());
+		return new MessageOutputStreamCap(owner, next);
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/stream/StreamingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/StreamingPipe.java
@@ -98,6 +98,7 @@ public abstract class StreamingPipe extends FixedForwardPipe implements IOutputS
 			log.debug("pipe [{}] cannot provide outputstream", () -> getName());
 			return null;
 		}
+		log.debug("pipe [{}] creating outputstream", () -> getName());
 		return provideOutputStream(session);
 	}
 	

--- a/core/src/main/java/nl/nn/adapterframework/stream/StreamingPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/StreamingPipe.java
@@ -92,8 +92,11 @@ public abstract class StreamingPipe extends FixedForwardPipe implements IOutputS
 		return null;
 	}
 
-	@Override
-	public final MessageOutputStream provideOutputStream(PipeLineSession session, IForwardTarget next) throws StreamingException {
+	/**
+	 * Don't override unless you're absolutely sure what you're doing!
+	 */
+	@Override //Can't make AOP'd methods final
+	public MessageOutputStream provideOutputStream(PipeLineSession session, IForwardTarget next) throws StreamingException {
 		if (!canProvideOutputStream()) {
 			log.debug("pipe [{}] cannot provide outputstream", () -> getName());
 			return null;

--- a/core/src/main/resources/FrankFrameworkConfigurationContext.xml
+++ b/core/src/main/resources/FrankFrameworkConfigurationContext.xml
@@ -6,8 +6,15 @@
  -->
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:aop="http://www.springframework.org/schema/aop"
 	default-autowire="byName"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+	xsi:schemaLocation="
+		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop.xsd
+	">
+
+	<!-- AOP has to be enabled explicitly on a per Context basis -->
+	<aop:config proxy-target-class="true" />
 
 	<bean
 		name="configurationDigester"

--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -130,6 +130,9 @@
 		<!-- Logger name="org.springframework" level="DEBUG" additivity="false">
 			<AppenderRef ref="stdout"/>
 		</Logger -->
+		<!-- Logger name="org.springframework.aop" level="DEBUG" additivity="false">
+			<AppenderRef ref="stdout"/>
+		</Logger -->
 		<!-- Logger name="bitronix.tm" level="DEBUG" additivity="false">
 			<AppenderRef ref="stdout"/>
 		</Logger -->


### PR DESCRIPTION
This PR adds debug logging for the creation of output streams.
The ladybug logging is still not good.
It appears to me that the AOP proxying of pipes and senders is broken, possibly after merge of #1686 