### PR TITLE
Disallow the use of javax annotation, xml.ws and xml.soap

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -65,10 +65,5 @@
 			<property name="format" value="^.*System\.(out|err).*$"/>
 			<property name="message" value="Don't use System.out/err, use LOG4J2 instead."/>
 		</module>
-
-		<module name="IllegalImport">
-		<!-- javax.activation -->
-			<property name="illegalPkgs" value="javax.annotation, javax.xml.soap, javax.xml.ws." />
-		</module>
 	</module>
 </module>

--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -28,7 +28,7 @@
 		<module name="AvoidStarImport">
 			<property name="allowStaticMemberImports" value="true" />
 		</module>
-		
+
 		<module name="EmptyBlock" />
 		<module name="ModifierOrder" />
 		<module name="RedundantModifier">
@@ -64,6 +64,11 @@
 			<property name="id" value="systemout"/>
 			<property name="format" value="^.*System\.(out|err).*$"/>
 			<property name="message" value="Don't use System.out/err, use LOG4J2 instead."/>
+		</module>
+
+		<module name="IllegalImport">
+		<!-- javax.activation -->
+			<property name="illegalPkgs" value="javax.annotation, javax.xml.soap, javax.xml.ws." />
 		</module>
 	</module>
 </module>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -100,6 +100,17 @@
 			<groupId>com.sun.activation</groupId>
 			<artifactId>jakarta.activation</artifactId>
 		</dependency>
+		<dependency><!-- javax based dependency -->
+			<groupId>jakarta.xml.soap</groupId>
+			<artifactId>jakarta.xml.soap-api</artifactId>
+			<version>1.4.2</version>
+			<exclusions>
+				<exclusion>
+					<groupId>jakarta.activation</groupId>
+					<artifactId>jakarta.activation-api</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>
@@ -634,7 +645,7 @@
 			<artifactId>jaxws-api</artifactId>
 			<version>2.3.0</version> <!-- 2.3.1 contains javax.activation 1.2.0 that conflicts with the jdk javax.activation (1.1.1) package. -->
 			<exclusions>
-				<exclusion>
+				<exclusion><!-- excluded because we use the jakarta based com.sun.xml.soap instead -->
 					<groupId>javax.xml.soap</groupId>
 					<artifactId>javax.xml.soap-api</artifactId>
 				</exclusion>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -95,14 +95,11 @@
 		<dependency><!-- this dependency handles javax.activation.* imports, compatible with the IBM JRE -->
 			<groupId>javax.activation</groupId>
 			<artifactId>activation</artifactId>
-			<version>1.1.1</version>
 		</dependency>
 		<dependency><!-- this dependency handles jakarta.activation.* imports -->
 			<groupId>com.sun.activation</groupId>
 			<artifactId>jakarta.activation</artifactId>
-			<version>2.0.1</version>
 		</dependency>
-
 
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>
@@ -636,6 +633,12 @@
 			<groupId>javax.xml.ws</groupId>
 			<artifactId>jaxws-api</artifactId>
 			<version>2.3.0</version> <!-- 2.3.1 contains javax.activation 1.2.0 that conflicts with the jdk javax.activation (1.1.1) package. -->
+			<exclusions>
+				<exclusion>
+					<groupId>javax.xml.soap</groupId>
+					<artifactId>javax.xml.soap-api</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<!--

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -785,11 +785,11 @@
 			<version>${postgresql.driver.version}</version>
 			<scope>test</scope>
 		</dependency>
-
+		<!-- LdapSenderTest -->
 		<dependency>
 			<groupId>com.unboundid</groupId>
 			<artifactId>unboundid-ldapsdk</artifactId>
