### PR TITLE
Frank!Doc: Remove java.lang.Object from the JSON

### DIFF
--- a/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankElementFilters.java
+++ b/frankDoc/src/main/java/nl/nn/adapterframework/frankdoc/model/FrankElementFilters.java
@@ -69,6 +69,6 @@ public final class FrankElementFilters {
 	}
 
 	public static Set<String> getExcludeFiltersForSuperclass() {
-		return new HashSet<>(Arrays.asList("org.springframework"));
+		return new HashSet<>(Arrays.asList("org.springframework", "java.lang"));
 	}
 }


### PR DESCRIPTION
It was not present in the first place in the XSDs.