### PR TITLE
Secure credential expansion

### DIFF
--- a/core/src/test/java/nl/nn/adapterframework/util/StringResolverTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/StringResolverTest.java
@@ -26,6 +26,8 @@ public class StringResolverTest {
 		InputStream propsStream = propertiesURL.openStream();
 		properties.load(propsStream);
 		assertTrue("did not find any properties!", properties.size() > 0);
+		
+		System.setProperty("authAliases.expansion.allowed", "alias1,alias2");
 	}
 
 	@Test
@@ -97,4 +99,9 @@ public class StringResolverTest {
 		assertEquals("passwordOnly", result);
 	}
 
+	@Test
+	public void resolvePasswordNotAllowed() {
+		String result = StringResolver.substVars("${credential:password:alias3}", properties);
+		assertEquals("!!not allowed to expand credential of authAlias [alias3]!!", result);
+	}
 }

--- a/test/src/main/configurations/MainConfig/ConfigurationAuthentication.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationAuthentication.xml
@@ -30,6 +30,18 @@
 				<forward name="exception" path="extractErrorMessage" />
 			</pipe>
 
+			<pipe name="expandCredentialProperty" className="nl.nn.adapterframework.pipes.FixedResultPipe"
+				substituteVars="true" returnString="username: ${credential:username:${test.alias}}; password:${credential:password:${test.alias}}">
+				<forward name="success" path="text2Xml" />
+				<forward name="exception" path="extractErrorMessage" />
+			</pipe>
+
+			<pipe name="expandCredentialPropertyNotAllowed" className="nl.nn.adapterframework.pipes.FixedResultPipe"
+				substituteVars="true" returnString="username: ${credential:username:secretAlias}; password:${credential:password:secretAlias}">
+				<forward name="success" path="text2Xml" />
+				<forward name="exception" path="extractErrorMessage" />
+			</pipe>
+
 			<pipe name="extractErrorMessage" className="nl.nn.adapterframework.pipes.XsltPipe" xpathExpression="*/@message"/>
 
 			<pipe name="text2Xml" className="nl.nn.adapterframework.pipes.Text2XmlPipe"

--- a/test/src/test/testtool/Authentication/scenario04.properties
+++ b/test/src/test/testtool/Authentication/scenario04.properties
@@ -1,0 +1,7 @@
+scenario.description = Expand credential in property
+scenario.active=${active.authentication}
+
+include = common.properties
+
+step1.sender.test.writeline = <expandCredentialProperty/>
+step2.sender.test.read  = scenario04/Result.xml

--- a/test/src/test/testtool/Authentication/scenario04/Result.xml
+++ b/test/src/test/testtool/Authentication/scenario04/Result.xml
@@ -1,0 +1,1 @@
+<result>username: testUser; password:testPassword</result>

--- a/test/src/test/testtool/Authentication/scenario05.properties
+++ b/test/src/test/testtool/Authentication/scenario05.properties
@@ -1,0 +1,7 @@
+scenario.description = Expand credential in property, but now allowed
+scenario.active=${active.authentication}
+
+include = common.properties
+
+step1.sender.test.writeline = <expandCredentialPropertyNotAllowed/>
+step2.sender.test.read  = scenario05/Result.xml

--- a/test/src/test/testtool/Authentication/scenario05/Result.xml
+++ b/test/src/test/testtool/Authentication/scenario05/Result.xml
@@ -1,0 +1,1 @@
+<result>username: testUser; password:testPassword</result>

--- a/test/src/test/testtool/Authentication/scenario05/Result.xml
+++ b/test/src/test/testtool/Authentication/scenario05/Result.xml
@@ -1,1 +1,1 @@
-<result>username: testUser; password:testPassword</result>
+<result>username: ; password:!!not allowed to expand credential of authAlias [secretAlias]!!</result>


### PR DESCRIPTION
in #2191 a feature to expand credentials as properties has been introduced. This PR solves a security issue of that, by only allowing to expand credentials that have their authAlias listed in the system property `authAliases.expansion.allowed`. This property must be configured by an administrator as a -D property, in catalina.properties or as a WebSphere custom property.

Example:
`FixedResultPipe` with `returnString="username: ${credential:username:testAlias}; password:${credential:password:testAlias}"`
yields:
`username: testUser; password:testPassword`
but only when `authAliases.expansion.allowed=testAlias` is specified as custom property
