### PR TITLE
Add queryMBeans permission

### DIFF
--- a/ear/src/main/application/META-INF/was.policy
+++ b/ear/src/main/application/META-INF/was.policy
@@ -129,6 +129,7 @@ permission javax.management.MBeanPermission "*", "addNotificationListener";
 permission javax.management.MBeanPermission "*", "unregisterMBean";
 permission javax.management.MBeanPermission "*", "queryNames";
 permission java.lang.management.ManagementPermission "monitor";
+permission javax.management.MBeanPermission "-#-[-]", "queryMBeans";
 
 // required for BitronixTransactionManager.begin() in receiveMessageAndMoveToErrorStorage
 permission javax.management.MBeanServerPermission "createMBeanServer";


### PR DESCRIPTION
This permission is required when using configurations.database.autoLoad, when doing a full reload without this permission, nothing is loaded any more