### PR TITLE
Remove xTags dependency

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -49,12 +49,6 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.ibissource</groupId>
-			<artifactId>ibis-xtags</artifactId>
-			<version>1.1</version>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
 			<groupId>jaxen</groupId>
 			<artifactId>jaxen</artifactId>
 			<version>1.2.0</version>


### PR DESCRIPTION
which I forgot to remove when I removed struts..

xTags silently depends on Dom4J which was removed in #2028
