### PR TITLE
Fix test adapter names and ensure only bound to address when provided

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@ Upcoming (7.8)
 ### Non backwards compatible changes
 
 - HttpSender no longer treats input message as parameters by default. For 7.7 compatibility, set attribute treatInputMessageAsParameters=true
+- WebServiceListener does no longer (simultaneously) bind to the listener-name AND address attribute.
 
 
 7.7

--- a/core/src/main/java/nl/nn/adapterframework/http/WebServiceListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/WebServiceListener.java
@@ -102,6 +102,10 @@ public class WebServiceListener extends PushingListenerAdapter implements HasPhy
 			String msg = "calling webservices via de ServiceDispatcher_ServiceProxy is deprecated. Please specify an address or serviceNamespaceURI and modify the call accordingly";
 			ConfigurationWarnings.add(this, log, msg, SuppressKeys.DEPRECATION_SUPPRESS_KEY, null);
 		}
+		if (StringUtils.isNotEmpty(getServiceNamespaceURI()) && StringUtils.isNotEmpty(getAddress())) {
+			String msg = "Please specify either an address or serviceNamespaceURI but not both";
+			ConfigurationWarnings.add(this, log, msg);
+		}
 
 		Bus bus = getApplicationContext().getBean("cxf", Bus.class);
 		if(bus instanceof SpringBus) {
@@ -126,16 +130,15 @@ public class WebServiceListener extends PushingListenerAdapter implements HasPhy
 			} else {
 				log.error("unable to publish listener ["+getName()+"] on CXF endpoint ["+getAddress()+"]");
 			}
-		}
-
-		//Can bind on multiple endpoints
-		if (StringUtils.isNotEmpty(getServiceNamespaceURI())) {
-			log.debug("registering listener ["+getName()+"] with ServiceDispatcher by serviceNamespaceURI ["+getServiceNamespaceURI()+"]");
-			ServiceDispatcher.getInstance().registerServiceClient(getServiceNamespaceURI(), this);
-		}
-		else {
-			log.debug("registering listener ["+getName()+"] with ServiceDispatcher");
-			ServiceDispatcher.getInstance().registerServiceClient(getName(), this); //Backwards compatibility
+		} else {
+			if (StringUtils.isNotEmpty(getServiceNamespaceURI())) {
+				log.debug("registering listener ["+getName()+"] with ServiceDispatcher by serviceNamespaceURI ["+getServiceNamespaceURI()+"]");
+				ServiceDispatcher.getInstance().registerServiceClient(getServiceNamespaceURI(), this);
+			}
+			else {
+				log.debug("registering listener ["+getName()+"] with ServiceDispatcher");
+				ServiceDispatcher.getInstance().registerServiceClient(getName(), this); //Backwards compatibility
+			}
 		}
 
 		super.open();

