### PR TITLE
Remove deletion of Lift ranker tool

### DIFF
--- a/.lift.toml
+++ b/.lift.toml
@@ -4,7 +4,7 @@ setup = ".lift/setup.sh"
 build = "mvn install -P ibissource,codecoverage -DskipTests=true"
 jdkVersion = "8"
 
-disableTools = [ "golangci-lint", "JSHint" ]
+disableTools = [ "golangci-lint", "JSHint", "ESLint" ]
 
 ignoreFiles = """
 **/js/angular/*.js

--- a/.lift/setup.sh
+++ b/.lift/setup.sh
@@ -2,18 +2,3 @@
 
 # Remove the default settings.xml that forces all repos to go through a mirror
 rm ~/.m2/settings.xml
-# ranker was causing an OOM exception so remove for now
-rm -rf /opt/muse/packages/ranker/
-mkdir -p /opt/muse/packages/ranker/
-
-cat <<EOF >> /opt/muse/packages/ranker/rank.py
-#!/usr/bin/env python3
-
-if __name__=="__main__":
-    print([])
-    exit()
-
-
-EOF
-
-chmod a+x /opt/muse/packages/ranker/rank.py


### PR DESCRIPTION
Here are the Lift results from my fork https://lift.sonatype.com/results/github.com/mattjohnson/iaf/01GJD5YAYG3QC2Z0MMVZ5RF4QS

The tools all complete and show results. The dependency scanning failed and we'll continue to look into why that has failed.