-			<version>2.3.8</version>
+			<version>4.0.14</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/core/src/test/java/nl/nn/adapterframework/util/XmlBuilderTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/XmlBuilderTest.java
@@ -8,18 +8,15 @@ import org.custommonkey.xmlunit.XMLUnit;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.unboundid.ldap.sdk.LDAPException;
-
 import nl.nn.adapterframework.testutil.MatchUtils;
 
 public class XmlBuilderTest {
-	
 	private final String UNICODE_CHARACTERS = " aâΔع你好ಡತ";
 	//private final String JAVA_ESCAPED_UNICODE_CHARACTERS = "\u0010 a\u00E2\u0394\u0639\u4F60\u597D\u0CA1\u0CA4";
 	private final String XML_RENDERED_UNICODE_CHARACTERS = "¿#16; aâΔع你好ಡತ";
 
 	@Before
-	public void initXMLUnit() throws LDAPException, IOException {
+	public void initXMLUnit() throws IOException {
 		XMLUnit.setIgnoreWhitespace(true);
 		XMLUnit.setIgnoreDiffBetweenTextAndCDATA(true);
 	}
@@ -150,13 +147,13 @@ public class XmlBuilderTest {
 
 	@Test
 	public void testAddEmbeddedCdata1() {
-		
+
 		String value = "<xml>&amp; <![CDATA[cdatastring < > & <tag/> ]]>rest</xml>";
-		
+
 		XmlBuilder root = new XmlBuilder("root");
 		root.setValue(value);
-		
-		String expected = "<root>"+XmlUtils.encodeChars(value)+"</root>";
+
+		String expected = "<root>" + XmlUtils.encodeChars(value) + "</root>";
 		MatchUtils.assertXmlEquals(expected, root.toXML(false));
 	}
 
@@ -164,27 +161,26 @@ public class XmlBuilderTest {
 	public void testAddEmbeddedCdata2() {
 		String CDATA_START="<![CDATA[";
 		String CDATA_END="]]>";
-		String CDATA_END_REPLACEMENT=CDATA_END.substring(0,1)+CDATA_END+CDATA_START+CDATA_END.substring(1);
-		
-		String value = "<xml>&amp; "+CDATA_START+"cdatastring < > & <tag/> "+CDATA_END+"rest</xml>";
-		
+		String CDATA_END_REPLACEMENT = CDATA_END.substring(0, 1) + CDATA_END + CDATA_START + CDATA_END.substring(1);
+
+		String value = "<xml>&amp; " + CDATA_START + "cdatastring < > & <tag/> " + CDATA_END + "rest</xml>";
+
 		XmlBuilder root = new XmlBuilder("root");
 		root.setCdataValue(value);
-		
-		String expected = "<root>"+CDATA_START+value.replace(CDATA_END, CDATA_END_REPLACEMENT)+CDATA_END+"</root>";
+
+		String expected = "<root>" + CDATA_START + value.replace(CDATA_END, CDATA_END_REPLACEMENT) + CDATA_END + "</root>";
 		MatchUtils.assertXmlEquals(expected, root.toXML(false));
 	}
-	
-	
+
 	@Test
 	public void testControlCharacters1() {
 		XmlBuilder root = new XmlBuilder("root");
 		XmlBuilder subElement = new XmlBuilder("element");
 		subElement.setValue("control char 1a [\u001a]");
 		root.addSubElement(subElement);
-		
+
 		String expected = "<root><element>control char 1a [¿#26;]</element></root>";
-		
+
 		MatchUtils.assertXmlEquals(expected, root.toXML());
 	}
 
@@ -194,30 +190,30 @@ public class XmlBuilderTest {
 		XmlBuilder subElement = new XmlBuilder("element");
 		subElement.setValue("control char 1a [¿#26;]");
 		root.addSubElement(subElement);
-		
+
 		String expected = "<root><element>control char 1a [¿#26;]</element></root>";
-		
+
 		MatchUtils.assertXmlEquals(expected, root.toXML());
 	}
-	
+
 	@Test
 	public void testPrettyPrint() {
 		XmlBuilder root = new XmlBuilder("root");
 		root.addSubElement("elementName", "elementValue");
-		String expected="<root>\n\t<elementName>elementValue</elementName>\n</root>";
+		String expected = "<root>\n\t<elementName>elementValue</elementName>\n</root>";
 		String actual = root.toXML().trim().replaceAll("  ", "\t").replaceAll(System.lineSeparator(), "\n");
 		assertEquals(expected, actual);
 	}
-	
+
 	@Test
 	public void testUnicodeMessage() {
 		XmlBuilder root = new XmlBuilder("root");
 		XmlBuilder subElement = new XmlBuilder("element");
-		subElement.setValue("Unicode characters ["+UNICODE_CHARACTERS+"]");
+		subElement.setValue("Unicode characters [" + UNICODE_CHARACTERS + "]");
 		root.addSubElement(subElement);
-		
-		String expected = "<root><element>Unicode characters ["+XML_RENDERED_UNICODE_CHARACTERS+"]</element></root>";
-		
+
+		String expected = "<root><element>Unicode characters [" + XML_RENDERED_UNICODE_CHARACTERS + "]</element></root>";
+
 		MatchUtils.assertXmlEquals(expected, root.toXML());
 	}
 

--- a/core/src/test/resources/Ldap/expected/updateNewEntry.xml
+++ b/core/src/test/resources/Ldap/expected/updateNewEntry.xml
@@ -149,9 +149,9 @@
 					<attribute name="changetype" value="add" />
 					<attribute name="modifyTimestamp" value="20180108095303.279Z" />
 					<attribute name="modifiersName" value="" />
+					<attribute name="cn" value="LEA Administrator" />
 					<attribute name="createTimestamp" value="20180108095303.211Z" />
 					<attribute name="creatorsName" value="cn=Internal Root User" />
-					<attribute name="cn" value="LEA Administrator" />
 					<attribute name="subschemaSubentry" value="cn=schema" />
 				</attributes>
 			</context>

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -20,6 +20,10 @@
 					<groupId>org.codehaus.woodstox</groupId>
 					<artifactId>woodstox-core-asl</artifactId>
 				</exclusion>
+				<exclusion><!-- excluded because it uses an old cxf version that introduces javax.annotation -->
+					<groupId>org.apache.cxf</groupId>
+					<artifactId>cxf-rt-rs-client</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -162,6 +162,18 @@
 				<version>${project.version}</version>
 			</dependency>
 
+			<!-- explicit dependency to force version 1.1.1 -->
+			<dependency><!-- this dependency handles javax.activation.* imports, compatible with the IBM JRE -->
+				<groupId>javax.activation</groupId>
+				<artifactId>activation</artifactId>
+				<version>1.1.1</version>
+			</dependency>
+			<dependency><!-- this dependency handles jakarta.activation.* imports -->
+				<groupId>com.sun.activation</groupId>
+				<artifactId>jakarta.activation</artifactId>
+				<version>2.0.1</version>
+			</dependency>
+
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>
 				<artifactId>log4j-core</artifactId>
@@ -312,6 +324,15 @@
 						</goals>
 						<configuration>
 							<rules>
+								<bannedDependencies>
+									<!-- Java Annotations was renamed to the Jakarta Annotations -->
+									<excludes>
+										<exclude>javax.annotation:javax.annotation-api</exclude>
+										<exclude>javax.xml.ws:javax.xml.ws-api</exclude>
+										<exclude>javax.xml.soap:javax.xml.soap-api</exclude>
+									</excludes>
+									<message>Prevent the use of both javax and jakarta packages</message>
+								</bannedDependencies>
 								<bannedDependencies>
 									<!-- the activation framework was renamed to the jarkata activation framework -->
 									<excludes>


### PR DESCRIPTION
Disallows the use of javax annotation, xml.ws and xml.soap and enforces the use of (com.sun) based Jakarta dependencies instead.
The dependencies have been renamed but their contents is still the same (the javax package is still used).