### PR TITLE
Reduce the use of org.json and use javax.json instead

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -347,6 +347,8 @@
 			<artifactId>ehcache</artifactId>
 			<version>2.10.9.2</version>
 		</dependency>
+
+		<!-- JsonPipe -->
 		<dependency>
 			<groupId>org.json</groupId>
 			<artifactId>json</artifactId>

--- a/core/src/main/java/nl/nn/adapterframework/pipes/JsonWellFormedChecker.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/JsonWellFormedChecker.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018, 2020 Nationale-Nederlanden, 2021 WeAreFrank!
+   Copyright 2018, 2020 Nationale-Nederlanden, 2021-2022 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -17,12 +17,11 @@ package nl.nn.adapterframework.pipes;
 
 import java.io.IOException;
 
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
+import javax.json.Json;
+import javax.json.JsonException;
+import javax.json.JsonReader;
 
 import nl.nn.adapterframework.core.PipeLineSession;
-import nl.nn.adapterframework.core.PipeForward;
 import nl.nn.adapterframework.core.PipeRunException;
 import nl.nn.adapterframework.core.PipeRunResult;
 import nl.nn.adapterframework.stream.Message;
@@ -35,30 +34,21 @@ import nl.nn.adapterframework.stream.Message;
  * @author  Tom van der Heijden
  */
 public class JsonWellFormedChecker extends FixedForwardPipe {
-	
+
 	@Override
 	public PipeRunResult doPipe(Message message, PipeLineSession session) throws PipeRunException {
-		PipeForward forward = getSuccessForward();
+		if(Message.isEmpty(message)) {
+			return new PipeRunResult(findForward("failure"), message);
+		}
 
-		String input;
-		try {
-			input = message.asString();
+		try(JsonReader jr = Json.createReader(message.asReader())) {
+			jr.read();
+		} catch (JsonException e) {
+			return new PipeRunResult(findForward("failure"), message);
 		} catch (IOException e) {
 			throw new PipeRunException(this, getLogPrefix(session)+"cannot open stream", e);
 		}
-		if (input.isEmpty()) {
-			forward = findForward("failure");
-		} else {
-			try {
-				new JSONObject(input);
-			} catch (JSONException ex) {
-				try {
-					new JSONArray(input);
-				} catch (JSONException ex1) {
-					forward = findForward("failure");
-				}
-			}
-		}
-		return new PipeRunResult(forward, message);
+
+		return new PipeRunResult(getSuccessForward(), message);
 	}
 }


### PR DESCRIPTION
Reduces the risk of an `StackOverflowError`, see https://security.snyk.io/vuln/SNYK-JAVA-ORGJSON-2841369