### PR TITLE
Prevent reports in progress

### DIFF
--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -14,7 +14,7 @@
 		<dependency>
 			<groupId>org.ibissource</groupId>
 			<artifactId>ibis-ladybug</artifactId>
-			<version>2.2-20210518.202847</version>
+			<version>2.2-20210623.185123</version>
 		</dependency>
 		<dependency>
 			<groupId>org.ibissource</groupId>

--- a/ladybug/src/main/java/nl/nn/ibistesttool/MessageCapturer.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/MessageCapturer.java
@@ -26,9 +26,10 @@ import lombok.Getter;
 import lombok.Setter;
 import nl.nn.adapterframework.stream.Message;
 import nl.nn.adapterframework.util.LogUtil;
+import nl.nn.testtool.MessageCapturerImpl;
 import nl.nn.testtool.TestTool;
 
-public class MessageCapturer implements nl.nn.testtool.MessageCapturer {
+public class MessageCapturer extends MessageCapturerImpl {
 	private Logger log = LogUtil.getLogger(this);
 
 	private @Setter @Getter TestTool testTool;
@@ -45,7 +46,7 @@ public class MessageCapturer implements nl.nn.testtool.MessageCapturer {
 				return StreamingType.CHARACTER_STREAM;
 			}
 		}
-		return StreamingType.NONE;
+		return super.getStreamingType(message);
 	}
 
 	@Override
@@ -61,13 +62,15 @@ public class MessageCapturer implements nl.nn.testtool.MessageCapturer {
 					log.error("Could not close writer", e);
 				}
 			}
+			return message;
 		} 
 		if (message instanceof WriterPlaceHolder) {
 			WriterPlaceHolder writerPlaceHolder = (WriterPlaceHolder)message;
 			writerPlaceHolder.setWriter(writer);
 			writerPlaceHolder.setSizeLimit(testTool.getMaxMessageLength());
+			return message;
 		}
-		return message;
+		return super.toWriter(message, writer, exceptionNotifier);
 	}
 
 	@Override
@@ -85,8 +88,9 @@ public class MessageCapturer implements nl.nn.testtool.MessageCapturer {
 					log.error("Could not close output stream", e);
 				}
 			}
+			return message;
 		}
-		return message;
+		return super.toOutputStream(message, outputStream, charsetNotifier, exceptionNotifier);
 	}
 
 }

--- a/ladybug/src/main/resources/springIbisTestTool.xml
+++ b/ladybug/src/main/resources/springIbisTestTool.xml
@@ -48,6 +48,10 @@
 		<property name="maxMessageLength"><ref bean="maxMessageLength"/></property>
 		<property name="regexFilter"><ref bean="regexFilter"/></property>
 		<property name="securityLoggerName" value="SEC"/>
+		<!-- Prevent threads that didn't start and aren't cancelled to keep reports in progress. Most of the times (like when using ParallelSenders) the main thread will wait for child threads to return their result anyway -->
+		<property name="closeThreads" value="true"/>
+		<!-- Prevent streams for which close method isn't invoked to keep reports in progress. Most of the times streams will be processed during the lifetime of the main thread (which is executing the PipeLine) anyway -->
+		<property name="closeMessageCapturers" value="true"/>
 	</bean>
 
 	<bean name="metadataExtractor" class="nl.nn.testtool.MetadataExtractor">


### PR DESCRIPTION
- Prevent reports in progress because of unclosed streams or threads that didn't start and aren't cancelled
- Visualize waiting for threads and streams