### PR TITLE
Fix ExchangeMailListener problems

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ConnectedFileSystemBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ConnectedFileSystemBase.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2020 WeAreFrank!
+   Copyright 2020, 2022 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -30,7 +30,7 @@ import nl.nn.adapterframework.util.StreamUtil;
 
 /**
  * Baseclass for {@link IBasicFileSystem FileSystems} that use a 'Connection' to connect to their storage.
- * 
+ *
  * @author Gerrit van Brakel
  *
  */
@@ -38,7 +38,7 @@ public abstract class ConnectedFileSystemBase<F,C> extends FileSystemBase<F> {
 
 	// implementations that have a thread-safe connection can set pooledConnection = false to use a shared connection.
 	private @Setter @Getter boolean pooledConnection=true;
-	
+
 	private C globalConnection;
 	private ObjectPool<C> connectionPool;
 
@@ -46,7 +46,7 @@ public abstract class ConnectedFileSystemBase<F,C> extends FileSystemBase<F> {
 	 * Create a fresh connection to the FileSystem.
 	 */
 	protected abstract C createConnection() throws FileSystemException;
-	
+
 	/**
 	 * Close connection to the FileSystem, releasing all resources.
 	 */
@@ -59,18 +59,21 @@ public abstract class ConnectedFileSystemBase<F,C> extends FileSystemBase<F> {
 			}
 		}
 	}
-	
-	
+
+
 	@Override
 	public void open() throws FileSystemException {
 		if (isPooledConnection()) {
 			openPool();
 		} else {
 			globalConnection = createConnection();
+			if (globalConnection==null) {
+				throw new FileSystemException("Cannot create connection");
+			}
 		}
 		super.open();
 	}
-	
+
 	@Override
 	public void close() throws FileSystemException {
 		try {
@@ -85,19 +88,19 @@ public abstract class ConnectedFileSystemBase<F,C> extends FileSystemBase<F> {
 			}
 		}
 	}
-	
+
 
 	/**
 	 * Get a Connection from the pool, or the global shared connection.
 	 */
 	protected C getConnection() throws FileSystemException {
 		try {
-			return isPooledConnection() ? connectionPool.borrowObject() : globalConnection;
+			return isPooledConnection() ? connectionPool!=null ? connectionPool.borrowObject() : null : globalConnection;
 		} catch (Exception e) {
 			throw new FileSystemException("Cannot get connection from pool of "+ClassUtils.nameOf(this), e);
 		}
 	}
