### PR TITLE
Fix MainConfig warnings

### DIFF
--- a/test/src/main/configurations/MainConfig/ConfigurationCorrelationMessageId.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationCorrelationMessageId.xml
@@ -19,7 +19,7 @@
 			<messageLog className="nl.nn.adapterframework.jdbc.JdbcTransactionalStorage" slotId="${applicationId}/CorrelationMessageIdXPath" />
 		</receiver>
 		<receiver correlationIDXPath="request/@name">
-			<listener className="nl.nn.adapterframework.http.WebServiceListener" name="CorrelationMessageIdXPath2" />
+			<listener className="nl.nn.adapterframework.http.WebServiceListener" name="CorrelationMessageIdXPath2" serviceNamespaceURI="CorrelationMessageIdXPath2" />
 			<messageLog className="nl.nn.adapterframework.jdbc.JdbcTransactionalStorage" slotId="${applicationId}/CorrelationMessageIdXPath2" />
 		</receiver>
 		<pipeline firstPipe="ResolveString">

--- a/test/src/main/configurations/MainConfig/ConfigurationMessageStoreSenderAndListenerPeek.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationMessageStoreSenderAndListenerPeek.xml
@@ -1,7 +1,7 @@
 <module>
 	<adapter name="MessageStoreListener">
 		<receiver transactionAttribute="Required" pollInterval="1">
-			<listener className="nl.nn.adapterframework.jdbc.MessageStoreListener" name="MessageStoreListener" slotId="${applicationId}/MessageStoreListener" peekUntransacted="true" />
+			<listener className="nl.nn.adapterframework.jdbc.MessageStoreListener" name="MessageStoreListener" slotId="${applicationId}/MessageStoreListener" />
 		</receiver>
 		<pipeline firstPipe="echoPipe">
 			<exits>


### PR DESCRIPTION
1 - WebServiceListener [CorrelationMessageIdXPath2] calling webservices via de ServiceDispatcher_ServiceProxy is deprecated. Please specify an address or serviceNamespaceURI and modify the call accordingly
2 -  MessageStoreListener [MessageStoreListener] attribute [peekUntransacted] already has a default value [true]