### PR TITLE
Remove xaAckMode for JBoss and WildFly

### DIFF
--- a/docker/appserver/JBoss/src/configuration/standalone.xml
+++ b/docker/appserver/JBoss/src/configuration/standalone.xml
@@ -551,7 +551,7 @@
 	              	<archive>activemq-rar.rar</archive>
 	                <transaction-support>XATransaction</transaction-support>  
 	                <config-property name="ServerUrl">  
-	                    tcp://host.docker.internal:61616?jms.xaAckMode=1
+	                    tcp://host.docker.internal:61616
 	                </config-property>  
 	                <connection-definitions>  
 	                    <connection-definition class-name="org.apache.activemq.ra.ActiveMQManagedConnectionFactory" jndi-name="jms/qcf-activemq" enabled="true" use-java-context="true" pool-name="jms/qcf-activemq" use-ccm="true">

--- a/docker/appserver/WildFly/src/configuration/standalone.xml
+++ b/docker/appserver/WildFly/src/configuration/standalone.xml
@@ -560,7 +560,7 @@
 	              	<archive>activemq-rar.rar</archive>
 	                <transaction-support>XATransaction</transaction-support>  
 	                <config-property name="ServerUrl">  
-	                    tcp://host.docker.internal:61616?jms.xaAckMode=1
+	                    tcp://host.docker.internal:61616
 	                </config-property>  
 	                <connection-definitions>  
 	                    <connection-definition class-name="org.apache.activemq.ra.ActiveMQManagedConnectionFactory" jndi-name="jms/qcf-activemq" enabled="true" use-java-context="true" pool-name="jms/qcf-activemq" use-ccm="true">


### PR DESCRIPTION
As mentioned before in PR #3690, do not set xaAckMode for JBoss and WildFly.
