### PR TITLE
Abort request when Content-Type does not match consumes

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
@@ -215,7 +215,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	 * @ff.default ANY
 	 */
 	public void setConsumes(MediaTypes value) {
-		this.consumes = value;
+		this.consumes = value != null ? value : MediaTypes.ANY;
 	}
 
 	/**
@@ -223,7 +223,7 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	 * @ff.default ANY
 	 */
 	public void setProduces(MediaTypes value) {
-		this.produces = value;
+		this.produces = value != null ? value : MediaTypes.ANY;
 	}
 
 	/**

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListener.java
@@ -39,6 +39,8 @@ import nl.nn.adapterframework.receivers.ReceiverAware;
 import nl.nn.adapterframework.stream.Message;
 import nl.nn.adapterframework.util.AppConstants;
 
+import javax.annotation.Nonnull;
+
 // TODO: Link to https://swagger.io/specification/ when anchors are supported by the Frank!Doc.
 /**
  * Listener that allows a {@link Receiver} to receive messages as a REST webservice.
@@ -214,24 +216,25 @@ public class ApiListener extends PushingListenerAdapter implements HasPhysicalDe
 	 * The required contentType on requests, if it doesn't match the request will fail
 	 * @ff.default ANY
 	 */
-	public void setConsumes(MediaTypes value) {
-		this.consumes = value != null ? value : MediaTypes.ANY;
+	public void setConsumes(@Nonnull MediaTypes value) {
+		this.consumes = value;
 	}
 
 	/**
 	 * The specified contentType on response. When <code>ANY</code> the response will determine the content type based on the return data.
 	 * @ff.default ANY
 	 */
-	public void setProduces(MediaTypes value) {
-		this.produces = value != null ? value : MediaTypes.ANY;
+	public void setProduces(@Nonnull MediaTypes value) {
+		this.produces = value;
 	}
 
 	/**
-	 * The specified character encoding on the response contentType header
+	 * The specified character encoding on the response contentType header. NULL or empty
+	 * values will be ignored.
 	 * @ff.default UTF-8
 	 */
 	public void setCharacterEncoding(String charset) {
-		if(StringUtils.isNotEmpty(charset)) {
+		if(StringUtils.isNotBlank(charset)) {
 			this.charset = charset;
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -364,7 +364,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					}
 				}
 
-				if(request.getContentType() != null && !listener.isConsumable(request.getContentType())) {
+				if(!listener.isConsumable(request.getContentType())) {
 					response.setStatus(415);
 					log.warn(createAbortMessage(remoteUser, 415) + "did not match consumes ["+listener.getConsumes()+"] got ["+request.getContentType()+"] instead");
 					return;

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -187,7 +187,7 @@ public class ApiListenerServlet extends HttpServletBase {
 	private void handleRequest(HttpServletRequest request, HttpServletResponse response, HttpMethod method, String uri) {
 		String remoteUser = request.getRemoteUser();
 
-		/**
+		/*
 		 * Initiate and populate messageContext
 		 */
 		try (PipeLineSession messageContext = new PipeLineSession()) {
@@ -204,7 +204,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					return;
 				}
 
-				/**
+				/*
 				 * Handle Cross-Origin Resource Sharing
 				 * TODO make this work behind loadbalancers/reverse proxies
 				 * TODO check if request ip/origin header matches allowOrigin property
@@ -231,7 +231,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					}
 				}
 
-				/**
+				/*
 				 * Get serviceClient
 				 */
 				ApiListener listener = config.getApiListener(method);
@@ -243,7 +243,7 @@ public class ApiListenerServlet extends HttpServletBase {
 
 				if(log.isTraceEnabled()) log.trace("ApiListenerServlet calling service ["+listener.getName()+"]");
 
-				/**
+				/*
 				 * Check authentication
 				 */
 				ApiPrincipal userPrincipal = null;
@@ -345,17 +345,17 @@ public class ApiListenerServlet extends HttpServletBase {
 						messageContext.put("authorizationToken", authorizationToken);
 					}
 				}
-				//Remove this? it's now available as header value
+				// Remove this? it's now available as header value
 				messageContext.put("remoteAddr", request.getRemoteAddr());
 				if(userPrincipal != null)
 					messageContext.put(PipeLineSession.API_PRINCIPAL_KEY, userPrincipal);
 				messageContext.put("uri", uri);
 
-				/**
+				/*
 				 * Evaluate preconditions
 				 */
 				String acceptHeader = request.getHeader("Accept");
-				if(StringUtils.isNotEmpty(acceptHeader)) { //If an Accept header is present, make sure we comply to it!
+				if(StringUtils.isNotEmpty(acceptHeader)) { // If an Accept header is present, make sure we comply to it!
 					if(!listener.accepts(acceptHeader)) {
 						response.setStatus(406);
 						response.getWriter().print("It appears you expected the MediaType ["+acceptHeader+"] but I only support the MediaType ["+listener.getContentType()+"] :)");
@@ -395,12 +395,12 @@ public class ApiListenerServlet extends HttpServletBase {
 				}
 				messageContext.put(UPDATE_ETAG_CONTEXT_KEY, listener.getUpdateEtag());
 
-				/**
+				/*
 				 * Check authorization
 				 */
 				//TODO: authentication implementation
 
-				/**
+				/*
 				 * Map uriIdentifiers into messageContext
 				 */
 				String[] patternSegments = listener.getUriPattern().split("/");
@@ -424,7 +424,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					}
 				}
 
-				/**
+				/*
 				 * Map queryParameters into messageContext
 				 */
 				Enumeration<String> paramnames = request.getParameterNames();
@@ -443,7 +443,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					}
 				}
 
-				/**
+				/*
 				 * Map headers into messageContext
 				 */
 				if(StringUtils.isNotEmpty(listener.getHeaderParams())) {
@@ -467,7 +467,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					messageContext.put("headers", headersXml.toXML());
 				}
 
-				/**
+				/*
 				 * Process the request through the pipeline.
 				 * If applicable, map multipart parts into messageContext
 				 */
@@ -528,13 +528,13 @@ public class ApiListenerServlet extends HttpServletBase {
 					body = MessageUtils.parseContentAsMessage(request);
 				}
 
-				/**
+				/*
 				 * Compile Allow header
 				 */
 				StringBuilder methods = new StringBuilder();
 				methods.append("OPTIONS, ");
 				for (HttpMethod mtd : config.getMethods()) {
-					methods.append(mtd + ", ");
+					methods.append(mtd).append(", ");
 				}
 				messageContext.put("allowedMethods", methods.substring(0, methods.length()-2));
 
@@ -558,7 +558,7 @@ public class ApiListenerServlet extends HttpServletBase {
 				PipeLineSession.setListenerParameters(messageContext, messageId, correlationId, null, null); //We're only using this method to keep setting mid/cid uniform
 				Message result = listener.processRequest(body, messageContext);
 
-				/**
+				/*
 				 * Calculate an eTag over the processed result and store in cache
 				 */
 				Boolean updateEtag = messageContext.getBoolean(UPDATE_ETAG_CONTEXT_KEY);
@@ -594,7 +594,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					}
 				}
 
-				/**
+				/*
 				 * Add headers
 				 */
 				response.addHeader("Allow", (String) messageContext.get("allowedMethods"));
@@ -626,7 +626,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					}
 				}
 
-				/**
+				/*
 				 * Check if an exitcode has been defined or if a statuscode has been added to the messageContext.
 				 */
 				int statusCode = messageContext.get(PipeLineSession.EXIT_CODE_CONTEXT_KEY, 0);
@@ -634,7 +634,7 @@ public class ApiListenerServlet extends HttpServletBase {
 					response.setStatus(statusCode);
 				}
 
-				/**
+				/*
 				 * Finalize the pipeline and write the result to the response
 				 */
 				if(!Message.isEmpty(result)) {

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -143,7 +143,7 @@ public class ApiListenerServlet extends HttpServletBase {
 			uri = uri.substring(0, uri.length()-1);
 		}
 
-		/**
+		/*
 		 * Generate OpenApi specification
 		 */
 		if(uri.equalsIgnoreCase("/openapi.json")) {
@@ -165,7 +165,7 @@ public class ApiListenerServlet extends HttpServletBase {
 			return;
 		}
 
-		/**
+		/*
 		 * Generate an OpenApi json file for a set of ApiDispatchConfigs
 		 * @Deprecated This is here to support old url's
 		 */

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/MediaTypes.java
@@ -70,6 +70,12 @@ public enum MediaTypes {
 	 * Matches the provided 'Content-Type' to this enum, should always be valid, is not weighted
 	 */
 	public boolean isConsumable(String contentType) {
+		if (this == ANY) {
+			return true;
+		}
+		if (StringUtils.isBlank(contentType)) {
+			return false;
+		}
 		try {
 			MimeType otherType = MimeTypeUtils.parseMimeType(contentType);
 			return mimeType.includes(otherType);

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
@@ -415,10 +415,10 @@ public class ApiListenerServletTest extends Mockito {
 	public void listenerAcceptsRequestWithoutContentTypeHeaderWhenConsumesAttributeNotSet() throws ServletException, IOException, ListenerException, ConfigurationException {
 		// Arrange
 		String uri="/listenerAcceptsContentTypeJSON";
-		new ApiListenerBuilder(uri, Methods.POST, null, null).build();
+		new ApiListenerBuilder(uri, Methods.POST, null, MediaTypes.JSON).build();
 
 		Map<String, String> headers = new HashMap<>();
-		headers.put("Accept", "*/*");
+		headers.put("Accept", "application/json");
 		HttpServletRequest request = createRequest(uri, Methods.POST, "{}", headers);
 
 		// Act

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
@@ -93,7 +93,7 @@ import nl.nn.adapterframework.util.LogUtil;
 
 public class ApiListenerServletTest extends Mockito {
 	private Logger log = LogUtil.getLogger(this);
-	private List<ApiListener> listeners = Collections.synchronizedList(new ArrayList<ApiListener>());
+	private List<ApiListener> listeners = Collections.synchronizedList(new ArrayList<>());
 	private static final String JWT_VALIDATION_URI="/jwtvalidator";
 
 	private static final String PAYLOAD="{\"sub\":\"UnitTest\",\"aud\":\"Framework\",\"iss\":\"JWTPipeTest\",\"jti\":\"1234\"}";
@@ -394,6 +394,46 @@ public class ApiListenerServletTest extends Mockito {
 	}
 
 	@Test
+	public void listenerRejectsRequestWithoutContentTypeHeaderWhenConsumesAttributeSet() throws ServletException, IOException, ListenerException, ConfigurationException {
+		// Arrange
+		String uri="/listenerDoesNotAcceptRequestWithoutContentTypeHeader";
+		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.XML, null).build();
+
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Accept", "application/json");
+		HttpServletRequest request = createRequest(uri, Methods.POST, "{}", headers);
+
+		// Act
+		Response result = service(request);
+
+		// Assert
+		assertEquals(415, result.getStatus());
+
+	}
+
+	@Test
+	public void listenerAcceptsRequestWithoutContentTypeHeaderWhenConsumesAttributeNotSet() throws ServletException, IOException, ListenerException, ConfigurationException {
+		// Arrange
+		String uri="/listenerAcceptsContentTypeJSON";
+		new ApiListenerBuilder(uri, Methods.POST, null, null).build();
+
+		Map<String, String> headers = new HashMap<>();
+		headers.put("Accept", "*/*");
+		HttpServletRequest request = createRequest(uri, Methods.POST, "{}", headers);
+
+		// Act
+		Response result = service(request);
+
+		// Assert
+		assertEquals(200, result.getStatus());
+		assertEquals("{}", result.getContentAsString());
+		assertEquals("OPTIONS, POST", result.getHeader("Allow"));
+		assertTrue("Content-Type header does not contain [application/json]", result.getContentType().contains("application/json"));
+		assertNull(result.getErrorMessage());
+
+	}
+
+	@Test
 	public void listenerDetectContentTypeAndCharsetISO8859() throws Exception {
 		String uri="/listenerDetectMimeType";
 		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.TEXT, MediaTypes.DETECT).build();
@@ -592,7 +632,7 @@ public class ApiListenerServletTest extends Mockito {
 
 		assertEquals(200, result.getStatus());
 		assertEquals("60", session.get("maxSpeed"));
-		List<String> transportList = Arrays.asList(new String[] {"car","bike","moped"});
+		List<String> transportList = Arrays.asList("car","bike","moped");
 		assertEquals(transportList, session.get("transport"));
 		assertEquals("OPTIONS, GET", result.getHeader("Allow"));
 		assertNull(result.getErrorMessage());
@@ -1073,14 +1113,13 @@ public class ApiListenerServletTest extends Mockito {
 	public MockHttpServletRequest prepareJWTRequest(String token) throws Exception {
 		Map<String, String> headers = new HashMap<String, String>();
 		headers.put("Authorization", "Bearer "+ (token != null ? token : createJWT()) );
-		MockHttpServletRequest request = createRequest(JWT_VALIDATION_URI, Methods.GET, null, headers);
 
-		return request;
+		return createRequest(JWT_VALIDATION_URI, Methods.GET, null, headers);
 	}
 
 	private class ApiListenerBuilder {
 
-		private ApiListener listener;
+		private final ApiListener listener;
 
 		public ApiListenerBuilder(String uri, Methods method) throws ListenerException, ConfigurationException {
 			this(uri, method, null, null);
@@ -1200,7 +1239,7 @@ public class ApiListenerServletTest extends Mockito {
 		}
 	}
 
-	private class Response {
+	private static class Response {
 		private MockHttpServletResponse response;
 
 		Response(MockHttpServletResponse response) {

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerTest.java
@@ -66,7 +66,7 @@ public class ApiListenerTest {
 	public void testContentTypes() throws ConfigurationException {
 		for(MediaTypes type : MediaTypes.values()) {
 			listener.setProduces(type);
-			listener.configure(); //Check if the mediatype passes the configure checks
+			listener.configure(); //Check if the media-type passes the 'configure' checks
 
 			assertTrue(listener.getContentType().includes(type.getMimeType()));
 		}
@@ -111,6 +111,30 @@ public class ApiListenerTest {
 
 		listener.setConsumes(MediaTypes.ANY);
 		assertTrue("can parse anything", listener.isConsumable(acceptHeader));
+	}
+
+	@Test
+	public void isConsumableEmptyContentTypeHeader() {
+		// Arrange
+		listener.setConsumes(MediaTypes.ANY);
+
+		// Act / Assert
+		assertTrue("can parse anything", listener.isConsumable(null));
+		assertTrue("can parse anything", listener.isConsumable(""));
+
+		// Arrange
+		listener.setConsumes(MediaTypes.XML);
+
+		// Act / Assert
+		assertFalse("can parse [XML]", listener.isConsumable(null));
+		assertFalse("can parse [XML]", listener.isConsumable(""));
+
+		// Arrange
+		listener.setConsumes(MediaTypes.JSON);
+
+		// Act / Assert
+		assertFalse("can parse [JSON]", listener.isConsumable(null));
+		assertFalse("can parse [JSON]", listener.isConsumable(""));
 	}
 
 	@Test

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/MediaTypeTest.java
@@ -67,6 +67,17 @@ public class MediaTypeTest {
 	}
 
 	@Test
+	public void isConsumableEmptyHeader() {
+		// Act / Assert
+		assertTrue("can parse anything", MediaTypes.ANY.isConsumable(null));
+		assertTrue("can parse anything", MediaTypes.ANY.isConsumable(""));
+		assertFalse("can parse [XML]", MediaTypes.XML.isConsumable(null));
+		assertFalse("can parse [XML]", MediaTypes.XML.isConsumable(""));
+		assertFalse("can parse [JSON]", MediaTypes.JSON.isConsumable(null));
+		assertFalse("can parse [JSON]", MediaTypes.JSON.isConsumable(""));
+	}
+
+	@Test
 	public void isConsumableMULTIPARTS() {
 		//There are different multipart contentTypes, see: https://msdn.microsoft.com/en-us/library/ms527355(v=exchg.10).aspx
 		//Test at least the 3 most commonly used multiparts

--- a/example/src/test/java/nl/nn/adapterframework/extensions/test/TestIbisTester.java
+++ b/example/src/test/java/nl/nn/adapterframework/extensions/test/TestIbisTester.java
@@ -12,10 +12,12 @@ public class TestIbisTester {
 
 	@Test
 	public void runIbisTester() {
+		// Arrange
 		IbisTester ibisTester = new IbisTester();
 		System.setProperty("junit.active", "true");
 		long start = System.currentTimeMillis();
 
+		// Act
 		ibisTester.initTest();
 		String testResult = ibisTester.testStartAdapters();
 		assertNull(testResult, testResult);
@@ -23,8 +25,9 @@ public class TestIbisTester {
 		IbisContext ibisContext = ibisTester.getIbisContext();
 		assertNotNull(ibisContext);
 
-		//Test generic startup time of an ibis with 3 adapters, should take less then 30 seconds.
+		// Assert
+		// Test generic startup time of an ibis with 3 adapters, should take less than 30 seconds.
 		long startupTime = (System.currentTimeMillis() - start);
-		assertTrue(startupTime < 30000, "Application took ["+startupTime+"] to start up!");
+		assertTrue(startupTime < 30_000, "Application took ["+startupTime+"ms] to start up, longer than allowed 30s!");
 	}
 }

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -173,7 +173,7 @@
 		https://bugs.eclipse.org/bugs/show_bug.cgi?id=398138
 		Note: Maven will copy the jar files from the war in the local repository
 		which might be an old snapshot.
-		
+
 		In older versions of Eclipse (Kepler - 20140224-0627) the larva and ladybug modules are not automatically added to the (correct) classpath.
 		Because of this the example module will throw a FileNotFoundException on springIbisTestTool.xml which prevents the IBIS from starting up.
 		In newer versions of Eclipse (at least version 20181214-0600 onwards) this seems to have been resolved.


### PR DESCRIPTION
First draft of changes to make sure XML is not accepted when JSON is specified, or rather: to make sure that when MediaType is specified (any other than `ANY`), the `Content-Type` request header has to be set.

NB: Creating this still as DRAFT PR so far because I still need to run the full test-suite.