### PR TITLE
Backport of 'Migrate to new MySql maven project'

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -834,8 +834,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<version>${mysql.driver.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/docker/appserver/JBoss/pom.xml
+++ b/docker/appserver/JBoss/pom.xml
@@ -42,8 +42,8 @@
 			<version>${mssql.driver.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<version>${mysql.driver.version}</version>
 		</dependency>
 		<dependency>

--- a/docker/appserver/Tomcat/pom.xml
+++ b/docker/appserver/Tomcat/pom.xml
@@ -34,8 +34,8 @@
 			<version>${mssql.driver.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<version>${mysql.driver.version}</version>
 		</dependency>
 		<dependency>

--- a/docker/appserver/WebSphere/pom.xml
+++ b/docker/appserver/WebSphere/pom.xml
@@ -53,8 +53,8 @@
 			<version>${mssql.driver.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<version>${mysql.driver.version}</version>
 		</dependency>
 		<dependency>

--- a/docker/appserver/WebSphere/src/scripts/configureJdbc.py
+++ b/docker/appserver/WebSphere/src/scripts/configureJdbc.py
@@ -48,7 +48,7 @@ def createDatasource(datasourceName, providerName, authAlias, properties):
 createTemplatedProvider('Oracle JDBC Driver (XA)', 		 'oracle.jdbc.xa.client.OracleXADataSource', 		'/work/drivers/ojdbc${oracle.driver.jdkversion}.jar')
 createTemplatedProvider('Microsoft SQL Server JDBC Driver (XA)', 'com.microsoft.sqlserver.jdbc.SQLServerXADataSource',  '/work/drivers/mssql-jdbc.jar')
 createProvider('H2 JDBC Driver (XA)', 'org.h2.jdbcx.JdbcDataSource', 'classpath=/work/drivers/h2.jar,xa=true')
-createProvider('MySQL JDBC Driver', 'com.mysql.cj.jdbc.MysqlXADataSource', 'classpath=/work/drivers/mysql-connector-java.jar')
+createProvider('MySQL JDBC Driver', 'com.mysql.cj.jdbc.MysqlXADataSource', 'classpath=/work/drivers/mysql-connector-j.jar')
 createProvider('PostgreSQL JDBC Driver', 'org.postgresql.xa.PGXADataSource', 'classpath=/work/drivers/postgresql.jar')
 
 createDatasource('ibis4test-h2', 'H2 JDBC Driver (XA)', [], [

--- a/docker/appserver/WildFly/pom.xml
+++ b/docker/appserver/WildFly/pom.xml
@@ -42,8 +42,8 @@
 			<version>${mssql.driver.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>mysql</groupId>
-			<artifactId>mysql-connector-java</artifactId>
+			<groupId>com.mysql</groupId>
+			<artifactId>mysql-connector-j</artifactId>
 			<version>${mysql.driver.version}</version>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Backport of PR https://github.com/ibissource/iaf/pull/3903.
Mysql artefact has moved, was already fixed in master. Now added to 7.8 branch for proper testing of jenkin issues