### PR TITLE
Return status 400 (instead of 500) for bad multipart requests (#4295)

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
+++ b/core/src/main/java/nl/nn/adapterframework/http/rest/ApiListenerServlet.java
@@ -525,7 +525,9 @@ public class ApiListenerServlet extends HttpServletBase {
 						}
 						messageContext.put("multipartAttachments", attachments.toXML());
 					} catch(MessagingException e) {
-						throw new IOException("Could not read mime multipart response", e);
+						response.sendError(400, "Could not read mime multipart response");
+						log.warn(createAbortMessage(remoteUser, 400) + "Could not read mime multipart response");
+						return;
 					}
 				} else {
 					body = MessageUtils.parseContentAsMessage(request);

--- a/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/http/rest/ApiListenerServletTest.java
@@ -567,6 +567,24 @@ public class ApiListenerServletTest extends Mockito {
 	}
 
 	@Test
+	public void listenerInvalidMultipartContent() throws ServletException, IOException, ListenerException, ConfigurationException {
+
+		// Arrange
+		String uri="/listenerMultipartContentNoContent";
+		new ApiListenerBuilder(uri, Methods.POST, MediaTypes.MULTIPART, MediaTypes.JSON).build();
+
+		MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+		HttpServletRequest request = createRequest(uri, Methods.POST, builder.build());
+
+		// Act
+		Response result = service(request);
+
+		// Assert
+		assertEquals(400, result.getStatus());
+		assertEquals("Could not read mime multipart response", result.getErrorMessage());
+	}
+
+	@Test
 	public void getRequestWithQueryParameters() throws ServletException, IOException, ListenerException, ConfigurationException {
 		String uri="/queryParamTest";
 		new ApiListenerBuilder(uri, Methods.GET).build();


### PR DESCRIPTION
(cherry picked from commit 3b134b68c47b811889dc4a99270a1f9572a940d5)