### PR TITLE
Exclude activation api dependency from jackson dependency

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -511,6 +511,12 @@
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
 			<artifactId>jackson-jaxrs-json-provider</artifactId>
 			<version>2.13.0</version>
+			<exclusions>
+				<exclusion>
+					<groupId>jakarta.activation</groupId>
+					<artifactId>jakarta.activation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!-- Use our own JaxB and JaxWS implementations to run on the IBM JDK -->


### PR DESCRIPTION
It seems the issue #2372 is back with the jackson dependency upgrade