### PR TITLE
Add generated folders and file to copyrightExcludeFile.txt

### DIFF
--- a/copyrightExcludeFile.txt
+++ b/copyrightExcludeFile.txt
@@ -6,6 +6,10 @@ webapp/
 webapp\
 docker/
 docker\
+.metadata/
+.metadata\
+.idea/
+.idea\
 /apt_generated
 \apt_generated
 MANIFEST.MF
@@ -53,3 +57,4 @@ org.eclipse.
 .bin
 .xquery
 .ldif
+.iml


### PR DESCRIPTION
IntelliJ generates the metadata/idea folders and a .iml file, which cause a copyright error when running it with the frank-runner