### PR TITLE
Fix ActiveMQ 5.16.5 issue in 7.8 release

### DIFF
--- a/docker/appserver/JBoss/src/configuration/standalone.xml
+++ b/docker/appserver/JBoss/src/configuration/standalone.xml
@@ -551,7 +551,7 @@
 	              	<archive>activemq-rar.rar</archive>
 	                <transaction-support>XATransaction</transaction-support>  
 	                <config-property name="ServerUrl">  
-	                    tcp://host.docker.internal:61616
+	                    tcp://host.docker.internal:61616?jms.xaAckMode=1
 	                </config-property>  
 	                <connection-definitions>  
 	                    <connection-definition class-name="org.apache.activemq.ra.ActiveMQManagedConnectionFactory" jndi-name="jms/qcf-activemq" enabled="true" use-java-context="true" pool-name="jms/qcf-activemq" use-ccm="true">

--- a/docker/appserver/WebSphere/src/scripts/configureJms.py
+++ b/docker/appserver/WebSphere/src/scripts/configureJms.py
@@ -20,7 +20,7 @@ def createGenericJMSDestination(jmsProviderName, name, jndiName, extJndiName):
 	return(jmsDestinationId)
 
 # ActiveMQ
-createJMSProvider('ActiveMQ', 'org.apache.activemq.jndi.ActiveMQInitialContextFactory', 'tcp://host.docker.internal:61616', 'classpath=/work/drivers/activemq-client.jar;/work/drivers/hawtbuf.jar;/work/drivers/slf4j-api.jar')
+createJMSProvider('ActiveMQ', 'org.apache.activemq.jndi.ActiveMQInitialContextFactory', 'tcp://host.docker.internal:61616?jms.xaAckMode=1', 'classpath=/work/drivers/activemq-client.jar;/work/drivers/hawtbuf.jar;/work/drivers/slf4j-api.jar')
 
 createGenericJMSCF('ActiveMQ', 'qcf', 'jms/qcf-activemq', 'XAConnectionFactory')
 

--- a/docker/appserver/WildFly/src/configuration/standalone.xml
+++ b/docker/appserver/WildFly/src/configuration/standalone.xml
@@ -560,7 +560,7 @@
 	              	<archive>activemq-rar.rar</archive>
 	                <transaction-support>XATransaction</transaction-support>  
 	                <config-property name="ServerUrl">  
-	                    tcp://host.docker.internal:61616
+	                    tcp://host.docker.internal:61616?jms.xaAckMode=1
 	                </config-property>  
 	                <connection-definitions>  
 	                    <connection-definition class-name="org.apache.activemq.ra.ActiveMQManagedConnectionFactory" jndi-name="jms/qcf-activemq" enabled="true" use-java-context="true" pool-name="jms/qcf-activemq" use-ccm="true">

--- a/test/src/main/webapp/META-INF/context.xml
+++ b/test/src/main/webapp/META-INF/context.xml
@@ -178,7 +178,7 @@
 	<Resource name="jms/qcf-activemq"
 		factory="org.apache.naming.factory.BeanFactory"
 		type="org.apache.activemq.ActiveMQXAConnectionFactory"
-		brokerURL="tcp://host.docker.internal:61616"
+		brokerURL="tcp://host.docker.internal:61616?jms.xaAckMode=1"
 	/>
 
 	<!-- Activemq-artemis resource configuration -->


### PR DESCRIPTION
When using ActiveMQ version 5.16.0 or higher "jms.xaAckMode=1" is need in the connection string to still be able to use an XAConnection/XASession without a transaction.

See [release notes ActiveMQ 5.16.0](https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12311210&version=12341032) Bug [AMQ-2659](https://issues.apache.org/jira/browse/AMQ-2659)

