### PR TITLE
Partially fix issue "Restrict which attributes developers can set on FrankElements #1883"

### DIFF
--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankElementFilters.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankElementFilters.java
@@ -69,10 +69,6 @@ public final class FrankElementFilters {
 	}
 
 	public static Set<String> getExcludeFiltersForSuperclass() {
-		// TODO: Include the below line, but to remove some attributes that are too much
-		// in the runtime-generated XSDs. Is not done while the compile-time XSDs are
-		// being compared to the runtime generated ones.
-		// return new HashSet<>(Arrays.asList("org.springframework"));
-		return new HashSet<>();
+		return new HashSet<>(Arrays.asList("org.springframework"));
 	}
 }


### PR DESCRIPTION
Frank attributes are created for setter methods and also setter methods inherited from a parent class. Some classes of the Frank!Framework inherit from Spring classes. Some setters of these Spring classes produced unwanted Frank attributes. This pull request fixes that.

The Frank element "Configuration" will still have attributes that we do not want with this pull request. Those are not related to Spring and will be fixed later.