### PR TITLE
Remove Jaxen dependency

### DIFF
--- a/webapp/pom.xml
+++ b/webapp/pom.xml
@@ -49,11 +49,6 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
-			<groupId>jaxen</groupId>
-			<artifactId>jaxen</artifactId>
-			<version>1.2.0</version>
-		</dependency>
-		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>javax.servlet-api</artifactId>
 			<scope>provided</scope>


### PR DESCRIPTION
Unsure why Jaxen was added to the webapp (https://github.com/ibissource/iaf/commit/26fe6584b1e5a0b3d5a6b890e23bb8db38bb52c4).
Might be related to ibis-xtags / dom4j as dom4j depends on the jaxen xpath parser.