### PR TITLE
Allow using another version of the frank-doc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,8 @@
 		<jboss-logging.version>3.4.2.Final</jboss-logging.version>
 		<argLine /> <!-- add empty default argLine so Surefire won't fail when JaCoCo isn't present -->
 		<!-- property [iaf.rootdir] is available to get the root of the project, because of the [directory-maven-plugin] -->
+		<!-- Override this property to use another version of the Frank!Doc -->
+		<frankdoc.version>1.1-SNAPSHOT</frankdoc.version>
 	</properties>
 
 	<name>Ibis AdapterFramework parent</name>
@@ -861,7 +863,7 @@
 							<docletArtifact>
 								<groupId>org.ibissource</groupId>
 								<artifactId>frank-doc</artifactId>
-								<version>1.1-SNAPSHOT</version>
+								<version>${frankdoc.version}</version>
 							</docletArtifact>
 							<additionalOptions>
 								<additionalOption>-outputDirectory</additionalOption>


### PR DESCRIPTION
This is useful for the CI/CD of the Frank!Doc. The Frank!Doc CI/CD verifies whether it can process the files of the F!F. With this change, the Frank!Doc CI/CD will enforce that the build of the F!F uses the desired version of this doclet.