--- a/core/src/main/java/nl/nn/adapterframework/receivers/ServiceDispatcher.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/ServiceDispatcher.java
@@ -91,9 +91,9 @@ public class ServiceDispatcher  {
 	 */
 	public Iterator<String> getRegisteredListenerNames() {
 		SortedSet<String> sortedKeys = new TreeSet<String>(registeredListeners.keySet());
-		return sortedKeys.iterator(); 
+		return sortedKeys.iterator();
 	}
-	
+
 	/**
 	 * Check whether a serviceName is registered at the <code>ServiceDispatcher</code>.
 	 * @return true if the service is registered at this dispatcher, otherwise false

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAddress.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAddress.xml
@@ -1,5 +1,5 @@
 <module>
-    <!-- serviceNamespaceURI listeners -->
+    <!-- WebServiceListeners with address -->
 	<adapter name="WebServiceListenerAddress" 
 		description="Test the functioning of the WebServiceListener with the attribute address">
 		<receiver>

--- a/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
+++ b/test/src/main/configurations/HTTP/ConfigurationWebServiceListenerSenderAttachments.xml
@@ -1,26 +1,23 @@
 <module>
 	<!-- Receiving Listeners -->
 	<adapter name="WebServiceListenerAddressAttachments"
-		description="Test the functioning of the WebServiceListener with the attribute Address receiving attachments">
-		<receiver name="WebServiceListenerTimeoutAddress">
-			<listener className="nl.nn.adapterframework.http.WebServiceListener"
-				address="urn/ws/address/attachments" />
+		description="Test the functioning of the WebServiceListener with the attribute [address] and receiving attachments">
+		<receiver name="WebServiceListener-address-with-attachments">
+			<listener className="nl.nn.adapterframework.http.WebServiceListener" address="urn/ws/address/attachments" />
 		</receiver>
 		<pipeline firstPipe="EchoPipe">
 			<exits>
 				<exit path="EXIT" state="success" />
 			</exits>
-			<pipe className="nl.nn.adapterframework.pipes.EchoPipe" name="EchoPipe"
-				getInputFromSessionKey="attachment1">
+			<pipe className="nl.nn.adapterframework.pipes.EchoPipe" name="EchoPipe" getInputFromSessionKey="attachment1">
 				<forward name="success" path="EXIT"/>
 			</pipe>
 		</pipeline>
 	</adapter>
 	<adapter name="WebServiceListenerAddressAttachmentsMultipartSessionKey"
-		description="Test the functioning of the WebServiceListener with the attribute Address receiving attachments using multipart sessionkey">
-		<receiver name="WebServiceListenerTimeoutAddressMultipartSessionKey">
-			<listener className="nl.nn.adapterframework.http.WebServiceListener"
-				address="urn/ws/address/attachments/multipart" />
+		description="Test the functioning of the WebServiceListener with the attribute [address] and receiving attachments using multipart sessionkey">
+		<receiver name="WebServiceListener-address-with-MultipartXmlSessionKey">
+			<listener className="nl.nn.adapterframework.http.WebServiceListener" address="urn/ws/address/attachments/multipart" />
 		</receiver>
 		<pipeline firstPipe="MergeAttachments">
 			<exits>
@@ -35,13 +32,12 @@
 			</pipe>
 		</pipeline>
 	</adapter>
-	
+
 	<!-- Returning Listeners -->
 	<adapter name="WebServiceListenerAddressAttachmentsReturnAttachments"
-		description="Test the functioning of the WebServiceListener with the attribute Address returning attachments">
-		<receiver name="WebServiceListenerTimeoutAddress">
-			<listener className="nl.nn.adapterframework.http.WebServiceListener"
-				address="urn/ws/address/attachments/returning" attachmentSessionKeys="attachment1"/>
+		description="Test the functioning of the WebServiceListener with the attribute [address] and returning attachments">
+		<receiver name="WebServiceListener-address-with-attachments">
+			<listener className="nl.nn.adapterframework.http.WebServiceListener" address="urn/ws/address/attachments/returning" attachmentSessionKeys="attachment1"/>
 		</receiver>
 		<pipeline firstPipe="EchoMessage">
 			<exits>
@@ -55,17 +51,16 @@
 				filename="${testdata.dir}/webservices/filetext.txt" storeResultInSessionKey="attachment1" 
 				preserveInput="true"
 				>
-				
+
 				<forward name="success" path="EXIT"/>
 			</pipe>
-
 		</pipeline>
 	</adapter>
+
 	<adapter name="WebServiceListenerAddressAttachmentsReturnAttachmentsSessionKey"
-		description="Test the functioning of the WebServiceListener with the attribute Address returning attachments">
-		<receiver name="WebServiceListenerTimeoutAddress">
-			<listener className="nl.nn.adapterframework.http.WebServiceListener"
-				address="urn/ws/address/attachments/returning/sessionkey"/>
+		description="Test the functioning of the WebServiceListener with the attribute [address] and returning attachments from session MultipartXml">
+		<receiver name="WebServiceListener-address-with-MultipartXml-attachments">
+			<listener className="nl.nn.adapterframework.http.WebServiceListener" address="urn/ws/address/attachments/returning/sessionkey"/>
 		</receiver>
 		<pipeline firstPipe="EchoMessage">
 			<exits>
@@ -93,9 +88,8 @@
 	<!-- Sending Senders -->
 	<adapter name="WebServiceSenderAddressAttachmentsWithParam" 
 		description="Test the functioning of the WebServiceSender sending attachments to a listener with address">
-		<receiver name="WebServiceSenderAddress">
-			<listener className="nl.nn.adapterframework.receivers.JavaListener"
-				serviceName="ibis4test-WebServiceSenderAddressAttachmentsWithParam" />
+		<receiver name="WebServiceSender-address">
+			<listener className="nl.nn.adapterframework.receivers.JavaListener" serviceName="ibis4test-WebServiceSenderAddressAttachmentsWithParam" />
 		</receiver>
 		<pipeline firstPipe="Send2WS">
 			<exits>
@@ -118,7 +112,7 @@
 	</adapter>
     <adapter name="WebServiceSenderAddressAttachments" 
 		description="Test the functioning of the WebServiceSender sending attachments to a listener with address">
-		<receiver name="WebServiceSenderAddress">
+		<receiver name="WebServiceSender-address-send-attachments">
 			<listener className="nl.nn.adapterframework.receivers.JavaListener"
 				serviceName="ibis4test-WebServiceSenderAddressAttachmentsMultipart" />
 		</receiver>
@@ -161,7 +155,7 @@
 	<!-- Receiving Senders -->
 	<adapter name="WebServiceSenderAddressAttachmentsReturningAttachments" 
 		description="Test the functioning of the WebServiceSender receiving attachments from a listener with address">
-		<receiver name="WebServiceSenderAddress">
+		<receiver name="WebServiceSender-address-receive-attachments">
 			<listener className="nl.nn.adapterframework.receivers.JavaListener"
 				serviceName="ibis4test-WebServiceSenderAddressAttachmentsReturning" />
 		</receiver>
@@ -195,7 +189,7 @@
 	</adapter>
 	<adapter name="WebServiceSenderAddressAttachmentsReturningAttachmentsSessionKey" 
 		description="Test the functioning of the WebServiceSender receiving attachments from a listener with address and multipartXml sessionkey">
-		<receiver name="WebServiceSenderAddress">
+		<receiver name="WebServiceSender-address-receive-attachment-in-session">
 			<listener className="nl.nn.adapterframework.receivers.JavaListener"
 				serviceName="ibis4test-WebServiceSenderAddressAttachmentsReturningSessionKey" />
 		</receiver>


### PR DESCRIPTION
The WebServiceListener used to bind to both the listeners name (which is determined based on the receiver name) AND the ` address` attribute. 