### PR TITLE
Introduce interface ITrigger

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/monitoring/ITrigger.java
+++ b/core/src/main/java/nl/nn/adapterframework/monitoring/ITrigger.java
@@ -1,0 +1,52 @@
+/*
+   Copyright 2013 Nationale-Nederlanden, 2021 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package nl.nn.adapterframework.monitoring;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.DisposableBean;
+
+import nl.nn.adapterframework.lifecycle.LazyLoadingEventListener;
+import nl.nn.adapterframework.monitoring.events.FireMonitorEvent;
+import nl.nn.adapterframework.util.XmlBuilder;
+
+public interface ITrigger extends LazyLoadingEventListener<FireMonitorEvent>, DisposableBean {
+	boolean isAlarm();
+	void clearEvents();
+	boolean isConfigured();
+	void configure();
+	void toXml(XmlBuilder monitor);
+	String getType();
+	String[] getEventCodes();
+	SeverityEnum getSeverityEnum();
+	String getSeverity();
+	int getThreshold();
+	int getPeriod();
+	Map<String, AdapterFilter> getAdapterFilters();
+	SourceFiltering getSourceFilteringEnum();
+	String getSourceFiltering();
+	void setEventCodes(String[] arr);
+	void setType(String type);
+	void setSeverityEnum(SeverityEnum enumeration);
+	void setThreshold(int i);
+	void setPeriod(int i);
+	void clearAdapterFilters();
+	void setSourceFilteringEnum(SourceFiltering filtering);
+	void registerAdapterFilter(AdapterFilter af);
+	void setMonitor(Monitor monitor);
+	void setAlarm(boolean b);
+}

--- a/core/src/main/java/nl/nn/adapterframework/monitoring/Monitor.java
+++ b/core/src/main/java/nl/nn/adapterframework/monitoring/Monitor.java
@@ -61,7 +61,7 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 
 	private MonitorManager manager = null;
 
-	private List<Trigger> triggers = new ArrayList<>();
+	private List<ITrigger> triggers = new ArrayList<>();
 	private Set<String> destinations = new HashSet<>(); 
 	private @Setter ApplicationContext applicationContext;
 
@@ -73,8 +73,8 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 		}
 
 		if (log.isDebugEnabled()) log.debug("monitor ["+getName()+"] configuring triggers");
-		for (Iterator<Trigger> it=triggers.iterator(); it.hasNext();) {
-			Trigger trigger = it.next();
+		for (Iterator<ITrigger> it=triggers.iterator(); it.hasNext();) {
+			ITrigger trigger = it.next();
 			if(!trigger.isConfigured()) {
 				trigger.configure();
 				((ConfigurableApplicationContext)applicationContext).addApplicationListener(trigger);
@@ -130,8 +130,8 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 	}
 
 	protected void clearEvents(boolean alarm) {
-		for (Iterator<Trigger> it=triggers.iterator(); it.hasNext();) {
-			Trigger trigger=(Trigger)it.next();
+		for (Iterator<ITrigger> it=triggers.iterator(); it.hasNext();) {
+			ITrigger trigger = it.next();
 			if (trigger.isAlarm()!=alarm) {
 				trigger.clearEvents();
 			}
@@ -159,8 +159,8 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 		monitor.addAttribute("name",getName());
 		monitor.addAttribute("type",getType());
 		monitor.addAttribute("destinations",getDestinationsAsString());
-		for (Iterator<Trigger> it=triggers.iterator();it.hasNext();) {
-			Trigger trigger=(Trigger)it.next();
+		for (Iterator<ITrigger> it=triggers.iterator();it.hasNext();) {
+			ITrigger trigger=it.next();
 			trigger.toXml(monitor);
 		}
 		return monitor;
@@ -211,12 +211,12 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 		}
 	}
 
-	public void registerTrigger(Trigger trigger) {
+	public void registerTrigger(ITrigger trigger) {
 		trigger.setMonitor(this);
 		triggers.add(trigger);
 	}
 
-	public void removeTrigger(Trigger trigger) {
+	public void removeTrigger(ITrigger trigger) {
 		int index = triggers.indexOf(trigger);
 		if(index > -1) {
 			AutowireCapableBeanFactory factory = applicationContext.getAutowireCapableBeanFactory();
@@ -225,11 +225,11 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 		}
 	}
 
-	public void registerAlarm(Trigger trigger) {
+	public void registerAlarm(ITrigger trigger) {
 		trigger.setAlarm(true);
 		registerTrigger(trigger);
 	}
-	public void registerClearing(Trigger trigger) {
+	public void registerClearing(ITrigger trigger) {
 		trigger.setAlarm(false);
 		registerTrigger(trigger);
 	}
@@ -245,10 +245,10 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 		return manager;
 	}
 
-	public List<Trigger> getTriggers() {
+	public List<ITrigger> getTriggers() {
 		return triggers;
 	}
-	public Trigger getTrigger(int index) {
+	public ITrigger getTrigger(int index) {
 		return triggers.get(index);
 	}
 
@@ -338,7 +338,7 @@ public class Monitor implements ApplicationContextAware, DisposableBean {
 		log.info("removing monitor ["+this+"]");
 
 		AutowireCapableBeanFactory factory = applicationContext.getAutowireCapableBeanFactory();
-		for (Trigger trigger : triggers) {
+		for (ITrigger trigger : triggers) {
 			factory.destroyBean(trigger);
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/monitoring/Trigger.java
+++ b/core/src/main/java/nl/nn/adapterframework/monitoring/Trigger.java
@@ -24,10 +24,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.Logger;
-import org.springframework.beans.factory.DisposableBean;
 
 import nl.nn.adapterframework.core.Adapter;
-import nl.nn.adapterframework.lifecycle.LazyLoadingEventListener;
 import nl.nn.adapterframework.monitoring.events.FireMonitorEvent;
 import nl.nn.adapterframework.util.DateUtils;
 import nl.nn.adapterframework.util.EnumUtils;
@@ -39,7 +37,7 @@ import nl.nn.adapterframework.util.XmlBuilder;
  * @since   4.9
  * 
  */
