### PR TITLE
Fix resumeTransaction always being forced when tx sync is inactive

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/jta/TransactionConnector.java
+++ b/core/src/main/java/nl/nn/adapterframework/jta/TransactionConnector.java
@@ -42,7 +42,7 @@ public class TransactionConnector<T,R> implements AutoCloseable {
 	private Thread parentThread;
 	private Thread childThread;
 	private ThrowingRunnable<?> onEndChildThreadAction;
-	
+
 	private boolean childThreadTransactionSuspended;
 
 	private TransactionConnector(TransactionConnectorCoordinator<T,R> coordinator, Object owner) {
@@ -51,7 +51,7 @@ public class TransactionConnector<T,R> implements AutoCloseable {
 		this.coordinator = coordinator;
 		this.owner = owner;
 	}
-	
+
 	/**
 	 * factory method, to be called from 'main' thread.
 	 * 
@@ -72,7 +72,7 @@ public class TransactionConnector<T,R> implements AutoCloseable {
 		coordinator.setLastInThread(instance);
 		return instance;
 	}
-	
+
 	/**
 	 * resume transaction, that was saved in parent thread, in the child thread.
 	 * After beginChildThread() has been called, new transactional resources cannot be enlisted in the parentThread, 

--- a/core/src/main/java/nl/nn/adapterframework/jta/TransactionConnectorCoordinator.java
+++ b/core/src/main/java/nl/nn/adapterframework/jta/TransactionConnectorCoordinator.java
@@ -139,7 +139,7 @@ public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 	public void resumeTransaction(boolean force) {
 		if (suspended || force) {
 			log.debug("resumeTransaction() resuming transaction of parent thread [{}], current thread [{}]", ()->parentThread.getName(), ()->Thread.currentThread().getName());
-			if (force || !TransactionSynchronizationManager.isSynchronizationActive()) {
+			if (!TransactionSynchronizationManager.isSynchronizationActive()) {
 				txManager.resumeTransaction(transaction, resourceHolder);
 			}
 		} else {

--- a/core/src/main/java/nl/nn/adapterframework/jta/TransactionConnectorCoordinator.java
+++ b/core/src/main/java/nl/nn/adapterframework/jta/TransactionConnectorCoordinator.java
@@ -47,7 +47,7 @@ public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 		transaction = this.txManager.getCurrentTransaction();
 		suspendTransaction();
 	}
-	
+
 	public static <T,R> TransactionConnectorCoordinator<T,R> getInstance(IThreadConnectableTransactionManager<T,R> txManager) {
 		if (txManager==null) {
 			throw new IllegalStateException("txManager is null");
@@ -68,12 +68,12 @@ public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 		log.debug("setting lastInThread [{}] to target [{}]", lastInThread, target);
 		lastInThread = target;
 	}
-	
+
 	public boolean isLastInThread(TransactionConnector<T,R> target) {
 		log.debug("comparing lastInThread [{}] to target [{}]", lastInThread, target);
 		return lastInThread==target;
 	}
-	
+
 	/**
 	 * Execute an action with the thread prepared for enlisting transactional resources.
 	 * To be called for obtaining transactional resources (like JDBC connections) if a TransactionConnector might already have been created on the thread.
@@ -106,8 +106,8 @@ public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 		}
 		return false;
 	}
-	
-	
+
+
 	public void resumeTransactionInChildThread(TransactionConnector<T,R> requester) {
 		Thread thread = Thread.currentThread();
 		if (thread!=parentThread) {
@@ -128,21 +128,21 @@ public class TransactionConnectorCoordinator<T,R> implements AutoCloseable {
 			log.debug("suspending transaction of parent thread [{}], current thread [{}]", ()->parentThread.getName(), ()->Thread.currentThread().getName());
 			resourceHolder = this.txManager.suspendTransaction(transaction);
 			suspended = true;
-		} else {	
+		} else {
 			log.debug("transaction of parent thread [{}] was already suspended, current thread [{}]", ()->parentThread.getName(), ()->Thread.currentThread().getName());
 		}
 	}
-	
+
 	public void resumeTransaction() {
 		resumeTransaction(false);
 	}
 	public void resumeTransaction(boolean force) {
 		if (suspended || force) {
 			log.debug("resumeTransaction() resuming transaction of parent thread [{}], current thread [{}]", ()->parentThread.getName(), ()->Thread.currentThread().getName());
-			if (!force || !TransactionSynchronizationManager.isSynchronizationActive()) {
+			if (force || !TransactionSynchronizationManager.isSynchronizationActive()) {
 				txManager.resumeTransaction(transaction, resourceHolder);
 			}
-		} else {	
+		} else {
 			log.debug("resumeTransaction() transaction of parent thread [{}] was already resumed, current thread [{}]", ()->parentThread.getName(), ()->Thread.currentThread().getName());
 		}
 		suspended = false;

--- a/core/src/main/java/nl/nn/adapterframework/pipes/XsltPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/XsltPipe.java
@@ -152,14 +152,11 @@ public class XsltPipe extends StreamingPipe implements InitializingBean {
 	}
 
 	/**
-	 * If true, then this pipe can provide an OutputStream to the previous pipe, to write its output to. Can be used to switch streaming off for debugging purposes.
-	 * NB: this also disables xslt.streaming
-	 * @ff.default set by appconstant streaming.auto
+	 * If true, then this pipe will process the XSLT while streaming in a different thread. Can be used to switch streaming xslt off for debugging purposes
+	 * @ff.default set by appconstant xslt.streaming.default
 	 */
-	@Override
-	public void setStreamingActive(boolean streamingActive) {
-		super.setStreamingActive(streamingActive);
-		sender.setStreamingActive(streamingActive);
+	public void setStreamingXslt(boolean streamingActive) {
+		sender.setStreamingXslt(streamingActive);
 	}
 
 

--- a/core/src/main/java/nl/nn/adapterframework/pipes/XsltPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/XsltPipe.java
@@ -151,6 +151,17 @@ public class XsltPipe extends StreamingPipe implements InitializingBean {
 		return false;
 	}
 
+	/**
+	 * If true, then this pipe can provide an OutputStream to the previous pipe, to write its output to. Can be used to switch streaming off for debugging purposes.
+	 * NB: this also disables xslt.streaming
+	 * @ff.default set by appconstant streaming.auto
+	 */
+	@Override
+	public void setStreamingActive(boolean streamingActive) {
+		super.setStreamingActive(streamingActive);
+		sender.setStreamingActive(streamingActive);
+	}
+
 
 	@Override
 	protected MessageOutputStream provideOutputStream(PipeLineSession session) throws StreamingException {

--- a/core/src/main/java/nl/nn/adapterframework/senders/JsonXsltSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/JsonXsltSender.java
@@ -72,7 +72,7 @@ public class JsonXsltSender extends XsltSender {
 			log.debug("sender [{}] cannot provide outputstream", () -> getName());
 			return null;
 		}
-		ThreadConnector threadConnector = getStreamingActive() ? new ThreadConnector(this, threadLifeCycleEventListener, txManager, session) : null;
+		ThreadConnector threadConnector = getStreamingXslt() ? new ThreadConnector(this, threadLifeCycleEventListener, txManager, session) : null;
 		MessageOutputStream target = MessageOutputStream.getTargetStream(this, session, next);
 		try {
 			TransformerPool poolToUse = getTransformerPoolToUse(session);

--- a/core/src/main/java/nl/nn/adapterframework/senders/JsonXsltSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/JsonXsltSender.java
@@ -72,7 +72,7 @@ public class JsonXsltSender extends XsltSender {
 			log.debug("sender [{}] cannot provide outputstream", () -> getName());
 			return null;
 		}
-		ThreadConnector threadConnector = isStreamingXslt() ? new ThreadConnector(this, threadLifeCycleEventListener, txManager, session) : null;
+		ThreadConnector threadConnector = getStreamingActive() ? new ThreadConnector(this, threadLifeCycleEventListener, txManager, session) : null;
 		MessageOutputStream target = MessageOutputStream.getTargetStream(this, session, next);
 		try {
 			TransformerPool poolToUse = getTransformerPoolToUse(session);

--- a/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
@@ -54,7 +54,6 @@ import nl.nn.adapterframework.stream.ThreadConnector;
 import nl.nn.adapterframework.stream.ThreadLifeCycleEventListener;
 import nl.nn.adapterframework.stream.xml.XmlTap;
 import nl.nn.adapterframework.util.AppConstants;
-import nl.nn.adapterframework.util.ClassUtils;
 import nl.nn.adapterframework.util.EnumUtils;
 import nl.nn.adapterframework.util.TransformerPool;
 import nl.nn.adapterframework.util.TransformerPool.OutputType;
@@ -345,10 +344,8 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 				reader.parse(source);
 				return target.getPipeRunResult();
 			}
-		} catch (ParserConfigurationException | SAXException | IOException | ConfigurationException e) {
-			throw new SenderException(getLogPrefix()+"Exception on transforming input", e);
-		} catch (Exception e) { //StreamingException | IllegalStateException
-			throw new SenderException(getLogPrefix()+"Exception retrieving targetstream"+ (next!=null?" from ["+ClassUtils.nameOf(next)+"]": ""), e);
+		} catch (Exception e) {
+			throw new SenderException(getLogPrefix()+"Cannot transform input", e);
 		}
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/XsltSender.java
@@ -101,7 +101,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 
 	protected ThreadLifeCycleEventListener<Object> threadLifeCycleEventListener;
 	protected @Setter IThreadConnectableTransactionManager txManager;
-	private @Getter Boolean streamingActive = null;
+	private @Getter Boolean streamingXslt = null;
 
 	/**
 	 * The <code>configure()</code> method instantiates a transformer for the specified
@@ -112,7 +112,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 		parameterNamesMustBeUnique = true;
 		super.configure();
 
-		if(streamingActive == null) streamingActive = AppConstants.getInstance(getConfigurationClassLoader()).getBoolean(XmlUtils.XSLT_STREAMING_BY_DEFAULT_KEY, false);
+		if(streamingXslt == null) streamingXslt = AppConstants.getInstance(getConfigurationClassLoader()).getBoolean(XmlUtils.XSLT_STREAMING_BY_DEFAULT_KEY, false);
 		dynamicTransformerPoolMap = Collections.synchronizedMap(new LRUMap(transformerPoolMapSize));
 
 		if(StringUtils.isNotEmpty(getXpathExpression()) && getOutputType()==null) {
@@ -184,7 +184,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 		}
 		try {
 			TransformerPool poolToUse = getTransformerPoolToUse(session);
-			boolean canStreamOut = streamingActive && !isDisableOutputEscaping(poolToUse); // TODO fix problem in TransactionConnecor that currently inhibits streaming out when disable-output-escaping is used
+			boolean canStreamOut = streamingXslt && !isDisableOutputEscaping(poolToUse); // TODO fix problem in TransactionConnecor that currently inhibits streaming out when disable-output-escaping is used
 			ThreadConnector threadConnector = canStreamOut ? new ThreadConnector(this, threadLifeCycleEventListener, txManager, session) : null;
 			MessageOutputStream target = MessageOutputStream.getTargetStream(this, session, next);
 			ContentHandler handler = createHandler(null, threadConnector, session, poolToUse, target);
@@ -327,7 +327,7 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 			throw new SenderException(getLogPrefix()+"got null input");
 		}
 
-		try (ThreadConnector threadConnector = streamingActive ? new ThreadConnector(this, threadLifeCycleEventListener, txManager, session) : null) {
+		try (ThreadConnector threadConnector = streamingXslt ? new ThreadConnector(this, threadLifeCycleEventListener, txManager, session) : null) {
 			try (MessageOutputStream target=MessageOutputStream.getTargetStream(this, session, next)) {
 				TransformerPool poolToUse = getTransformerPoolToUse(session);
 				ContentHandler handler = createHandler(message, threadConnector, session, poolToUse, target);
@@ -352,9 +352,9 @@ public class XsltSender extends StreamingSenderBase implements IThreadCreator {
 		}
 	}
 
-	@IbisDoc({"If true, then this pipe will process the XSLT while streaming in a different thread. Can be used to switch streaming off for debugging purposes","set by appconstant xslt.streaming.default"})
-	public void setStreamingActive(Boolean streamingActive) {
-		this.streamingActive = streamingActive;
+	@IbisDoc({"If true, then this sender will process the XSLT while streaming in a different thread. Can be used to switch streaming off for debugging purposes","set by appconstant xslt.streaming.default"})
+	public void setStreamingXslt(Boolean streamingActive) {
+		this.streamingXslt = streamingActive;
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/stream/Message.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/Message.java
@@ -241,7 +241,7 @@ public class Message implements Serializable {
 	}
 
 	public boolean isRepeatable() {
-		return request instanceof String || request instanceof ThrowingSupplier || request instanceof byte[] || request instanceof ByteArrayInputStream || request instanceof Node;
+		return request instanceof String || request instanceof ThrowingSupplier || request instanceof byte[] || request instanceof Node;
 	}
 
 	/**

--- a/core/src/main/java/nl/nn/adapterframework/stream/MessageOutputStream.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/MessageOutputStream.java
@@ -48,21 +48,21 @@ import nl.nn.adapterframework.xml.XmlWriter;
 
 public class MessageOutputStream implements AutoCloseable {
 	protected static Logger log = LogUtil.getLogger(MessageOutputStream.class);
-	
+
 	private INamedObject owner;
 	protected Object requestStream;
 	private Message response;
 	private PipeForward forward;
 	private String conversionCharset;
-	
+
 	private MessageOutputStream nextStream;
 	private MessageOutputStream tail;
-	
+
 	private Set<AutoCloseable> resourcesToClose;
-	
+
 	private ThreadConnector<?> threadConnector;
 	private ThreadConnector<?> targetThreadConnector;
-	
+
 	protected MessageOutputStream(INamedObject owner, IForwardTarget next, String conversionCharset) {
 		this.owner=owner;
 		this.conversionCharset=conversionCharset;
@@ -74,7 +74,7 @@ public class MessageOutputStream implements AutoCloseable {
 		this.conversionCharset=conversionCharset;
 		connect(nextStream);
 	}
-	
+
 	public MessageOutputStream(INamedObject owner, OutputStream stream, IForwardTarget next) {
 		this(owner, stream, next, null);
 	}
@@ -89,7 +89,7 @@ public class MessageOutputStream implements AutoCloseable {
 		this(owner, nextStream, conversionCharset);
 		this.requestStream=stream;
 	}
-	
+
 	public MessageOutputStream(INamedObject owner, Writer writer, IForwardTarget next) {
 		this(owner, writer, next, null);
 	}
@@ -104,7 +104,7 @@ public class MessageOutputStream implements AutoCloseable {
 		this(owner, nextStream, conversionCharset);
 		this.requestStream=writer;
 	}
-	
+
 	// this constructor for testing only
 	<T> MessageOutputStream(ContentHandler handler) {
 		this(null, (IForwardTarget)null, null);
@@ -117,7 +117,7 @@ public class MessageOutputStream implements AutoCloseable {
 		threadConnector = new ThreadConnector<T>(owner, threadLifeCycleEventListener, txManager, session);
 		this.targetThreadConnector = targetThreadConnector;
 	}
-	
+
 	// this constructor for testing only
 	<T> MessageOutputStream(JsonEventHandler handler) {
 		this(null, (IForwardTarget)null, null);
@@ -141,7 +141,7 @@ public class MessageOutputStream implements AutoCloseable {
 			tail=nextStream.tail;
 		}
 	}
-	
+
 	protected void setRequestStream(Object requestStream) {
 		this.requestStream = requestStream;
 	}
@@ -159,14 +159,14 @@ public class MessageOutputStream implements AutoCloseable {
 	public void afterClose() throws Exception {
 		// can be overridden when necessary
 	}
-	
+
 	public void closeOnClose(AutoCloseable resource) {
 		if (resourcesToClose==null) {
 			resourcesToClose = new LinkedHashSet<>();
 		}
 		resourcesToClose.add(resource);
 	}
-	
+
 	@Override
 	public final void close() throws Exception {
 		try {
@@ -220,11 +220,11 @@ public class MessageOutputStream implements AutoCloseable {
 		}
 		return "MessageOutputStream of "+ClassUtils.nameOf(owner)+" ";
 	}
-	
+
 	public OutputStream asStream() throws StreamingException {
 		return asStream(null);
 	}
-	
+
 	public OutputStream asStream(String charset) throws StreamingException {
 		if (requestStream instanceof OutputStream) {
 			if (log.isDebugEnabled()) log.debug(getLogPrefix() + "returning OutputStream as OutputStream");
@@ -347,7 +347,7 @@ public class MessageOutputStream implements AutoCloseable {
 		}
 		log.warn("captureCharacterStream() called before stream is installed.");
 	}
-	
+
 	public ByteArrayOutputStream captureBinaryStream() {
 		ByteArrayOutputStream result = new ByteArrayOutputStream();
 		captureBinaryStream(result);
@@ -378,7 +378,7 @@ public class MessageOutputStream implements AutoCloseable {
 		}
 		log.warn("captureBinaryStream() called before stream is installed.");
 	}
-	
+
 	/**
 	 * Response message, e.g. the filename, of the {IOutputStreamTarget target}
 	 * after processing the stream. It is the responsibility of the

--- a/core/src/main/java/nl/nn/adapterframework/stream/StreamingSenderBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/StreamingSenderBase.java
@@ -32,7 +32,7 @@ public abstract class StreamingSenderBase extends SenderWithParametersBase imple
 		super.configure();
 		canProvideOutputStream = getParameterList()==null || !getParameterList().isInputValueOrContextRequiredForResolution();
 	}
-	
+
 	@Override
 	// can make this sendMessage() 'final', debugging handled by IStreamingSender.sendMessage(), that includes the MessageOutputStream
 	public final Message sendMessage(Message message, PipeLineSession session) throws SenderException, TimeoutException {
@@ -52,5 +52,4 @@ public abstract class StreamingSenderBase extends SenderWithParametersBase imple
 	public boolean supportsOutputStreamPassThrough() {
 		return true;
 	}
-	
 }

--- a/core/src/main/java/nl/nn/adapterframework/stream/ThreadLifeCycleEventListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/ThreadLifeCycleEventListener.java
@@ -22,5 +22,5 @@ public interface ThreadLifeCycleEventListener<T> {
 	public <O> O threadCreated(T ref, O request);
 	public <O> O threadEnded(T ref, O result);
 	public Throwable threadAborted(T ref, Throwable t);
-	
+
 }

--- a/core/src/main/java/nl/nn/adapterframework/xml/ExceptionCatchingFilter.java
+++ b/core/src/main/java/nl/nn/adapterframework/xml/ExceptionCatchingFilter.java
@@ -25,12 +25,12 @@ import org.xml.sax.SAXParseException;
 
 public abstract class ExceptionCatchingFilter extends FullXmlFilter {
 
-	public ExceptionCatchingFilter(ContentHandler handler) {
+	protected ExceptionCatchingFilter(ContentHandler handler) {
 		super(handler);
 	}
 
 	protected abstract void handleException(Exception e) throws SAXException;
-	
+
 	@Override
 	public void startDocument() throws SAXException {
 		try {
@@ -74,8 +74,7 @@ public abstract class ExceptionCatchingFilter extends FullXmlFilter {
 			handleException(e);
 		}
 	}
-	
-	
+
 	@Override
 	public void comment(char[] ch, int start, int length) throws SAXException {
 		try {

--- a/core/src/main/java/nl/nn/adapterframework/xml/ThreadConnectingFilter.java
+++ b/core/src/main/java/nl/nn/adapterframework/xml/ThreadConnectingFilter.java
@@ -35,9 +35,6 @@ public class ThreadConnectingFilter extends ExceptionCatchingFilter {
 		if (t instanceof SAXException) {
 			throw (SAXException) t;
 		}
-		if (t instanceof IllegalStateException) { //Transaction Exceptions
-			throw (IllegalStateException) t;
-		}
 		if (t instanceof Exception) {
 			throw new SaxException((Exception)t);
 		}

--- a/core/src/main/java/nl/nn/adapterframework/xml/ThreadConnectingFilter.java
+++ b/core/src/main/java/nl/nn/adapterframework/xml/ThreadConnectingFilter.java
@@ -23,7 +23,7 @@ import nl.nn.adapterframework.stream.ThreadConnector;
 public class ThreadConnectingFilter extends ExceptionCatchingFilter {
 
 	private ThreadConnector threadConnector;
-	
+
 	public ThreadConnectingFilter(ThreadConnector threadConnector, ContentHandler handler) {
 		super(handler);
 		this.threadConnector=threadConnector;
@@ -35,15 +35,22 @@ public class ThreadConnectingFilter extends ExceptionCatchingFilter {
 		if (t instanceof SAXException) {
 			throw (SAXException) t;
 		}
+		if (t instanceof IllegalStateException) { //Transaction Exceptions
+			throw (IllegalStateException) t;
+		}
 		if (t instanceof Exception) {
 			throw new SaxException((Exception)t);
 		}
 		throw new RuntimeException(t);
 	}
-	
+
 	@Override
 	public void startDocument() throws SAXException {
-		threadConnector.startThread(null);
+		try {
+			threadConnector.startThread(null);
+		} catch(Exception e) {
+			handleException(e); //Cleanup dangling threads, creates better Ladybug reports
+		}
 		super.startDocument();
 	}
 

--- a/ladybug/src/main/java/nl/nn/ibistesttool/IbisDebuggerAdvice.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/IbisDebuggerAdvice.java
@@ -405,6 +405,10 @@ public class IbisDebuggerAdvice implements InitializingBean, ThreadLifeCycleEven
 		if (!isEnabled()) {
 			return;
 		}
+		if (log.isDebugEnabled()) {
+			String nameClause=threadInfo.owner instanceof INamedObject?" name ["+((INamedObject)threadInfo.owner).getName()+"]":"";
+			log.debug("cancelChildThread thread id ["+Thread.currentThread().getId()+"] thread name ["+Thread.currentThread().getName()+"] owner ["+threadInfo.owner.getClass().getSimpleName()+"]"+nameClause+" threadId ["+threadInfo.threadId+"] correlationId ["+threadInfo.correlationId+"]");
+		}
 		ibisDebugger.cancelThread(threadInfo.owner, threadInfo.threadId, threadInfo.correlationId);
 	}
 


### PR DESCRIPTION
- Disable streaming xslt when attribute streamingActive is set to false
- Improve error handling when XsltSender cannot parse XML (and the ExceptionCatchingFilter is never called)