### PR TITLE
Fix receiver in error state not appearing as error in console

### DIFF
--- a/webapp/src/main/webapp/iaf/gui/js/controllers.js
+++ b/webapp/src/main/webapp/iaf/gui/js/controllers.js
@@ -260,7 +260,7 @@ angular.module('iaf.beheerconsole')
 
 					for(x in adapter.receivers) {
 						var adapterReceiver = adapter.receivers[x];
-						if(adapterReceiver.started === false)
+						if(adapterReceiver.state != 'started')
 							adapter.status = 'warning';
 
 						if(adapterReceiver.transactionalStores) {


### PR DESCRIPTION
Appears to have been introduced in #2570 while adding exception_stopped and exception_starting.