### PR TITLE
Throw exception when file to read does not exist in fileSystems (7.7)

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemActor.java
@@ -336,6 +336,9 @@ public class FileSystemActor<F, FS extends IBasicFileSystem<F>> implements IOutp
 				}
 				case READ: {
 					F file=getFile(input, pvl);
+					if(!fileSystem.exists(file)) {
+						throw new FileSystemException("File to read does not exist.");
+					}
 					Message in = fileSystem.readFile(file, getCharset());
 					if (getBase64()!=null) {
 						return new Base64InputStream(in.asInputStream(), getBase64()==Base64Pipe.Direction.ENCODE);

--- a/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemActorTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/filesystem/FileSystemActorTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -533,6 +534,20 @@ public abstract class FileSystemActorTest<F, FS extends IWritableFileSystem<F>> 
 		Message result = Message.asMessage(actor.doAction(message, pvl, session));
 		assertEquals(contents, result.asString());
 		assertEquals(fileShouldStillExistAfterwards, _fileExists(filename));
+	}
+
+	@Test
+	public void fileSystemActorReadActionNonExistingFileTest() throws Exception {
+		String filename = "nonExistingfile";
+
+		actor.setAction(FileSystemAction.READ);
+		actor.configure(fileSystem,null,owner);
+		actor.open();
+
+		Message message= new Message(filename);
+		ParameterValueList pvl = null;
+
+		assertThrows(FileSystemException.class, () -> actor.doAction(message, pvl, session));
 	}
 
 	@Test


### PR DESCRIPTION
Closes #3266 