### PR TITLE
Add explicit javax.activation:1.1.1 dependency

### DIFF
--- a/aspose/pom.xml
+++ b/aspose/pom.xml
@@ -189,6 +189,10 @@
 					<groupId>xerces</groupId>
 					<artifactId>xercesImpl</artifactId>
 				</exclusion>
+				<exclusion>
+					<groupId>jakarta.activation</groupId>
+					<artifactId>jakarta.activation-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 

--- a/aspose/pom.xml
+++ b/aspose/pom.xml
@@ -189,7 +189,7 @@
 					<groupId>xerces</groupId>
 					<artifactId>xercesImpl</artifactId>
 				</exclusion>
-				<exclusion>
+				<exclusion><!-- excluded because we want to ignore this (1.2.2) version! this dependency handles javax.activation.* imports, and is NOT compatible with the IBM JRE -->
 					<groupId>jakarta.activation</groupId>
 					<artifactId>jakarta.activation-api</artifactId>
 				</exclusion>

--- a/cmis/pom.xml
+++ b/cmis/pom.xml
@@ -56,6 +56,12 @@
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-frontend-jaxws</artifactId>
 			<version>${cxf.version}</version>
+			<exclusions>
+				<exclusion><!-- excluded because we want to ignore this (1.2.2) version! this dependency handles javax.activation.* imports, and is NOT compatible with the IBM JRE -->
+					<groupId>jakarta.activation</groupId>
+					<artifactId>jakarta.activation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>

--- a/cmis/pom.xml
+++ b/cmis/pom.xml
@@ -67,12 +67,6 @@
 			<artifactId>cxf-rt-ws-policy</artifactId>
 			<version>${cxf.version}</version>
 		</dependency>
-		<dependency>
-			<groupId>jakarta.activation</groupId>
-			<artifactId>jakarta.activation-api</artifactId>
-			<version>2.1.0</version>
-			<scope>test</scope>
-		</dependency>
 
 		<dependency>
 			<groupId>org.ibissource</groupId>

--- a/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/TestBindingTypes.java
+++ b/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/TestBindingTypes.java
@@ -3,7 +3,6 @@ package nl.nn.adapterframework.extensions.cmis;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -15,10 +14,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
-import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.PipeLineSession;
-import nl.nn.adapterframework.core.SenderException;
-import nl.nn.adapterframework.core.TimeoutException;
 import nl.nn.adapterframework.stream.Message;
 import nl.nn.adapterframework.testutil.TestAssertions;
 
@@ -111,14 +107,15 @@ public class TestBindingTypes extends CmisSenderTestBase {
 	}
 
 	@Test
