### PR TITLE
Fix warnings in config HTTP

### DIFF
--- a/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationRestListener.xml
@@ -198,7 +198,7 @@
 			</pipe>
 
 			<pipe name="decodeFile" className="nl.nn.adapterframework.pipes.Base64Pipe"
-				direction="decode" convert2String="false">
+				direction="decode" outputType="bytes">
 				<forward name="success" path="writeFile" />
 			</pipe>
 

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSender.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSender.xml
@@ -77,7 +77,7 @@
 			<pipe name="Send2WS"
 				className="nl.nn.adapterframework.pipes.SenderPipe">
 				<sender className="nl.nn.adapterframework.http.WebServiceSender"
-					proxyHost="${proxy.host}" proxyPort="${proxy.port}" proxyUserName="${proxy.username}"
+					proxyHost="${proxy.host}" proxyPort="${proxy.port}" proxyUsername="${proxy.username}"
 					proxyPassword="${proxy.password}" url="${web.protocol}://www.webservicex.net/CurrencyConvertor.asmx"
 					soapAction="${web.protocol}://www.webserviceX.NET/ConversionRate"
 					allowSelfSignedCertificates="true" verifyHostname="false" 

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
@@ -103,9 +103,9 @@
 			</exits> 
 			<pipe className="nl.nn.adapterframework.pipes.SenderPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
-				<sender className="nl.nn.adapterframework.http.WebServiceSender" paramsInUrl="false" inputMessageParam="file"
-					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments" multipart="true"
-					allowSelfSignedCertificates="true" verifyHostname="false" mtomEnabled="true"
+				<sender className="nl.nn.adapterframework.http.WebServiceSender" firstBodyPartName="file"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments"
+					allowSelfSignedCertificates="true" verifyHostname="false" postType="MTOM"
 				/>
 				<param name='file' value="&lt;xml&gt;I just sent some text! :)&lt;/xml&gt;"/>
 				<forward name="success" path="EXIT" />
@@ -142,9 +142,9 @@
 			</pipe> 
 			<pipe className="nl.nn.adapterframework.pipes.SenderPipe"
 				name="Send2WS" getInputFromFixedValue="&lt;xml&gt;hello world&lt;/xml&gt;">
-				<sender className="nl.nn.adapterframework.http.WebServiceSender" paramsInUrl="false" inputMessageParam="file"
-					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments/multipart" multipart="true"
-					allowSelfSignedCertificates="true" verifyHostname="false" mtomEnabled="true" multipartXmlSessionKey="multipart"
+				<sender className="nl.nn.adapterframework.http.WebServiceSender" firstBodyPartName="file"
+					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/services/urn/ws/address/attachments/multipart"
+					allowSelfSignedCertificates="true" verifyHostname="false" postType="MTOM" multipartXmlSessionKey="multipart"
 				/>
 				<forward name="success" path="EXIT" />
 			</pipe>


### PR DESCRIPTION
1 - WebServiceSender attribute [proxyUserName] is deprecated: Please use "proxyUsername" instead
2 - Base64Pipe attribute [convert2String] is deprecated: Please use "outputType" instead