### PR TITLE
Fix failure of ConfigurationDigesterTest

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,6 +94,7 @@ Start reading our code and you'll get the hang of it. We optimize for readabilit
     - Class level IbisDoc, not larger then 5 to 10 lines
     - For each configurable attribute, IbisDoc must not be larger then 2 lines
     - Any examples and more detailed information, that has to be incorperated in to the IbisManual, should be provided as a separate file(s) attached to the pull request
+  * In JavaDoc comments, do not use the `’` character. It breaks the Frank!Doc. You can use `'` instead.
   * Please do not modify files purely for the sake of formatting, or do so in a dedicated pull request. Formatting changes make a pull request harder to understand for reviewers.
   * You can experiment with Eclipse's formatting capabilities. In the preferences window, search for the string "tab". You will get an overview of all the options about formatting. The following options are interesting in particular:
     - There are many screens in which you can define that you use tabs instead of spaces for indentation. Please visit them all to configure that you use tabs.

--- a/idin/src/main/java/nl/nn/adapterframework/extensions/idin/IdinSender.java
+++ b/idin/src/main/java/nl/nn/adapterframework/extensions/idin/IdinSender.java
@@ -431,7 +431,7 @@ public class IdinSender extends SenderWithParametersBase implements HasPhysicalD
 
 
 	/**
-	 * @param acquirerDirectoryUrl The web address of the Acquirer’s Routing service platform from where the 
+	 * @param acquirerDirectoryUrl The web address of the Acquirer's Routing service platform from where the 
 	 * list of Issuers is retrieved (using a directory request).
 	 */
 	public void setAcquirerDirectoryUrl(String acquirerDirectoryUrl) {
@@ -442,7 +442,7 @@ public class IdinSender extends SenderWithParametersBase implements HasPhysicalD
 	}
 
 	/**
-	 * @param acquirerTransactionUrl The web address of the Acquirer’s Routing Service platform 
+	 * @param acquirerTransactionUrl The web address of the Acquirer's Routing Service platform 
 	 * where the transactions (authentication requests) are initiated.
 	 */
 	public void setAcquirerTransactionUrl(String acquirerTransactionUrl) {
@@ -453,7 +453,7 @@ public class IdinSender extends SenderWithParametersBase implements HasPhysicalD
 	}
 
 	/**
-	 * @param acquirerStatusUrl The web address of the Acquirer’s Routing Service platform to where 
+	 * @param acquirerStatusUrl The web address of the Acquirer's Routing Service platform to where 
 	 * the library sends status request messages.
 	 */
 	public void setAcquirerStatusUrl(String acquirerStatusUrl) {
@@ -500,7 +500,7 @@ public class IdinSender extends SenderWithParametersBase implements HasPhysicalD
 	}
 
 	/**
-	 * This is the certificate owned by the Merchant. It’s the private certificate
+	 * This is the certificate owned by the Merchant. It's the private certificate
 	 * used to sign messages sent by the Merchant to the Acquirer's Routing Service platform. Its public
 	 * key is also used by the Acquirer to authenticate incoming messages from the Merchant. The
 	 * Merchant certificate must be in PKCS#12 format which has the extension .p12 or .pfx
@@ -542,7 +542,7 @@ public class IdinSender extends SenderWithParametersBase implements HasPhysicalD
 	 * only needs its public key. The public certificate must be in PEM format (base64 ASCII) and typically 
 	 * has the file extension .cer,.crt or .pem.
 	 * 
-	 * @param acquirerCertificateAlias : The alias assigned to the Acquirer’s certificate in the keystore.
+	 * @param acquirerCertificateAlias : The alias assigned to the Acquirer's certificate in the keystore.
 	 * This could be the alias you supplied explicitly when importing an existing certificate in the keystore, 
 	 * or it could be an alias automatically assigned by the keytool application.
 	 */
@@ -558,7 +558,7 @@ public class IdinSender extends SenderWithParametersBase implements HasPhysicalD
 	 * only needs its public key. The public certificate must be in PEM format (base64 ASCII) and typically 
 	 * has the file extension .cer,.crt or .pem.
 	 * 
-	 * @param acquirerAlternativeCertificateAlias : The alias assigned to the Acquirer’s certificate in the keystore.
+	 * @param acquirerAlternativeCertificateAlias : The alias assigned to the Acquirer's certificate in the keystore.
 	 * This could be the alias you supplied explicitly when importing an existing certificate in the keystore, 
 	 * or it could be an alias automatically assigned by the keytool application.
 	 */


### PR DESCRIPTION
Fix failing tests in the build of the entire iaf repository. The build was started like:

$ mvn -PattachFrankDoc install

The error was:

[INFO] Running nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest
[ERROR] Tests run: 5, Failures: 0, Errors: 3, Skipped: 0, Time elapsed: 0.172 s <<< FAILURE! - in nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest
[ERROR] testConfigurationPreParser(nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest)  Time elapsed: 0.032 s  <<< ERROR!
java.io.IOException: Cannot get canonicalizer using [/xml/xsd/FrankConfig-compatibility.xsd]
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testConfigurationPreParser(ConfigurationDigesterTest.java:53)
Caused by: org.xml.sax.SAXParseException: Invalid byte 1 of 1-byte UTF-8 sequence.
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testConfigurationPreParser(ConfigurationDigesterTest.java:53)
Caused by: org.apache.xerces.impl.io.MalformedByteSequenceException: Invalid byte 1 of 1-byte UTF-8 sequence.
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testConfigurationPreParser(ConfigurationDigesterTest.java:53)

[ERROR] testNewCanonicalizer(nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest)  Time elapsed: 0.008 s  <<< ERROR!
java.io.IOException: Cannot get canonicalizer using [/xml/xsd/FrankConfig-compatibility.xsd]
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testNewCanonicalizer(ConfigurationDigesterTest.java:35)
Caused by: org.xml.sax.SAXParseException: Invalid byte 1 of 1-byte UTF-8 sequence.
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testNewCanonicalizer(ConfigurationDigesterTest.java:35)
Caused by: org.apache.xerces.impl.io.MalformedByteSequenceException: Invalid byte 1 of 1-byte UTF-8 sequence.
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testNewCanonicalizer(ConfigurationDigesterTest.java:35)

[ERROR] testFixedValueAttributeResolverWithFrankConfig(nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest)  Time elapsed: 0.004 s  <<< ERROR!
org.xml.sax.SAXParseException: Invalid byte 1 of 1-byte UTF-8 sequence.
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testFixedValueAttributeResolverWithFrankConfig(ConfigurationDigesterTest.java:108)
Caused by: org.apache.xerces.impl.io.MalformedByteSequenceException: Invalid byte 1 of 1-byte UTF-8 sequence.
        at nl.nn.adapterframework.configuration.digester.ConfigurationDigesterTest.testFixedValueAttributeResolverWithFrankConfig(ConfigurationDigesterTest.java:108)

[INFO] Running nl.nn.adapterframework.configuration.digester.FrankDigesterRulesTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.022 s - in nl.nn.adapterframework.configuration.digester.FrankDigesterRulesTest

With this pull request, this issue will be fixed. The issue was that our JavaDoc comments contained a character that could not be parsed by the Frank!Doc logic. The character is replaced. In CONTRIBUTING.md, it is documented that this character should not be used.