-	public void configure() throws ConfigurationException {
+	public void configure() throws Exception {
 		sender.setBindingType(bindingType);
 		sender.setAction(action);
 		sender.configure();
+		sender.open();
 	}
 
 	@Test
-	public void sendMessage() throws ConfigurationException, SenderException, TimeoutException, IOException {
+	public void sendMessage() throws Exception {
 
 		if(action.equals("get")) {
 			sender.setFileContentSessionKey("");
@@ -132,7 +129,7 @@ public class TestBindingTypes extends CmisSenderTestBase {
 	}
 
 	@Test
-	public void sendMessageWithContentStream() throws ConfigurationException, SenderException, TimeoutException, IOException {
+	public void sendMessageWithContentStream() throws Exception {
 		if(!action.equals("get")) return;
 
 		configure();

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -92,6 +92,13 @@
 			<version>${micrometer.version}</version>
 		</dependency>
 
+		<!-- explicit dependency to force version 1.1.1 -->
+		<dependency>
+			<groupId>javax.activation</groupId>
+			<artifactId>activation</artifactId>
+			<version>1.1.1</version>
+		</dependency>
+
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>
 			<artifactId>geronimo-jms_1.1_spec</artifactId>
@@ -103,6 +110,7 @@
 			<version>1.3</version>
 			<scope>provided</scope>
 		</dependency>
+
 		<dependency>
 			<!-- to be able to extract Oracle error messages in IbisException.getExceptionSpecificDetails() -->
 			<groupId>com.oracle.database.jdbc</groupId>
@@ -113,12 +121,6 @@
 		<dependency>
 			<groupId>com.sun.mail</groupId>
 			<artifactId>javax.mail</artifactId>
-			<exclusions>
-				<exclusion> <!-- conflicts with the javax.activation package from jdk see https://github.com/ibissource/iaf/issues/2372 -->
-					<groupId>javax.activation</groupId>
-					<artifactId>activation</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>javax.xml</groupId>
@@ -619,7 +621,7 @@
 		<dependency>
 			<groupId>javax.xml.ws</groupId>
 			<artifactId>jaxws-api</artifactId>
-			<version>2.3.0</version> <!-- 2.3.1 contains javax.activation package that conflicts with the jdk javax.activation package. -->
+			<version>2.3.0</version> <!-- 2.3.1 contains javax.activation 1.2.0 that conflicts with the jdk javax.activation (1.1.1) package. -->
 		</dependency>
 
 		<!--
@@ -634,10 +636,6 @@
 				<exclusion>
 					<groupId>javax.xml.stream</groupId>
 					<artifactId>stax-api</artifactId>
-				</exclusion>
-				<exclusion> <!-- conflicts with the javax.activation package from jdk see https://github.com/ibissource/iaf/issues/2372 -->
-					<groupId>javax.activation</groupId>
-					<artifactId>activation</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -93,11 +93,17 @@
 		</dependency>
 
 		<!-- explicit dependency to force version 1.1.1 -->
-		<dependency>
+		<dependency><!-- this dependency handles javax.activation.* imports, compatible with the IBM JRE -->
 			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
 			<version>1.1.1</version>
 		</dependency>
+		<dependency><!-- this dependency handles jakarta.activation.* imports -->
+			<groupId>com.sun.activation</groupId>
+			<artifactId>jakarta.activation</artifactId>
+			<version>2.0.1</version>
+		</dependency>
+
 
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>
@@ -313,6 +319,10 @@
 				<exclusion>
 					<groupId>org.apache.geronimo.javamail</groupId>
 					<artifactId>geronimo-javamail_1.4_mail</artifactId>
+				</exclusion>
+				<exclusion><!-- excluded because we want to ignore this (1.2.2) version! this dependency handles javax.activation.* imports, and is NOT compatible with the IBM JRE -->
+					<groupId>jakarta.activation</groupId>
+					<artifactId>jakarta.activation-api</artifactId>
 				</exclusion>
 			</exclusions>
 		</dependency>
@@ -558,6 +568,10 @@
 					<groupId>org.apache.geronimo.specs</groupId>
 					<artifactId>geronimo-jta_1.1_spec</artifactId>
 				</exclusion>
+				<exclusion><!-- excluded because we want to ignore this (1.2.2) version! this dependency handles javax.activation.* imports, and is NOT compatible with the IBM JRE -->
+					<groupId>jakarta.activation</groupId>
+					<artifactId>jakarta.activation-api</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -688,6 +702,12 @@
 			<groupId>org.apache.tika</groupId>
 			<artifactId>tika-core</artifactId>
 			<version>1.28.3</version>
+			<exclusions>
+				<exclusion><!-- excluded because we want to ignore this (1.2.2) version! this dependency handles javax.activation.* imports, and is NOT compatible with the IBM JRE -->
+					<groupId>jakarta.activation</groupId>
+					<artifactId>jakarta.activation-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<!-- explicitly defined because of dependency inheritance -->
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,39 @@
 				<artifactId>glassfish-copyright-maven-plugin</artifactId>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-enforcer-plugin</artifactId>
+				<version>3.1.0</version>
+				<executions>
+					<execution>
+						<id>enforce-lib-ban</id>
+						<goals>
+							<goal>enforce</goal>
+						</goals>
+						<configuration>
+							<rules>
+								<bannedDependencies>
+									<!-- the activation framework was renamed to the jarkata activation framework -->
+									<excludes>
+										<exclude>javax.activation:javax.activation-api</exclude>
+										<exclude>com.sun.activation:javax.activation</exclude>
+								<!-- 	<exclude>javax.activation:activation</exclude> -->
+									</excludes>
+									<message>use com.sun.activation:jakarta.activation instead of jakarta.activation:jakarta.activation-api</message>
+								</bannedDependencies>
+								<bannedDependencies>
+									<!-- the implementation com.sun.activation:jakarta.activation contains the api classes too -->
+									<excludes>
+										<exclude>jakarta.activation:jakarta.activation-api</exclude>
+									</excludes>
+									<message>the implementation com.sun.activation:jakarta.activation is included and it contains the api classes too</message>
+								</bannedDependencies>
+							</rules>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<artifactId>maven-surefire-plugin</artifactId>
 				<version>2.22.2</version>
 				<configuration>


### PR DESCRIPTION
Ik heb na alle wijzigingen de oude en nieuwe war files vergeleken, het enige verschil is de toevoeging van de javax.activation:1.1.1 dependency. De excludes staan er nu hard in om mogelijke problemen in de toekomst tegen te gaan. Nu wordt de oude `jakarta.activation:jakarta.activation-api:1.2.2` jar overschreven en de `com.sun.activation:jakarta.activation:2.0.1` gebruikt. De inhoud in een ander package staat (javax/jakarta), de jar's gebruiken de zelfde naam.. Supersedes #2392