-public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, DisposableBean {
+public class Trigger implements ITrigger {
 	protected Logger log = LogUtil.getLogger(this);
 
 	public static final int SOURCE_FILTERING_NONE=0;
@@ -60,6 +58,7 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 	private LinkedList<Date> eventDates = null;
 	private boolean configured = false;
 
+	@Override
 	public void configure() {
 		if (eventCodes.isEmpty()) {
 			log.warn("trigger of Monitor ["+getMonitor().getName()+"] should have at least one eventCode specified");
@@ -76,6 +75,7 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 		configured = true;
 	}
 
+	@Override
 	public boolean isConfigured() {
 		return configured;
 	}
@@ -118,6 +118,7 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 		}
 	}
 
+	@Override
 	public void clearEvents() {
 		if (eventDates!=null) {
 			eventDates.clear();
@@ -136,6 +137,7 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 		}
 	}
 
+	@Override
 	public void toXml(XmlBuilder monitor) {
 		XmlBuilder trigger=new XmlBuilder(isAlarm()?"alarm":"clearing");
 		monitor.addSubElement(trigger);
@@ -182,6 +184,7 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 		}
 	}
 
+	@Override
 	public void setMonitor(Monitor monitor) {
 		this.monitor = monitor;
 	}
@@ -189,13 +192,16 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 		return monitor;
 	}
 
+	@Override
 	public void setAlarm(boolean b) {
 		alarm = b;
 	}
+	@Override
 	public boolean isAlarm() {
 		return alarm;
 	}
 
+	@Override
 	public String getType() {
 		if (isAlarm()) {
 			return "Alarm";
@@ -203,6 +209,8 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 			return "Clearing";
 		}
 	}