-	
+
 	protected void releaseConnection(C connection) {
 		if (isPooledConnection()) {
 			try {
@@ -107,7 +110,7 @@ public abstract class ConnectedFileSystemBase<F,C> extends FileSystemBase<F> {
 			}
 		}
 	}
-	
+
 	/**
 	 * Remove the connection from the pool, e.g. after it has been part of trouble.
 	 * If a shared (non-pooled) connection is invalidated, the shared connection is recreated.
@@ -127,7 +130,7 @@ public abstract class ConnectedFileSystemBase<F,C> extends FileSystemBase<F> {
 			log.warn("Cannot invalidate connection of "+ClassUtils.nameOf(this), e);
 		}
 	}
-	
+
 	/**
 	 * Postpone the release of the connection to after the stream is closed.
 	 * If any IOExceptions on the stream occur, the connection is invalidated.
@@ -156,7 +159,7 @@ public abstract class ConnectedFileSystemBase<F,C> extends FileSystemBase<F> {
 					super.destroyObject(p);
 				}
 
-			}); 
+			});
 		}
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -84,7 +84,7 @@ import nl.nn.adapterframework.xml.SaxElementBuilder;
 
 /**
  * Implementation of a {@link IBasicFileSystem} of an Exchange Mail Inbox.
- * 
+ *
  * To obtain an accessToken:
  * <ol>
  * 	<li>follow the steps in {@link "https://docs.microsoft.com/en-us/exchange/client-developer/exchange-web-services/how-to-authenticate-an-ews-application-by-using-oauth"}</li>
@@ -92,11 +92,11 @@ import nl.nn.adapterframework.xml.SaxElementBuilder;
  *  <li>exchange the Authorization-Code for an accessToken</li>
  *  <li>configure the accessToken directly, or as the password of a JAAS entry referred to by authAlias</li>
  * </ol>
- * 
+ *
  * N.B. MS Exchange is susceptible to problems with invalid XML characters, like &#x3;
- * To work around these problems, a special streaming XMLInputFactory is configured in 
+ * To work around these problems, a special streaming XMLInputFactory is configured in
  * METAINF/services/javax.xml.stream.XMLInputFactory as nl.nn.adapterframework.xml.StaxParserFactory
- * 
+ *
  * @author Peter Leeuwenburgh (as {@link ExchangeMailListener})
  * @author Gerrit van Brakel
  *
@@ -129,7 +129,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			throw new ConfigurationException("either url or mailAddress needs to be specified");
 		}
 	}
-	
+
 	@Override
 	public void open() throws FileSystemException {
 		super.open();
@@ -148,7 +148,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 				basefolderId=findFolder(inboxId,getBaseFolder());
 			} catch (Exception e) {
 				throw new FileSystemException("Could not find baseFolder ["+getBaseFolder()+"] as subfolder of ["+inboxId.getFolderName()+"]", e);
-			}	
+			}
 			if (basefolderId==null) {
 				log.debug("Could not get baseFolder ["+getBaseFolder()+"] as subfolder of ["+inboxId.getFolderName()+"]");
 				basefolderId=findFolder(null,getBaseFolder());
@@ -165,7 +165,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	@Override
 	protected ExchangeService createConnection() throws FileSystemException {
 		ExchangeService exchangeService = new ExchangeService(ExchangeVersion.Exchange2010_SP2);
-		
+
 		String defaultUsername = StringUtils.isEmpty(getAccessToken())? getUsername() : null;
 		String defaultPassword = StringUtils.isEmpty(getAccessToken())? getPassword() : getAccessToken();
 
@@ -180,8 +180,8 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			exchangeService.setCredentials(credentials);
 		}
 
-		
-		
+
+
 		if (StringUtils.isNotEmpty(getProxyHost()) && (StringUtils.isNotEmpty(getProxyAuthAlias()) || StringUtils.isNotEmpty(getProxyUsername()) || StringUtils.isNotEmpty(getProxyPassword()))) {
 			CredentialFactory proxyCf = new CredentialFactory(getProxyAuthAlias(), getProxyUsername(), getProxyPassword());
 			WebProxyCredentials webProxyCredentials = new WebProxyCredentials(proxyCf.getUsername(), proxyCf.getPassword(), getProxyDomain());
@@ -200,7 +200,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 				log.debug("did not validate redirection url ["+redirectionUrl+"]");
 				return super.autodiscoverRedirectionUrlValidationCallback(redirectionUrl);
 			}
-			
+
 		};
 
 		if (StringUtils.isEmpty(getUrl())) {
@@ -222,11 +222,11 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		return exchangeService;
 	}
 
-	
+
 	public FolderId findFolder(String folderName) throws Exception {
 		return findFolder(basefolderId, folderName);
 	}
-	
+
 	public FolderId findFolder(FolderId baseFolderId, String folderName) throws FileSystemException {
 		ExchangeService exchangeService = getConnection();
 		try {
@@ -243,7 +243,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 				if (findFoldersResultsIn.getTotalCount() == 0) {
 					if(log.isDebugEnabled()) log.debug("no folder found with name [" + folderName + "] in basefolder ["+baseFolderId+"]");
 					return null;
-				} 
+				}
 				if (findFoldersResultsIn.getTotalCount() > 1) {
 					if (log.isDebugEnabled()) {
 						for (Folder folder:findFoldersResultsIn.getFolders()) {
@@ -352,10 +352,10 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 
 				@Override
 				public EmailMessage next() {
-					// must cast <Items> to <EmailMessage> separately, cannot cast Iterator<Item> to Iterator<EmailMessage> 
+					// must cast <Items> to <EmailMessage> separately, cannot cast Iterator<Item> to Iterator<EmailMessage>
 					return (EmailMessage)itemIterator.next();
 				}
-				
+
 			}, (Runnable)() -> { releaseConnection(exchangeService); });
 		} catch (Exception e) {
 			invalidateConnection(exchangeService);
@@ -363,7 +363,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		}
 	}
 
-	
+
 	@Override
 	public boolean folderExists(String folder) throws FileSystemException {
 		FolderId folderId;
@@ -375,11 +375,11 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		return folderId!=null;
 	}
 
-	
+
 	@Override
 	public Message readFile(EmailMessage f, String charset) throws FileSystemException, IOException {
 		EmailMessage emailMessage;
-		
+
 		ExchangeService exchangeService = getConnection();
 		try {
 			if (f.getId()!=null) {
@@ -409,7 +409,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			throw new FileSystemException(e);
 		}
 	}
-	
+
 	@Override
 	public void deleteFile(EmailMessage f) throws FileSystemException {
 		 try {
@@ -478,8 +478,8 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			throw new FileSystemException("Could not determine modification time",e);
 		}
 	}
-	
-	
+
+
 	private String cleanAddress(EmailAddress address) {
 		String personal = address.getName();
 		String email = address.getAddress();
@@ -491,15 +491,15 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		}
 		return iaddress.toUnicodeString();
 	}
-	
+
 	private List<String> asList(EmailAddressCollection addressCollection) {
 		if (addressCollection==null) {
 			return Collections.emptyList();
 		}
 		return addressCollection.getItems().stream().map(this::cleanAddress).collect(Collectors.toList());
 	}
-	
-	
+
+
 	@Override
 	public Map<String, Object> getAdditionalFileProperties(EmailMessage f) throws FileSystemException {
 		EmailMessage emailMessage;
@@ -515,11 +515,11 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			result.put(IMailFileSystem.TO_RECEPIENTS_KEY, asList(emailMessage.getToRecipients()));
 			result.put(IMailFileSystem.CC_RECEPIENTS_KEY, asList(emailMessage.getCcRecipients()));
 			result.put(IMailFileSystem.BCC_RECEPIENTS_KEY, asList(emailMessage.getBccRecipients()));
-			result.put(IMailFileSystem.FROM_ADDRESS_KEY, getFrom(emailMessage)); 
-			result.put(IMailFileSystem.SENDER_ADDRESS_KEY, getSender(emailMessage)); 
-			result.put(IMailFileSystem.REPLY_TO_RECEPIENTS_KEY, getReplyTo(emailMessage)); 
-			result.put(IMailFileSystem.DATETIME_SENT_KEY, getDateTimeSent(emailMessage)); 
-			result.put(IMailFileSystem.DATETIME_RECEIVED_KEY, getDateTimeReceived(emailMessage)); 
+			result.put(IMailFileSystem.FROM_ADDRESS_KEY, getFrom(emailMessage));
+			result.put(IMailFileSystem.SENDER_ADDRESS_KEY, getSender(emailMessage));
+			result.put(IMailFileSystem.REPLY_TO_RECEPIENTS_KEY, getReplyTo(emailMessage));
+			result.put(IMailFileSystem.DATETIME_SENT_KEY, getDateTimeSent(emailMessage));
+			result.put(IMailFileSystem.DATETIME_RECEIVED_KEY, getDateTimeReceived(emailMessage));
 			try {
 				InternetMessageHeaderCollection internetMessageHeaders = emailMessage.getInternetMessageHeaders();
 				if (internetMessageHeaders!=null) {
@@ -552,14 +552,14 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		}
 	}
 
-	
+
 	@Override
 	public void forwardMail(EmailMessage emailMessage, String destination) throws FileSystemException {
 		try {
 			ResponseMessage forward = emailMessage.createForward();
 			forward.getToRecipients().clear();
 			forward.getToRecipients().add(destination);
-			
+
 //			if(forwardMessage != null){
 //				forward.setBodyPrefix(MessageBody.getMessageBodyFromText(forwardMessage));
 //			}
@@ -678,8 +678,8 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		return result;
 	}
 
-	
-	
+
+
 	public FolderId getFolderIdByFolderName(ExchangeService exchangeService, String folderName, boolean create) throws Exception{
 		FindFoldersResults findResults;
 		findResults = exchangeService.findFolders(basefolderId, new SearchFilter.IsEqualTo(FolderSchema.DisplayName, folderName), new FolderView(Integer.MAX_VALUE));
@@ -732,7 +732,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		}
 	}
 
-	
+
 	protected String getFrom(EmailMessage emailMessage) throws FileSystemException {
 		try {
 			return cleanAddress(emailMessage.getFrom());
@@ -741,7 +741,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			return null;
 		}
 	}
-	
+
 	protected String getSender(EmailMessage emailMessage) throws FileSystemException {
 		try {
 			EmailAddress sender = emailMessage.getSender();
@@ -760,7 +760,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			return null;
 		}
 	}
-	
+
 	protected Date getDateTimeSent(EmailMessage emailMessage) throws FileSystemException {
 		try {
 			return emailMessage.getDateTimeSent();
@@ -769,7 +769,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			return null;
 		}
 	}
-	
+
 	protected Date getDateTimeReceived(EmailMessage emailMessage) throws FileSystemException {
 		try {
 			return emailMessage.getDateTimeReceived();
@@ -778,7 +778,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			return null;
 		}
 	}
-	
+
 	@Override
 	public String getSubject(EmailMessage emailMessage) throws FileSystemException {
 		try {
@@ -787,7 +787,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			throw new FileSystemException("Could not get Subject", e);
 		}
 	}
-	
+
 
 	@Override
 	public Message getMimeContent(EmailMessage emailMessage) throws FileSystemException {
@@ -798,15 +798,15 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		} catch (Exception e) {
 			throw new FileSystemException("Could not get MimeContent", e);
 		}
-		
+
 	}
-	
+
 	@Override
 	public void extractEmail(EmailMessage emailMessage, SaxElementBuilder emailXml) throws FileSystemException {
 		try {
 			if (emailMessage.getId()!=null) {
-				PropertySet ps = new PropertySet(EmailMessageSchema.DateTimeSent, EmailMessageSchema.DateTimeReceived, EmailMessageSchema.From, 
-						EmailMessageSchema.ToRecipients, EmailMessageSchema.CcRecipients, EmailMessageSchema.BccRecipients, EmailMessageSchema.Subject, 
+				PropertySet ps = new PropertySet(EmailMessageSchema.DateTimeSent, EmailMessageSchema.DateTimeReceived, EmailMessageSchema.From,
+						EmailMessageSchema.ToRecipients, EmailMessageSchema.CcRecipients, EmailMessageSchema.BccRecipients, EmailMessageSchema.Subject,
 						EmailMessageSchema.Body, EmailMessageSchema.Attachments);
 				emailMessage.load(ps);
 			}
@@ -825,7 +825,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			throw new FileSystemException(e);
 		}
 	}
-	
+
 
 
 	@Override
@@ -849,7 +849,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 
 
 	private static class RedirectionUrlCallback implements IAutodiscoverRedirectionUrl {
-		
+
 		@Override
 		public boolean autodiscoverRedirectionUrlValidationCallback(String redirectionUrl) {
 			return redirectionUrl.toLowerCase().startsWith("https://"); //TODO: provide better test on how to trust this url
@@ -888,8 +888,8 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		return accessToken;
 	}
 
-	@IbisDoc({"5", "Alias used to obtain accessToken or username and password for authentication to Exchange mail server. " + 
-			"If the alias refers to a combination of a username and a password, the deprecated Basic Authentication method is used. " + 
+	@IbisDoc({"5", "Alias used to obtain accessToken or username and password for authentication to Exchange mail server. " +
+			"If the alias refers to a combination of a username and a password, the deprecated Basic Authentication method is used. " +
 			"If the alias refers to a password without a username, the password is treated as the accessToken.", ""})
 	@Override
 	public void setAuthAlias(String authAlias) {
@@ -970,5 +970,5 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	public String getProxyDomain() {
 		return proxyDomain;
 	}
-	
+
 }

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -782,8 +782,9 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	@Override
 	public String getSubject(EmailMessage emailMessage) throws FileSystemException {
 		try {
+			emailMessage.load(new PropertySet(ItemSchema.Subject));
 			return emailMessage.getSubject();
-		} catch (ServiceLocalException e) {
+		} catch (Exception e) {
 			throw new FileSystemException("Could not get Subject", e);
 		}
 	}
@@ -798,7 +799,6 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		} catch (Exception e) {
 			throw new FileSystemException("Could not get MimeContent", e);
 		}
-
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ImapFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ImapFileSystem.java
@@ -127,7 +127,7 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 		}
 	}
 
-	private IMAPFolder getFolder(IMAPFolder baseFolder, String name) throws MessagingException, FileSystemException {
+	private IMAPFolder getFolder(IMAPFolder baseFolder, String name) throws MessagingException {
 		if (StringUtils.isNotEmpty(name)) {
 			return (IMAPFolder)baseFolder.getFolder(name);
 		}
@@ -165,12 +165,12 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 			if (!folder.isOpen()) {
 				folder.open(Folder.READ_WRITE);
 			}
-			return folder.getMessageByUID(nameToUid(filename));
+			Message result = folder.getMessageByUID(nameToUid(filename));
+			releaseConnection(baseFolder);
+			return result;
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 
@@ -190,12 +190,12 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 		IMAPFolder baseFolder = getConnection();
 		try {
 			IMAPFolder folder = getFolder(baseFolder, foldername);
-			return folder.exists();
+			boolean result = folder.exists();
+			releaseConnection(baseFolder);
+			return result;
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 
@@ -208,12 +208,11 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 				folder.open(Folder.READ_WRITE);
 			}
 			Message messages[] = folder.getMessages();
+			releaseConnection(baseFolder);
 			return messages.length;
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 
@@ -229,12 +228,11 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 				folder.open(Folder.READ_WRITE);
 			}
 			Message messages[] = folder.getMessages();
+			releaseConnection(baseFolder);
 			return FileSystemUtils.getDirectoryStream(Arrays.asList(messages));
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 
@@ -265,12 +263,12 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 			}
 			IMAPFolder destination = getFolder(baseFolder, destinationFolder);
 			destination.open(Folder.READ_WRITE);
-			return destination.getMessageByUID(results[0].uid);
+			Message result = destination.getMessageByUID(results[0].uid);
+			releaseConnection(baseFolder);
+			return result;
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 
@@ -292,12 +290,12 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 			}
 			IMAPFolder destination = getFolder(baseFolder, destinationFolder);
 			destination.open(Folder.READ_WRITE);
-			return destination.getMessageByUID(results[0].uid);
+			Message result = destination.getMessageByUID(results[0].uid);
+			releaseConnection(baseFolder);
+			return result;
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 
@@ -307,13 +305,13 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 		try {
 			IMAPFolder folder = getFolder(baseFolder, folderName);
 			if (!folder.create(Folder.HOLDS_FOLDERS + Folder.HOLDS_MESSAGES)) {
+				invalidateConnection(baseFolder);
 				throw new FileSystemException("Could not create folder [" + folderName + "]");
 			}
+			releaseConnection(baseFolder);
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 
@@ -323,16 +321,17 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 		try {
 			IMAPFolder folder = getFolder(baseFolder, folderName);
 			if (folder == null) {
+				invalidateConnection(baseFolder);
 				throw new FileSystemException("Could not find folder object [" + folderName + "]");
 			}
 			if (!folder.delete(removeNonEmptyFolder)) {
+				invalidateConnection(baseFolder);
 				throw new FileSystemException("Could not delete folder [" + folderName + "]");
 			}
+			releaseConnection(baseFolder);
 		} catch (MessagingException e) {
 			invalidateConnection(baseFolder);
 			throw new FileSystemException(e);
-		} finally {
-			releaseConnection(baseFolder);
 		}
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ImapFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ImapFileSystem.java
@@ -67,10 +67,10 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 
 	private @Getter String host;
 	private @Getter int port = 993;
-	
+
 	private Session emailSession = Session.getInstance(System.getProperties());
 
-	
+
 	@Override
 	public void configure() throws ConfigurationException {
 		if (StringUtils.isEmpty(getHost())) {
@@ -85,8 +85,14 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 			// emailSession.setDebug(true);
 			CredentialFactory cf = new CredentialFactory(getAuthAlias(), getUsername(), getPassword());
 			Store store = emailSession.getStore("imaps");
-			store.connect(getHost(), getPort(), cf.getUsername(), cf.getPassword());
-
+			try {
+				store.connect(getHost(), getPort(), cf.getUsername(), cf.getPassword());
+			} catch (Exception e) {
+				throw new FileSystemException("Cannot connect to Store at host ["+getHost()+"] port ["+getPort()+"] user ["+cf.getUsername()+"]", e);
+			}
+			if (!store.isConnected()) {
+				throw new FileSystemException("Cannot connect to Store at host ["+getHost()+"] port ["+getPort()+"] user ["+cf.getUsername()+"]");
+			}
 			IMAPFolder inbox = (IMAPFolder)store.getFolder("INBOX");
 			IMAPFolder folder;
 			String baseFolder = getBaseFolder();
@@ -100,6 +106,9 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 				}
 			} else {
 				folder = inbox;
+				if (!folder.exists()) {
+					throw new FileSystemException("Could not find baseFolder ["+folder+"]");
+				}
 			}
 			return folder;
 		} catch (MessagingException e) {
@@ -211,6 +220,9 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 	@Override
 	public DirectoryStream<Message> listFiles(String foldername) throws FileSystemException {
 		IMAPFolder baseFolder = getConnection();
+		if (baseFolder==null) {
+			return null;
+		}
 		try {
 			IMAPFolder folder = getFolder(baseFolder, foldername);
 			if (!folder.isOpen()) {
@@ -587,7 +599,7 @@ public class ImapFileSystem extends MailFileSystemBase<Message, MimeBodyPart, IM
 	}
 
 	private class MimeContentMessage extends nl.nn.adapterframework.stream.Message {
-		
+
 		public MimeContentMessage(IMAPMessage imapMessage) {
 			super(() -> imapMessage.getMimeStream(), null, imapMessage.getClass());
 		}

--- a/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
@@ -440,13 +440,12 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IR
 			if (timeoutGuard.cancel()) {
 				throw new TimeoutException("timeout exceeded while starting receiver");
 			}
-
-			throwEvent(RCV_STARTED_RUNNING_MONITOR_EVENT);
-			if (getListener() instanceof IPullingListener){
-				// start all threads. Also sets runstate=STARTED 
-				listenerContainer.start();
-			}
 		}
+		if (getListener() instanceof IPullingListener){
+			// start all threads. Also sets runstate=STARTED 
+			listenerContainer.start();
+		}
+		throwEvent(RCV_STARTED_RUNNING_MONITOR_EVENT);
 	}
 
 	/**

--- a/test/src/main/configurations/MainConfig/ConfigurationExchangeMail.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationExchangeMail.xml
@@ -14,7 +14,8 @@
 				processedFolder="${exchangemail.processedFolder}"
 				errorFolder="${exchangemail.errorFolder}"
 				createFolders="true"
-				disableFolderBrowsers="${exchangemail.disableFolderBrowsers}"
+				disableMessageBrowsers="${exchangemail.disableMessageBrowsers}"
+				messageType="contents"
 			/>
 		</receiver>
 		<receiver name="ImapMail" active="${imapmail.active}">
@@ -31,7 +32,8 @@
 				processedFolder="${imapmail.processedFolder}"
 				errorFolder="${imapmail.errorFolder}"
 				createFolders="true"
-				disableFolderBrowsers="${imapmail.disableFolderBrowsers}"
+				disableMessageBrowsers="${imapmail.disableMessageBrowsers}"
+				messageType="contents"
 			/>
 		</receiver>
 		<pipeline>


### PR DESCRIPTION
- do not release connection if it has been invalidated
- load properties required for MessageContext
- pass loaded message to MessageContext generator
- do not start listenerContainer if an exception occurred