### PR TITLE
HttpListenerSender warning fix for inputMessageParam to firstBodyPartName

### DIFF
--- a/test/src/main/configurations/HTTP/ConfigurationHttpListenerSender.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationHttpListenerSender.xml
@@ -26,7 +26,7 @@
 				<sender className="nl.nn.adapterframework.http.HttpSender"
 					methodType="POST"
 					url="${web.protocol}://${web.host}:${web.port}${web.contextpath}/HttpListener?service=LocalHttpListener"
-					inputMessageParam="request" />
+					firstBodyPartName="request"/>
 				<forward name="success" path="EXIT" />
 			</pipe>
 		</pipeline>


### PR DESCRIPTION
Deze fix is voor de warning:

 HttpSender attribute [inputMessageParam]: Use the <code>firstBodyPartName</code> attribute instead