### PR TITLE
partial fix #1885 "ibisdoc.xsd regular expressions are not compliant"

### DIFF
--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/AttributeTypeStrategy.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/AttributeTypeStrategy.java
@@ -40,7 +40,10 @@ public enum AttributeTypeStrategy {
 
 	private static Logger log = LogUtil.getLogger(AttributeTypeStrategy.class);
 
-	private static final String PATTERN_REF = "\\$\\{[^\\}]+\\}";
+	// The $-sign is not escaped in the regex below. This way,
+	// the regexes in the XSDs are not flagged by XMLSpy.
+	private static final String PATTERN_REF = "$\\{[^\\}]+\\}";
+
 	private static final String FRANK_BOOLEAN = "frankBoolean";
 	private static final String FRANK_INT = "frankInt";
 	private static final String PATTERN_FRANK_BOOLEAN = String.format("(true|false)|(%s)", PATTERN_REF);

--- a/frankDoc/src/test/resources/doc/examplesExpected/sequence.xsd
+++ b/frankDoc/src/test/resources/doc/examplesExpected/sequence.xsd
@@ -86,17 +86,17 @@
   </xs:group>
   <xs:simpleType name="frankBoolean">
     <xs:restriction base="xs:string">
-      <xs:pattern value="(true|false)|(\$\{[^\}]+\})" />
+      <xs:pattern value="(true|false)|($\{[^\}]+\})" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="frankInt">
     <xs:restriction base="xs:string">
-      <xs:pattern value="((\+|-)?[0-9]+)|(\$\{[^\}]+\})" />
+      <xs:pattern value="((\+|-)?[0-9]+)|($\{[^\}]+\})" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="variableRef">
     <xs:restriction base="xs:string">
-      <xs:pattern value="\$\{[^\}]+\}" />
+      <xs:pattern value="$\{[^\}]+\}" />
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/frankDoc/src/test/resources/doc/examplesExpected/simple.xsd
+++ b/frankDoc/src/test/resources/doc/examplesExpected/simple.xsd
@@ -106,17 +106,17 @@ This is the header of the JavaDoc of "DescribedPossibleIChild".</xs:documentatio
   </xs:simpleType>
   <xs:simpleType name="frankBoolean">
     <xs:restriction base="xs:string">
-      <xs:pattern value="(true|false)|(\$\{[^\}]+\})" />
+      <xs:pattern value="(true|false)|($\{[^\}]+\})" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="frankInt">
     <xs:restriction base="xs:string">
-      <xs:pattern value="((\+|-)?[0-9]+)|(\$\{[^\}]+\})" />
+      <xs:pattern value="((\+|-)?[0-9]+)|($\{[^\}]+\})" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="variableRef">
     <xs:restriction base="xs:string">
-      <xs:pattern value="\$\{[^\}]+\}" />
+      <xs:pattern value="$\{[^\}]+\}" />
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>

--- a/frankDoc/src/test/resources/doc/examplesExpected/simpleForCompatibility.xsd
+++ b/frankDoc/src/test/resources/doc/examplesExpected/simpleForCompatibility.xsd
@@ -106,17 +106,17 @@ This is the header of the JavaDoc of "DescribedPossibleIChild".</xs:documentatio
   </xs:simpleType>
   <xs:simpleType name="frankBoolean">
     <xs:restriction base="xs:string">
-      <xs:pattern value="(true|false)|(\$\{[^\}]+\})" />
+      <xs:pattern value="(true|false)|($\{[^\}]+\})" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="frankInt">
     <xs:restriction base="xs:string">
-      <xs:pattern value="((\+|-)?[0-9]+)|(\$\{[^\}]+\})" />
+      <xs:pattern value="((\+|-)?[0-9]+)|($\{[^\}]+\})" />
     </xs:restriction>
   </xs:simpleType>
   <xs:simpleType name="variableRef">
     <xs:restriction base="xs:string">
-      <xs:pattern value="\$\{[^\}]+\}" />
+      <xs:pattern value="$\{[^\}]+\}" />
     </xs:restriction>
   </xs:simpleType>
 </xs:schema>


### PR DESCRIPTION
With this fix, XMLSpy should not report errors anymore about frankdoc.xsd. I tested that the frankdoc.xsd from this code works in Eclipse and VSCode. Before merging, can you check with XMLSpy? I do not have that application. I emailed the XSDs to Gerrit.