### PR TITLE
Frank!Doc: Demonstrate that initial field value is not available for attributes

### DIFF
--- a/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/DocletApiTest.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/frankdoc/doclet/DocletApiTest.java
@@ -1,0 +1,49 @@
+package nl.nn.adapterframework.frankdoc.doclet;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import com.sun.javadoc.ClassDoc;
+import com.sun.javadoc.FieldDoc;
+
+public class DocletApiTest {
+	private static ClassDoc fieldOwner;
+
+	@BeforeClass
+	public static void setUp() {
+		ClassDoc[] classes = TestUtil.getClassDocs("nl.nn.adapterframework.javadoc.test");
+		assertEquals(1, classes.length);
+		fieldOwner = classes[0];
+	}
+
+	@Test
+	public void whenFieldIsFinalAndGetsValueImmediatelyThenValueAvailable() {
+		FieldDoc field = getField("finalFieldDirectlyInitialized");
+		assertEquals("finalFieldDirectlyInitialized the value", field.constantValue());
+	}
+
+	@Test
+	public void whenFieldIsFinalAndGetsValueInConstructorThenValueNotAvailable() {
+		FieldDoc field = getField("finalFieldInitializedInConstructor");
+		assertNull(field.constantValue());
+	}
+
+	@Test
+	public void whenFieldIsNotFinalThenValueNotAvailable() {
+		FieldDoc field = getField("nonFinalFieldInitialized");
+		assertNull(field.constantValue());
+	}
+
+	FieldDoc getField(String name) {
+		FieldDoc[] fields = fieldOwner.fields();
+		for(FieldDoc field: fields) {
+			if(field.name().equals(name)) {
+				return field;
+			}
+		}
+		throw new IllegalArgumentException(String.format("Class [%s] does not have field [%s]", fieldOwner.name(), name));
+	}
+}

--- a/frankDoc/src/test/java/nl/nn/adapterframework/javadoc/test/FieldOwner.java
+++ b/frankDoc/src/test/java/nl/nn/adapterframework/javadoc/test/FieldOwner.java
@@ -1,0 +1,11 @@
+package nl.nn.adapterframework.javadoc.test;
+
+public class FieldOwner {
+	public final String finalFieldDirectlyInitialized = "finalFieldDirectlyInitialized the value";
+	public final String finalFieldInitializedInConstructor;
+	public String nonFinalFieldInitialized = "nonFinalFieldInitialized the value";
+
+	public FieldOwner() {
+		finalFieldInitializedInConstructor = "finalFieldInitializedInConstructor the value";
+	}
+}


### PR DESCRIPTION
In Java, you can give an initial value within a field declaration. It would be nice if the Frank!Doc could grab this initial value. Then we would not need to duplicate that value in an ff.default JavaDoc tag. Alas, this is not possible. This PR demonstrates this. If we merge it, we will remember.