### PR TITLE
SQL injections warning not suppressed

### DIFF
--- a/copyrightExcludeFile.txt
+++ b/copyrightExcludeFile.txt
@@ -4,6 +4,8 @@ src/test/
 src\test\
 webapp/
 webapp\
+overlays/
+overlays\
 docker/
 docker\
 .metadata/

--- a/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ShowSecurityItems.java
+++ b/core/src/main/java/nl/nn/adapterframework/webcontrol/api/ShowSecurityItems.java
@@ -302,7 +302,7 @@ public final class ShowSecurityItems extends Base {
 
 		String dsInfo = null;
 		try {
-			qs.configure();
+			qs.configure(true);
 			dsInfo = qs.getDatasourceInfo();
 		} catch (JdbcException | ConfigurationException e) {
 			log.debug("no datasource ("+ClassUtils.nameOf(e)+"): "+e.getMessage());


### PR DESCRIPTION
This change fixes the SQL Injection Warning that is triggered from the Security Items page; I have tested this using IAF Example (with and without the change) however I'm not sure if adding a unit-test is worth the effort?

NB: The bug only applies to 7.8 and earlier. It does not apply to 7.9, as the code for the Security Items has changed and no longer triggers this warning.

