### PR TITLE
Fix messageId handling in ApiListenerServlet

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -17,7 +17,12 @@ package nl.nn.adapterframework.http.rest;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import jakarta.mail.BodyPart;
 import jakarta.mail.MessagingException;

--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -17,12 +17,7 @@ package nl.nn.adapterframework.http.rest;
 
 import java.io.IOException;
 import java.time.Instant;
-import java.util.Arrays;
-import java.util.Date;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import jakarta.mail.BodyPart;
 import jakarta.mail.MessagingException;
@@ -544,24 +539,10 @@ public class ApiListenerServlet extends HttpServletBase {
 				}
 				messageContext.put("allowedMethods", methods.substring(0, methods.length()-2));
 
-				String messageId = null;
-				if(StringUtils.isNotEmpty(listener.getMessageIdHeader())) {
-					String messageIdHeader = request.getHeader(listener.getMessageIdHeader());
-					if(StringUtils.isNotEmpty(messageIdHeader)) {
-						messageId = messageIdHeader;
-					}
-				}
-				String correlationId = null;
-				if(StringUtils.isNotEmpty(listener.getCorrelationIdHeader())) {
-					String correlationIdHeaderValue = request.getHeader(listener.getCorrelationIdHeader());
-					if(StringUtils.isNotEmpty(correlationIdHeaderValue)) {
-						messageId = correlationIdHeaderValue;
-					}
-				}
-				if (StringUtils.isEmpty(correlationId) && StringUtils.isNotEmpty(messageId)) {
-					correlationId = messageId;
-				}
+				final String messageId = getHeaderOrDefault(request, listener.getMessageIdHeader(), null);
+				final String correlationId = getHeaderOrDefault(request, listener.getCorrelationIdHeader(), messageId);
 				PipeLineSession.setListenerParameters(messageContext, messageId, correlationId, null, null); //We're only using this method to keep setting mid/cid uniform
+
 				Message result = listener.processRequest(body, messageContext);
 
 				/*
@@ -689,6 +670,14 @@ public class ApiListenerServlet extends HttpServletBase {
 				}
 			}
 		}
+	}
+
+	private String getHeaderOrDefault(HttpServletRequest request, String headerName, String defaultValue) {
+		if (StringUtils.isBlank(headerName)) {
+			return defaultValue;
+		}
+		final String headerValue = request.getHeader(headerName);
+		return StringUtils.isNotBlank(headerValue) ? headerValue : defaultValue;
 	}
 
 	@Override

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
@@ -957,6 +957,57 @@ public class ApiListenerServletTest extends Mockito {
 	}
 
 	@Test
+	public void testRequestWithMessageId() throws ServletException, IOException, ListenerException, ConfigurationException {
+		// Arrange
+		String uri = "/messageIdTest1";
+		new ApiListenerBuilder(uri, Methods.POST)
+			.setMessageIdHeader("X-Message-ID")
+			.setCorrelationIdHeader("X-Correlation-ID")
+			.build();
+
+		Map<String, String> headers = new HashMap<>();
+		headers.put("X-Message-ID", "msg1");
+		HttpServletRequest request = createRequest(uri, Methods.POST, "{\"tralalalallala\":true}", headers);
+
+		// Act
+		Response result = service(request);
+
+		// Assert
+		assertEquals(200, result.getStatus());
+		assertTrue(session.containsKey(PipeLineSession.messageIdKey));
+		assertEquals("msg1", session.get(PipeLineSession.messageIdKey));
+		assertTrue(session.containsKey(PipeLineSession.correlationIdKey));
+		assertEquals("msg1", session.get(PipeLineSession.correlationIdKey));
+		assertNull(result.getErrorMessage());
+	}
+
+	@Test
+	public void testRequestWithMessageIdAndCorrelationId() throws ServletException, IOException, ListenerException, ConfigurationException {
+		// Arrange
+		String uri = "/messageIdTest2";
+		new ApiListenerBuilder(uri, Methods.POST)
+			.setMessageIdHeader("X-Message-ID")
+			.setCorrelationIdHeader("X-Correlation-ID")
+			.build();
+
+		Map<String, String> headers = new HashMap<>();
+		headers.put("X-Message-ID", "msg1");
+		headers.put("X-Correlation-ID", "msg2");
+		HttpServletRequest request = createRequest(uri, Methods.POST, "{\"tralalalallala\":true}", headers);
+
+		// Act
+		Response result = service(request);
+
+		// Assert
+		assertEquals(200, result.getStatus());
+		assertTrue(session.containsKey(PipeLineSession.messageIdKey));
+		assertEquals("msg1", session.get(PipeLineSession.messageIdKey));
+		assertTrue(session.containsKey(PipeLineSession.correlationIdKey));
+		assertEquals("msg2", session.get(PipeLineSession.correlationIdKey));
+		assertNull(result.getErrorMessage());
+	}
+
+	@Test
 	public void testJwtTokenParsingWithRequiredIssuer() throws Exception {
 		new ApiListenerBuilder(JWT_VALIDATION_URI, Methods.GET)
 			.setJwksURL(TestFileUtils.getTestFileURL("/JWT/jwks.json").toString())
@@ -1238,6 +1289,16 @@ public class ApiListenerServletTest extends Mockito {
 
 		public ApiListenerBuilder setExactMatchClaims(String exactMatchClaims) {
 			listener.setExactMatchClaims(exactMatchClaims);
+			return this;
+		}
+
+		public ApiListenerBuilder setMessageIdHeader(String headerName) {
+			listener.setMessageIdHeader(headerName);
+			return this;
+		}
+
+		public ApiListenerBuilder setCorrelationIdHeader(String headerName) {
+			listener.setCorrelationIdHeader(headerName);
 			return this;
 		}
 


### PR DESCRIPTION
Fix messageId handling in ApiListenerServlet when the correlationId header is also present.
