### PR TITLE
Set AcceptHeuristicHazard in WAS test container

### DIFF
--- a/docker/appserver/WebSphere/src/scripts/configureTransactionService.py
+++ b/docker/appserver/WebSphere/src/scripts/configureTransactionService.py
@@ -1,0 +1,8 @@
+print "Setting TransactionService settings"
+
+transactionService = AdminConfig.list('TransactionService')
+
+# Accept heuristic hazard to allow one phase resources (such as ActiveMQ) to participate in two phase commits
+AdminConfig.modify(transactionService, [['acceptHeuristicHazard', 'true']])
+
+AdminConfig.save()


### PR DESCRIPTION
 This is required to accept a one phase resources in two phase transactions, such as ActiveMQ which does not support XA.