### PR TITLE
Use job name instead of hardcoded name

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/scheduler/job/SendMessageJob.java
+++ b/core/src/main/java/nl/nn/adapterframework/scheduler/job/SendMessageJob.java
@@ -48,7 +48,7 @@ public class SendMessageJob extends JobDef {
 		localSender = SpringUtils.createBean(getApplicationContext(), IbisLocalSender.class);
 		localSender.setJavaListener(getJavaListener());
 		localSender.setIsolated(false);
-		localSender.setName("AdapterJob");
+		localSender.setName("Job " + getName());
 		if (getInterval() == 0) {
 			localSender.setDependencyTimeOut(-1);
 		}


### PR DESCRIPTION
Closes #2419 