### PR TITLE
Change WSDL endpoints and Increase JMS scenario timeouts

### DIFF
--- a/test/src/main/configurations/JDBC/ConfigurationManageDatabaseWrapper.xml
+++ b/test/src/main/configurations/JDBC/ConfigurationManageDatabaseWrapper.xml
@@ -17,6 +17,7 @@
 				className="nl.nn.adapterframework.pipes.PutInSession">
 				<param name="expectedNumberOfResults" sessionKey="expectedNumberOfResults" defaultValue="-1"/>
 				<param name="numberOfAttempts" sessionKey="numberOfAttempts" defaultValue="10"/>
+				<param name="timeout" sessionKey="timeout" defaultValue="1000"/>
 				<forward name="success" path="SendToManageDatabase"/>
 			</pipe>
 			
@@ -63,8 +64,14 @@
 				<forward name="equals" path="EXIT" />
 			</pipe>
 			
-			<pipe name="Wait" 
-				className="nl.nn.adapterframework.pipes.DelayPipe" delayTime="1000">
+			<pipe name="Wait" className="nl.nn.adapterframework.pipes.XmlIf" getInputFromSessionKey="timeout" regex="5000" >
+				<forward name="then" path="Wait5000"/>
+				<forward name="else" path="Wait1000"/>
+			</pipe>
+			<pipe name="Wait1000" className="nl.nn.adapterframework.pipes.DelayPipe" delayTime="1000">
+				<forward name="success" path="SendToManageDatabase" />
+			</pipe>
+			<pipe name="Wait5000" className="nl.nn.adapterframework.pipes.DelayPipe" delayTime="5000">
 				<forward name="success" path="SendToManageDatabase" />
 			</pipe>
 		</pipeline>

--- a/test/src/test/testtool/ApiWsdlGenerator/common.properties
+++ b/test/src/test/testtool/ApiWsdlGenerator/common.properties
@@ -1,10 +1,10 @@
 include = ../global.properties
 
 http.ApiWsdlGenerator.className=nl.nn.adapterframework.http.HttpSender
-http.ApiWsdlGenerator.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/iaf/api/webservices/ApiWsdlGenerator.wsdl
+http.ApiWsdlGenerator.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/iaf/api/webservices/MainConfig/ApiWsdlGenerator.wsdl
 
 http.ApiWsdlGeneratorMultipart.className=nl.nn.adapterframework.http.HttpSender
-http.ApiWsdlGeneratorMultipart.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/iaf/api/webservices/ApiWsdlGeneratorMultipart.wsdl
+http.ApiWsdlGeneratorMultipart.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/iaf/api/webservices/MainConfig/ApiWsdlGeneratorMultipart.wsdl
 
 replaceRegularExpressionKeys.ApiWsdlGenerator-Timestamp.key1=\\son\\s\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}
 replaceRegularExpressionKeys.ApiWsdlGenerator-Timestamp.key2= on 2020-04-23T14:30:08

--- a/test/src/test/testtool/JmsListenerSender/FF/scenario03.properties
+++ b/test/src/test/testtool/JmsListenerSender/FF/scenario03.properties
@@ -7,6 +7,8 @@ manage.dbwrapper.param1.name=expectedNumberOfResults
 manage.dbwrapper.param1.value=2
 manage.dbwrapper.param2.name=numberOfAttempts
 manage.dbwrapper.param2.value=20
+manage.dbwrapper.param3.name=timeout
+manage.dbwrapper.param3.value=5000
 
 step1.java.XmlJmsBrowserSender.write = common/remove-in.xml
 step2.java.XmlJmsBrowserSender.read = common/remove-out.xml

--- a/test/src/test/testtool/JmsListenerSender/FF/scenario04.properties
+++ b/test/src/test/testtool/JmsListenerSender/FF/scenario04.properties
@@ -4,7 +4,7 @@ scenario.active=${active.jms}
 include = common.properties
 
 manage.dbwrapper.param1.name=expectedNumberOfResults
-manage.dbwrapper.param1.value=2
+manage.dbwrapper.param1.value=1
 manage.dbwrapper.param2.name=numberOfAttempts
 manage.dbwrapper.param2.value=20
 manage.dbwrapper.param3.name=timeout

--- a/test/src/test/testtool/JmsListenerSender/FF/scenario04.properties
+++ b/test/src/test/testtool/JmsListenerSender/FF/scenario04.properties
@@ -4,9 +4,11 @@ scenario.active=${active.jms}
 include = common.properties
 
 manage.dbwrapper.param1.name=expectedNumberOfResults
-manage.dbwrapper.param1.value=1
+manage.dbwrapper.param1.value=2
 manage.dbwrapper.param2.name=numberOfAttempts
 manage.dbwrapper.param2.value=20
+manage.dbwrapper.param3.name=timeout
+manage.dbwrapper.param3.value=5000
 
 step1.java.XmlJmsBrowserSender.write = common/remove-in.xml
 step2.java.XmlJmsBrowserSender.read = common/remove-out.xml

--- a/test/src/test/testtool/Validators/Schema/openapi-json.json
+++ b/test/src/test/testtool/Validators/Schema/openapi-json.json
@@ -15,6 +15,13 @@
             "get":{
                 "parameters":[
                     {
+                        "name": "Message-Id",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name":"Status",
                         "in":"query",
                         "schema":{

--- a/test/src/test/testtool/Validators/Schema/openapi-soap.json
+++ b/test/src/test/testtool/Validators/Schema/openapi-soap.json
@@ -15,6 +15,13 @@
             "get":{
                 "parameters":[
                     {
+                        "name": "Message-Id",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name":"Status",
                         "in":"query",
                         "schema":{

--- a/test/src/test/testtool/Validators/Schema/openapi_post.json
+++ b/test/src/test/testtool/Validators/Schema/openapi_post.json
@@ -24,6 +24,13 @@
                 },
                 "parameters":[
                     {
+                        "name": "Message-Id",
+                        "in": "header",
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
                         "name":"Status",
                         "in":"query",
                         "schema":{

--- a/test/src/test/testtool/Validators/SoapValidator/common.properties
+++ b/test/src/test/testtool/Validators/SoapValidator/common.properties
@@ -13,5 +13,5 @@ api.SoapAndRestSchema.url=${web.protocol}://${web.host}:${web.port}${web.context
 api.SoapAndRestSchema.authAlias=${framework.api.user.alias}
 
 api.SoapAndRestWsdl.className=nl.nn.adapterframework.http.HttpSender
-api.SoapAndRestWsdl.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/iaf/api/webservices/SoapValidator.wsdl
+api.SoapAndRestWsdl.url=${web.protocol}://${web.host}:${web.port}${web.contextpath}/iaf/api/webservices/MainConfig/SoapValidator.wsdl
 api.SoapAndRestWsdl.authAlias=${framework.api.user.alias}


### PR DESCRIPTION
Increase timeouts for 2 iffy iaf-test scenario's back to their originals from  #4151
- /JmsListenerSender/FF/scenario03 - JmsFFSender OK, exception in listener, with a missing 'E' record in the errorstore,
- /JmsListenerSender/FF/scenario04 - JmsFFSenderWithDatasource OK. with an unexpected message on the queue.