+
+	@Override
 	public void setType(String type) {
 		if (type.equalsIgnoreCase("Alarm")) {
 			setAlarm(true);
@@ -224,12 +232,15 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 		addEventCode(code);
 	}
 
+	@Override
 	public void setEventCodes(String[] arr) {
 		clearEventCodes();
 		for (int i=0;i<arr.length;i++) {
 			addEventCode(arr[i]);
 		}
 	}
+
+	@Override
 	public String[] getEventCodes() {
 		return eventCodes.toArray(new String[eventCodes.size()]);
 	}
@@ -241,39 +252,54 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 	public void setSeverity(String severity) {
 		setSeverityEnum(EnumUtils.parse(SeverityEnum.class, severity));
 	}
+
+	@Override
 	public void setSeverityEnum(SeverityEnum enumeration) {
 		severity = enumeration;
 	}
+
+	@Override
 	public SeverityEnum getSeverityEnum() {
 		return severity;
 	}
+
+	@Override
 	public String getSeverity() {
 		return severity==null?null:severity.name();
 	}
 
+	@Override
 	public void setThreshold(int i) {
 		threshold = i;
 	}
+
+	@Override
 	public int getThreshold() {
 		return threshold;
 	}
 
+	@Override
 	public void setPeriod(int i) {
 		period = i;
 	}
+
+	@Override
 	public int getPeriod() {
 		return period;
 	}
 
+	@Override
 	public Map<String, AdapterFilter> getAdapterFilters() {
 		return adapterFilters;
 	}
 
+	@Override
 	public void clearAdapterFilters() {
 		adapterFilters.clear();
 		setSourceFilteringEnum(SourceFiltering.NONE);
 	}
 
+	@Override
 	public void registerAdapterFilter(AdapterFilter af) {
 		adapterFilters.put(af.getAdapter(),af);
 		if(af.isFilteringToLowerLevelObjects()) {
@@ -290,12 +316,17 @@ public class Trigger implements LazyLoadingEventListener<FireMonitorEvent>, Disp
 		return sourceFiltering == SourceFiltering.ADAPTER;
 	}
 
+	@Override
 	public void setSourceFilteringEnum(SourceFiltering filtering) {
 		this.sourceFiltering = filtering;
 	}
+
+	@Override
 	public String getSourceFiltering() {
 		return sourceFiltering.name().toLowerCase();
 	}
+
+	@Override
 	public SourceFiltering getSourceFilteringEnum() {
 		return sourceFiltering;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ShowMonitors.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ShowMonitors.java
@@ -49,6 +49,7 @@ import org.springframework.context.ApplicationContext;
 import nl.nn.adapterframework.monitoring.AdapterFilter;
 import nl.nn.adapterframework.monitoring.EventThrowing;
 import nl.nn.adapterframework.monitoring.EventTypeEnum;
+import nl.nn.adapterframework.monitoring.ITrigger;
 import nl.nn.adapterframework.monitoring.Monitor;
 import nl.nn.adapterframework.monitoring.MonitorException;
 import nl.nn.adapterframework.monitoring.MonitorManager;
@@ -139,8 +140,8 @@ public final class ShowMonitors extends Base {
 		}
 
 		List<Map<String, Object>> triggers = new ArrayList<Map<String, Object>>();
-		List<Trigger> listOfTriggers = monitor.getTriggers();
-		for(Trigger trigger : listOfTriggers) {
+		List<ITrigger> listOfTriggers = monitor.getTriggers();
+		for(ITrigger trigger : listOfTriggers) {
 
 			Map<String, Object> map = mapTrigger(trigger);
 			map.put("id", listOfTriggers.indexOf(trigger));
@@ -159,7 +160,7 @@ public final class ShowMonitors extends Base {
 		return monitorMap;
 	}
 
-	private Map<String, Object> mapTrigger(Trigger trigger) {
+	private Map<String, Object> mapTrigger(ITrigger trigger) {
 		Map<String, Object> triggerMap = new HashMap<String, Object>();
 
 		triggerMap.put("type", trigger.getType());
@@ -319,7 +320,7 @@ public final class ShowMonitors extends Base {
 			throw new ApiException("Monitor not found!", Status.NOT_FOUND);
 		}
 
-		Trigger trigger = SpringUtils.createBean(mm.getApplicationContext(), Trigger.class);
+		ITrigger trigger = SpringUtils.createBean(mm.getApplicationContext(), Trigger.class);
 		handleTrigger(trigger, json);
 		monitor.registerTrigger(trigger);
 		monitor.configure();
@@ -351,7 +352,7 @@ public final class ShowMonitors extends Base {
 		Map<String, Object> returnMap = new HashMap<>();
 
 		if(id != null) {
-			Trigger trigger = monitor.getTrigger(id);
+			ITrigger trigger = monitor.getTrigger(id);
 			if(trigger == null) {
 				throw new ApiException("Trigger not found!", Status.NOT_FOUND);
 			} else {
@@ -390,7 +391,7 @@ public final class ShowMonitors extends Base {
 			throw new ApiException("Monitor not found!", Status.NOT_FOUND);
 		}
 
-		Trigger trigger = monitor.getTrigger(index);
+		ITrigger trigger = monitor.getTrigger(index);
 		if(trigger == null) {
 			throw new ApiException("Trigger not found!", Status.NOT_FOUND);
 		}
@@ -401,7 +402,7 @@ public final class ShowMonitors extends Base {
 	}
 
 	@SuppressWarnings("unchecked")
-	private void handleTrigger(Trigger trigger, Map<String, Object> json) {
+	private void handleTrigger(ITrigger trigger, Map<String, Object> json) {
 		List<String> eventList = null;
 		String type = null;
 		SeverityEnum severity = null;
@@ -483,7 +484,7 @@ public final class ShowMonitors extends Base {
 			throw new ApiException("Monitor not found!", Status.NOT_FOUND);
 		}
 
-		Trigger trigger = monitor.getTrigger(index);
+		ITrigger trigger = monitor.getTrigger(index);
 
 		if(trigger == null) {
 			throw new ApiException("Trigger not found!", Status.NOT_FOUND);


### PR DESCRIPTION
For the Frank!Doc, we want to introduce an interface ITrigger that is implemented by classes Trigger, Alarm and Clearing. We do not want to do this in a single pull request. This pull request just introduces ITrigger and lets the existing class Trigger implement it.

I have done the following tests:
* Run the Larva tests.
* Checkout the master branch and have a screen with the monitors that exist in Ibis4Test. Stop the Frank!Framework but leave the screen with the monitors. Checkout this pull request and start Ibis4Test again. Open a new tab in the browser and view the monitors again. Compare the two pages with monitors. There was no difference.
* Hack Ibis4Example (not checked in) to have a configuration with a monitor. Supply test messages to the example adapter to trigger and clear the test monitor.
* Raise the test monitor in the Frank!Console and clear it using a test message.