### PR TITLE
Add mailbox reference to mail-messages

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeAttachmentReference.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeAttachmentReference.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeAttachmentReference.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeAttachmentReference.java
@@ -1,0 +1,39 @@
+/*
+   Copyright 2022 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.filesystem;
+
+import javax.annotation.Nonnull;
+
+import lombok.Getter;
+import microsoft.exchange.webservices.data.property.complex.Attachment;
+
+/**
+ * Reference to an attachment of an Exchange message, together with the {@link ExchangeObjectReference} to the
+ * mailbox from which the attachment originated.
+ */
+public class ExchangeAttachmentReference {
+	private final @Getter @Nonnull ExchangeObjectReference mailFolder;
+	private final @Getter @Nonnull Attachment attachment;
+
+	private ExchangeAttachmentReference(final @Nonnull ExchangeObjectReference mailFolder, @Nonnull Attachment attachment) {
+		this.mailFolder = mailFolder;
+		this.attachment = attachment;
+	}
+
+	public static ExchangeAttachmentReference of(final @Nonnull ExchangeObjectReference mailFolder, @Nonnull Attachment attachment) {
+		return new ExchangeAttachmentReference(mailFolder, attachment);
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -984,7 +984,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 		try {
 			return cleanAddress(emailMessage.getFrom());
 		} catch (ServiceLocalException e) {
-			log.warn("Could not get From Address: {}", e.getMessage());
+			log.warn("Could not get From Address: {}", e::getMessage);
 			return null;
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -1117,7 +1117,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 		// only set impersonated user in oauth situation
 		if (client != null) {
 			ImpersonatedUserId impersonatedUserId = new ImpersonatedUserId(ConnectingIdType.SmtpAddress, mailbox);
-			log.debug("Set mailservice impersonated user ID to [{}]", impersonatedUserId);
+			log.debug("Set mailservice impersonated user ID to [{}]", impersonatedUserId.getId());
 			service.setImpersonatedUserId(impersonatedUserId);
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -57,7 +57,6 @@ import microsoft.exchange.webservices.data.core.enumeration.service.DeleteMode;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceLocalException;
 import microsoft.exchange.webservices.data.core.exception.service.local.ServiceVersionException;
 import microsoft.exchange.webservices.data.core.exception.service.remote.ServiceResponseException;
-import microsoft.exchange.webservices.data.core.response.ServiceResponse;
 import microsoft.exchange.webservices.data.core.service.folder.Folder;
 import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 import microsoft.exchange.webservices.data.core.service.item.Item;
@@ -69,7 +68,6 @@ import microsoft.exchange.webservices.data.credential.ExchangeCredentials;
 import microsoft.exchange.webservices.data.credential.WebCredentials;
 import microsoft.exchange.webservices.data.credential.WebProxyCredentials;
 import microsoft.exchange.webservices.data.misc.ImpersonatedUserId;
-import microsoft.exchange.webservices.data.misc.SoapFaultDetails;
 import microsoft.exchange.webservices.data.property.complex.Attachment;
 import microsoft.exchange.webservices.data.property.complex.AttachmentCollection;
 import microsoft.exchange.webservices.data.property.complex.EmailAddress;
@@ -114,25 +112,26 @@ import nl.nn.adapterframework.xml.SaxElementBuilder;
  *     	<li>Configure the tenantId which could be retrieved from Azure AD -> App Registrations -> MyApp -> Overview</li>
  * 		<li>Make sure your application is able to reach <code>https://login.microsoftonline.com</code>. Required for token retrieval. </li>
  * </ol>
- *
- *
+ * <p>
+ * <p>
  * N.B. MS Exchange is susceptible to problems with invalid XML characters, like &amp;#x3;.
  * To work around these problems, a special streaming XMLInputFactory is configured in
  * METAINF/services/javax.xml.stream.XMLInputFactory as nl.nn.adapterframework.xml.StaxParserFactory
  *
  * @author Peter Leeuwenburgh (as {@link ExchangeMailListener})
  * @author Gerrit van Brakel
- *
  */
-public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachment,ExchangeService> implements HasKeystore, HasTruststore {
+public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageReference, ExchangeAttachmentReference, ExchangeService> implements HasKeystore, HasTruststore {
+	public static final byte[] EMPTY_MESSAGE_CONTENT = new byte[0];
 	private final @Getter(onMethod = @__(@Override)) String domain = "Exchange";
 	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
-	private @Getter @Setter ApplicationContext applicationContext;
-	private @Getter String name="ExchangeFileSystem";
+	private @Getter
+	@Setter ApplicationContext applicationContext;
+	private @Getter String name = "ExchangeFileSystem";
 
 	private @Getter String mailAddress;
-	private @Getter String mailboxObjectSeparator="|";
-	private @Getter boolean validateAllRedirectUrls=true;
+	private @Getter String mailboxObjectSeparator = "|";
+	private @Getter boolean validateAllRedirectUrls = true;
 	private @Getter String url;
 	private @Getter String filter;
 
@@ -151,27 +150,44 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	private @Getter String tenantId = null;
 
 	/* SSL */
-	private @Getter @Setter String keystore;
-	private @Getter @Setter String keystoreAuthAlias;
-	private @Getter @Setter String keystorePassword;
-	private @Getter @Setter KeystoreType keystoreType=KeystoreType.PKCS12;
-	private @Getter @Setter String keystoreAlias;
-	private @Getter @Setter String keystoreAliasAuthAlias;
-	private @Getter @Setter String keystoreAliasPassword;
-	private @Getter @Setter String keyManagerAlgorithm=null;
+	private @Getter
+	@Setter String keystore;
+	private @Getter
+	@Setter String keystoreAuthAlias;
+	private @Getter
+	@Setter String keystorePassword;
+	private @Getter
+	@Setter KeystoreType keystoreType = KeystoreType.PKCS12;
+	private @Getter
+	@Setter String keystoreAlias;
+	private @Getter
+	@Setter String keystoreAliasAuthAlias;
+	private @Getter
+	@Setter String keystoreAliasPassword;
+	private @Getter
+	@Setter String keyManagerAlgorithm = null;
 
-	private @Getter @Setter String truststore=null;
-	private @Getter @Setter String truststoreAuthAlias;
-	private @Getter @Setter String truststorePassword=null;
-	private @Getter @Setter KeystoreType truststoreType=KeystoreType.JKS;
-	private @Getter @Setter String trustManagerAlgorithm=null;
-	private @Getter @Setter boolean allowSelfSignedCertificates = false;
-	private @Getter @Setter boolean verifyHostname=true;
-	private @Getter @Setter boolean ignoreCertificateExpiredException=false;
-	private @Getter @Setter boolean enableConnectionTracing=false;
+	private @Getter
+	@Setter String truststore = null;
+	private @Getter
+	@Setter String truststoreAuthAlias;
+	private @Getter
+	@Setter String truststorePassword = null;
+	private @Getter
+	@Setter KeystoreType truststoreType = KeystoreType.JKS;
+	private @Getter
+	@Setter String trustManagerAlgorithm = null;
+	private @Getter
+	@Setter boolean allowSelfSignedCertificates = false;
+	private @Getter
+	@Setter boolean verifyHostname = true;
+	private @Getter
+	@Setter boolean ignoreCertificateExpiredException = false;
+	private @Getter
+	@Setter boolean enableConnectionTracing = false;
 
-	private @Getter CredentialFactory credentials=null;
-	private @Getter CredentialFactory proxyCredentials=null;
+	private @Getter CredentialFactory credentials = null;
+	private @Getter CredentialFactory proxyCredentials = null;
 
 	private ConfidentialClientApplication client;
 	private MsalClientAdapter msalClientAdapter;
@@ -185,7 +201,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		log.debug("Configuring the ExchangeFileSystem spring bean");
 		if (StringUtils.isNotEmpty(getFilter())) {
 			if (!getFilter().equalsIgnoreCase("NDR")) {
-				throw new ConfigurationException("illegal value for filter [" + getFilter()	+ "], must be 'NDR' or empty");
+				throw new ConfigurationException("illegal value for filter [" + getFilter() + "], must be 'NDR' or empty");
 			}
 		}
 		if (StringUtils.isEmpty(getUrl()) && StringUtils.isEmpty(getMailAddress())) {
@@ -201,12 +217,12 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			proxyCredentials = new CredentialFactory(getProxyAuthAlias(), getProxyUsername(), getProxyPassword());
 		}
 
-		if( StringUtils.isNotEmpty(getTenantId()) ){
-			msalClientAdapter = applicationContext!=null ? SpringUtils.createBean(applicationContext, MsalClientAdapter.class): new MsalClientAdapter();
+		if (StringUtils.isNotEmpty(getTenantId())) {
+			msalClientAdapter = applicationContext != null ? SpringUtils.createBean(applicationContext, MsalClientAdapter.class) : new MsalClientAdapter();
 			msalClientAdapter.setProxyHost(getProxyHost());
 			msalClientAdapter.setProxyPort(getProxyPort());
 			CredentialFactory proxyCf = getProxyCredentials();
-			if (proxyCf!=null) {
+			if (proxyCf != null) {
 				msalClientAdapter.setProxyUsername(proxyCf.getUsername());
 				msalClientAdapter.setProxyPassword(proxyCf.getPassword());
 			}
@@ -241,7 +257,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	public void open() throws FileSystemException {
 		log.debug("Opening the ExchangeFileSystem");
 		super.open();
-		if( msalClientAdapter != null ){
+		if (msalClientAdapter != null) {
 			executor = Executors.newSingleThreadExecutor(); //Create a new Executor in the same thread(context) to avoid SecurityExceptions when setting a ClassLoader on the Runnable.
 
 			CredentialFactory cf = getCredentials();
@@ -260,7 +276,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 				throw new FileSystemException("Failed to initialize MSAL ConfidentialClientApplication.", e);
 			}
 		}
-		basefolderId = getBaseFolderId(getMailAddress(),getBaseFolder());
+		basefolderId = getBaseFolderId(getMailAddress(), getBaseFolder());
 	}
 
 	@Override
@@ -268,14 +284,14 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		log.debug("Closing the ExchangeFileSystem");
 		try {
 			super.close();
-			if(msalClientAdapter != null){
+			if (msalClientAdapter != null) {
 				msalClientAdapter.close();
 				client = null;
 			}
-		} catch (SenderException e){
+		} catch (SenderException e) {
 			throw new FileSystemException("An exception occurred during closing of MSAL HttpClient", e);
 		} finally {
-			if(executor != null) {
+			if (executor != null) {
 				executor.shutdown();
 				executor = null;
 			}
@@ -293,23 +309,23 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		} else {
 			inboxId = new FolderId(WellKnownFolderName.Inbox);
 		}
-		log.debug("determined inbox ["+inboxId+"] foldername ["+inboxId.getFolderName()+"]");
+		log.debug("determined inbox [" + inboxId + "] foldername [" + inboxId.getFolderName() + "]");
 
 		if (StringUtils.isNotEmpty(baseFolderName)) {
 			try {
-				basefolderId=findFolder(inboxId,baseFolderName);
+				basefolderId = findFolder(inboxId, baseFolderName);
 			} catch (Exception e) {
-				throw new FileSystemException("Could not find baseFolder ["+baseFolderName+"] as subfolder of ["+inboxId.getFolderName()+"]", e);
+				throw new FileSystemException("Could not find baseFolder [" + baseFolderName + "] as subfolder of [" + inboxId.getFolderName() + "]", e);
 			}
-			if (basefolderId==null) {
-				log.debug("Could not get baseFolder ["+baseFolderName+"] as subfolder of ["+inboxId.getFolderName()+"]");
-				basefolderId=findFolder(null,baseFolderName);
+			if (basefolderId == null) {
+				log.debug("Could not get baseFolder [" + baseFolderName + "] as subfolder of [" + inboxId.getFolderName() + "]");
+				basefolderId = findFolder(null, baseFolderName);
 			}
-			if (basefolderId==null) {
-				throw new FileSystemException("Could not find baseFolder ["+baseFolderName+"]");
+			if (basefolderId == null) {
+				throw new FileSystemException("Could not find baseFolder [" + baseFolderName + "]");
 			}
 		} else {
-			basefolderId=inboxId;
+			basefolderId = inboxId;
 		}
 		return basefolderId;
 	}
@@ -329,8 +345,8 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			try {
 				String token = future.get().accessToken();
 				// use OAuth Bearer token authentication
-				exchangeService.getHttpHeaders().put("Authorization", "Bearer "+token);
-			} catch (Exception e){
+				exchangeService.getHttpHeaders().put("Authorization", "Bearer " + token);
+			} catch (Exception e) {
 				throw new FileSystemException("Could not generate access token!", e);
 			}
 		} else {
@@ -341,13 +357,13 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			exchangeService.setCredentials(exchangeCredentials);
 		}
 
-		if(StringUtils.isNotEmpty(getMailAddress())){
+		if (StringUtils.isNotEmpty(getMailAddress())) {
 			setMailboxOnService(exchangeService, getMailAddress());
 		}
 
 		if (StringUtils.isNotEmpty(getProxyHost())) {
 			CredentialFactory proxyCf = getProxyCredentials();
-			WebProxyCredentials webProxyCredentials = proxyCf !=null ? new WebProxyCredentials(proxyCf.getUsername(), proxyCf.getPassword(), getProxyDomain()) : null;
+			WebProxyCredentials webProxyCredentials = proxyCf != null ? new WebProxyCredentials(proxyCf.getUsername(), proxyCf.getPassword(), getProxyDomain()) : null;
 			WebProxy webProxy = new WebProxy(getProxyHost(), getProxyPort(), webProxyCredentials);
 			exchangeService.setWebProxy(webProxy);
 		}
@@ -357,31 +373,31 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			@Override
 			public boolean autodiscoverRedirectionUrlValidationCallback(String redirectionUrl) {
 				if (isValidateAllRedirectUrls()) {
-					log.debug("validated redirection url ["+redirectionUrl+"]");
+					log.debug("validated redirection url [" + redirectionUrl + "]");
 					return true;
 				}
-				log.debug("did not validate redirection url ["+redirectionUrl+"]");
+				log.debug("did not validate redirection url [" + redirectionUrl + "]");
 				return super.autodiscoverRedirectionUrlValidationCallback(redirectionUrl);
 			}
 
 		};
 
 		if (StringUtils.isEmpty(getUrl())) {
-			log.debug("performing autodiscovery for ["+getMailAddress()+"]");
+			log.debug("performing autodiscovery for [" + getMailAddress() + "]");
 			try {
-				exchangeService.autodiscoverUrl(getMailAddress(),redirectionUrlCallback);
+				exchangeService.autodiscoverUrl(getMailAddress(), redirectionUrlCallback);
 				//TODO call setUrl() here to avoid repeated autodiscovery
 			} catch (Exception e) {
-				throw new FileSystemException("cannot autodiscover for ["+getMailAddress()+"]", e);
+				throw new FileSystemException("cannot autodiscover for [" + getMailAddress() + "]", e);
 			}
 		} else {
 			try {
 				exchangeService.setUrl(new URI(getUrl()));
 			} catch (URISyntaxException e) {
-				throw new FileSystemException("cannot set URL ["+getUrl()+"]", e);
+				throw new FileSystemException("cannot set URL [" + getUrl() + "]", e);
 			}
 		}
-		log.debug("using url ["+exchangeService.getUrl()+"]");
+		log.debug("using url [" + exchangeService.getUrl() + "]");
 		return exchangeService;
 	}
 
@@ -422,17 +438,17 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		FolderView folderViewIn = new FolderView(10);
 		SearchFilter searchFilterIn = new SearchFilter.IsEqualTo(FolderSchema.DisplayName, targetFolder.getObjectName());
 		try {
-			if (targetFolder.getBaseFolderId()!=null) {
+			if (targetFolder.getBaseFolderId() != null) {
 				findFoldersResultsIn = exchangeService.findFolders(targetFolder.getBaseFolderId(), searchFilterIn, folderViewIn);
 			} else {
 				findFoldersResultsIn = exchangeService.findFolders(WellKnownFolderName.MsgFolderRoot, searchFilterIn, folderViewIn);
 			}
 		} catch (Exception e) {
-			throw new FileSystemException("Cannot find folder ["+targetFolder.getObjectName()+"]", e);
+			throw new FileSystemException("Cannot find folder [" + targetFolder.getObjectName() + "]", e);
 		}
 		if (findFoldersResultsIn.getTotalCount() == 0) {
 			log.debug("no folder found with name [{}] in basefolder [{}]", targetFolder::getObjectName, targetFolder::getBaseFolderId);
-			if(createFolder){
+			if (createFolder) {
 				log.debug("creating folder with name [{}] in basefolder [{}]", targetFolder::getObjectName, targetFolder::getBaseFolderId);
 				createFolder(targetFolder.getOriginalReference());
 				return findFolder(exchangeService, targetFolder, false);
@@ -441,7 +457,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		}
 		if (findFoldersResultsIn.getTotalCount() > 1) {
 			if (log.isDebugEnabled()) {
-				for (Folder folder:findFoldersResultsIn.getFolders()) {
+				for (Folder folder : findFoldersResultsIn.getFolders()) {
 					try {
 						log.debug("found folder [{}]", folder.getDisplayName());
 					} catch (ServiceLocalException e) {
@@ -449,13 +465,13 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 					}
 				}
 			}
-			throw new FileSystemException("multiple folders found with name ["+ targetFolder.getObjectName() + "]");
+			throw new FileSystemException("multiple folders found with name [" + targetFolder.getObjectName() + "]");
 		}
 		return findFoldersResultsIn.getFolders().get(0).getId();
 	}
 
 	@Override
-	public EmailMessage toFile(String filename) throws FileSystemException {
+	public ExchangeMessageReference toFile(String filename) throws FileSystemException {
 		log.debug("Get EmailMessage for reference [{}]", filename);
 		ExchangeObjectReference reference = asObjectReference(filename);
 		ExchangeService exchangeService = getConnection(reference);
@@ -463,39 +479,38 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		try {
 			ItemId itemId = ItemId.getItemIdFromString(reference.getObjectName());
 			// TODO: check if this bind can be left out
-			return EmailMessage.bind(exchangeService,itemId);
+			return ExchangeMessageReference.of(reference, EmailMessage.bind(exchangeService, itemId));
 		} catch (Exception e) {
 			invalidateConnectionOnRelease = true;
-			throw new FileSystemException("Cannot convert filename ["+filename+"] into an ItemId", e);
+			throw new FileSystemException("Cannot convert filename [" + filename + "] into an ItemId", e);
 		} finally {
 			releaseConnection(exchangeService, invalidateConnectionOnRelease);
 		}
 	}
 
 	@Override
-	public EmailMessage toFile(String folder, String filename) throws FileSystemException {
+	public ExchangeMessageReference toFile(String folder, String filename) throws FileSystemException {
 		return toFile(filename);
 	}
 
 	private boolean itemExistsInFolder(ExchangeService exchangeService, FolderId folderId, String itemId) throws Exception {
 		ItemView view = new ItemView(1);
 		view.getOrderBy().add(ItemSchema.DateTimeReceived, SortDirection.Ascending);
-		SearchFilter searchFilter =  new SearchFilter.IsEqualTo(ItemSchema.Id, itemId);
+		SearchFilter searchFilter = new SearchFilter.IsEqualTo(ItemSchema.Id, itemId);
 		FindItemsResults<Item> findResults;
-		findResults = exchangeService.findItems(folderId,searchFilter, view);
-		return findResults.getTotalCount()!=0;
+		findResults = exchangeService.findItems(folderId, searchFilter, view);
+		return findResults.getTotalCount() != 0;
 	}
 
 	@Override
-	public boolean exists(EmailMessage f) throws FileSystemException {
+	public boolean exists(ExchangeMessageReference f) throws FileSystemException {
 		log.trace("Check if message exists: message [{}]", f);
-		ExchangeService exchangeService = getConnection();
+		ExchangeService exchangeService = getConnection(f.getMailFolder());
 		boolean invalidateConnectionOnRelease = false;
 		try {
-			setMailboxOnService(exchangeService, getReceivedBy(f));
 			// TODO: check if this bind can be left out
-			EmailMessage emailMessage = EmailMessage.bind(exchangeService, f.getId());
-			return itemExistsInFolder(exchangeService, emailMessage.getParentFolderId(), f.getId().toString());
+			EmailMessage emailMessage = EmailMessage.bind(exchangeService, f.getMessage().getId());
+			return itemExistsInFolder(exchangeService, emailMessage.getParentFolderId(), f.getMessage().getId().toString());
 		} catch (ServiceResponseException e) {
 			ServiceError errorCode = e.getErrorCode();
 			if (errorCode == ServiceError.ErrorItemNotFound) {
@@ -511,9 +526,8 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 
-
 	@Override
-	public DirectoryStream<EmailMessage> listFiles(final String folder) throws FileSystemException {
+	public DirectoryStream<ExchangeMessageReference> listFiles(final String folder) throws FileSystemException {
 		if (!isOpen()) {
 			return null;
 		}
@@ -523,23 +537,23 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		boolean closeConnectionOnExit = true;
 		try {
 			FolderId folderId = findFolder(reference);
-			if (folderId==null) {
-				throw new FileSystemException("Cannot find folder ["+folder+"]");
+			if (folderId == null) {
+				throw new FileSystemException("Cannot find folder [" + folder + "]");
 			}
-			ItemView view = new ItemView(getMaxNumberOfMessagesToList()<0?100:getMaxNumberOfMessagesToList());
+			ItemView view = new ItemView(getMaxNumberOfMessagesToList() < 0 ? 100 : getMaxNumberOfMessagesToList());
 			view.getOrderBy().add(ItemSchema.DateTimeReceived, SortDirection.Ascending);
 			FindItemsResults<Item> findResults;
 			if ("NDR".equalsIgnoreCase(getFilter())) {
 				SearchFilter searchFilterBounce = new SearchFilter.IsEqualTo(ItemSchema.ItemClass, "REPORT.IPM.Note.NDR");
-				findResults = exchangeService.findItems(folderId,searchFilterBounce, view);
+				findResults = exchangeService.findItems(folderId, searchFilterBounce, view);
 			} else {
 				findResults = exchangeService.findItems(folderId, view);
 			}
 			if (findResults.getTotalCount() == 0) {
-				return FileSystemUtils.getDirectoryStream((Iterator<EmailMessage>)null);
+				return FileSystemUtils.getDirectoryStream((Iterator<ExchangeMessageReference>) null);
 			}
 			Iterator<Item> itemIterator = findResults.getItems().iterator();
-			DirectoryStream<EmailMessage> result = FileSystemUtils.getDirectoryStream(new Iterator<EmailMessage>() {
+			DirectoryStream<ExchangeMessageReference> result = FileSystemUtils.getDirectoryStream(new Iterator<ExchangeMessageReference>() {
 
 				@Override
 				public boolean hasNext() {
@@ -547,17 +561,16 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 				}
 
 				@Override
-				public EmailMessage next() {
-					// must cast <Items> to <EmailMessage> separately, cannot cast Iterator<Item> to Iterator<EmailMessage>
-					return (EmailMessage)itemIterator.next();
+				public ExchangeMessageReference next() {
+					return ExchangeMessageReference.of(reference, (EmailMessage) itemIterator.next());
 				}
 
-			}, (Runnable)() -> { releaseConnection(exchangeService, false); });
+			}, (Runnable) () -> releaseConnection(exchangeService, false));
 			closeConnectionOnExit = false;
 			return result;
 		} catch (Exception e) {
 			invalidateConnectionOnRelease = true;
-			throw new FileSystemException("Cannot list messages in folder ["+folder+"]", e);
+			throw new FileSystemException("Cannot list messages in folder [" + folder + "]", e);
 		} finally {
 			if (closeConnectionOnExit) {
 				releaseConnection(exchangeService, invalidateConnectionOnRelease);
@@ -573,16 +586,16 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		ExchangeObjectReference reference = asObjectReference(foldername);
 		ExchangeService exchangeService = getConnection(reference);
 		FolderId folderId = findFolder(exchangeService, reference);
-		if (folderId==null) {
-			throw new FileSystemException("Cannot find folder ["+foldername+"]");
+		if (folderId == null) {
+			throw new FileSystemException("Cannot find folder [" + foldername + "]");
 		}
 		boolean invalidateConnectionOnRelease = false;
 		try {
-			Folder folder = Folder.bind(exchangeService,folderId);
+			Folder folder = Folder.bind(exchangeService, folderId);
 			return folder.getTotalCount();
 		} catch (Exception e) {
 			invalidateConnectionOnRelease = true;
-			throw new FileSystemException("Cannot list messages in folder ["+foldername+"]", e);
+			throw new FileSystemException("Cannot list messages in folder [" + foldername + "]", e);
 		} finally {
 			releaseConnection(exchangeService, invalidateConnectionOnRelease);
 		}
@@ -592,20 +605,20 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	@Override
 	public boolean folderExists(String folder) throws FileSystemException {
 		FolderId folderId = findFolder(asObjectReference(folder));
-		return folderId!=null;
+		return folderId != null;
 	}
 
 	@Override
-	public Message readFile(EmailMessage f, String charset) throws FileSystemException, IOException {
-		EmailMessage emailMessage = f;
+	public Message readFile(ExchangeMessageReference f, String charset) throws FileSystemException, IOException {
+		EmailMessage emailMessage = f.getMessage();
 
 		try {
-			if (emailMessage.getId()!=null) {
+			if (emailMessage.getId() != null) {
 				PropertySet ps = new PropertySet(EmailMessageSchema.DateTimeReceived,
-						EmailMessageSchema.From, EmailMessageSchema.Subject,
-						EmailMessageSchema.DateTimeSent,
-						EmailMessageSchema.LastModifiedTime,
-						EmailMessageSchema.Size);
+					EmailMessageSchema.From, EmailMessageSchema.Subject,
+					EmailMessageSchema.DateTimeSent,
+					EmailMessageSchema.LastModifiedTime,
+					EmailMessageSchema.Size);
 				if (isReadMimeContents()) {
 					ps.add(ItemSchema.MimeContent);
 				} else {
@@ -617,7 +630,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 				MimeContent mc = emailMessage.getMimeContent();
 				return new Message(mc.getContent(), charset);
 			}
-			return new Message(MessageBody.getStringFromMessageBody(emailMessage.getBody()), FileSystemUtils.getContext(this, emailMessage));
+			return new Message(MessageBody.getStringFromMessageBody(emailMessage.getBody()), FileSystemUtils.getContext(this, f));
 		} catch (FileSystemException e) {
 			throw e;
 		} catch (Exception e) {
@@ -626,21 +639,22 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 	@Override
-	public void deleteFile(EmailMessage f) throws FileSystemException {
+	public void deleteFile(ExchangeMessageReference f) throws FileSystemException {
 		try {
-			f.delete(DeleteMode.MoveToDeletedItems);
+			f.getMessage().delete(DeleteMode.MoveToDeletedItems);
 		} catch (Exception e) {
-			throw new FileSystemException("Could not delete",e);
+			throw new FileSystemException("Could not delete", e);
 		}
 	}
+
 	@Override
-	public EmailMessage moveFile(EmailMessage f, String destinationFolder, boolean createFolder, boolean resultantMustBeReturned) throws FileSystemException {
+	public ExchangeMessageReference moveFile(ExchangeMessageReference f, String destinationFolder, boolean createFolder, boolean resultantMustBeReturned) throws FileSystemException {
 		ExchangeObjectReference reference = asObjectReference(destinationFolder);
 		ExchangeService exchangeService = getConnection(reference);
 		boolean invalidateConnectionOnRelease = false;
 		try {
 			FolderId destinationFolderId = findFolder(exchangeService, reference, createFolder);
-			return (EmailMessage)f.move(destinationFolderId);
+			return ExchangeMessageReference.of(reference, (EmailMessage) f.getMessage().move(destinationFolderId));
 		} catch (Exception e) {
 			invalidateConnectionOnRelease = true;
 			throw new FileSystemException(e);
@@ -650,13 +664,13 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 	@Override
-	public EmailMessage copyFile(EmailMessage f, String destinationFolder, boolean createFolder, boolean resultantMustBeReturned) throws FileSystemException {
+	public ExchangeMessageReference copyFile(ExchangeMessageReference f, String destinationFolder, boolean createFolder, boolean resultantMustBeReturned) throws FileSystemException {
 		ExchangeObjectReference reference = asObjectReference(destinationFolder);
 		ExchangeService exchangeService = getConnection(reference);
 		boolean invalidateConnectionOnRelease = false;
 		try {
 			FolderId destinationFolderId = findFolder(exchangeService, reference, createFolder);
-			return (EmailMessage)f.copy(destinationFolderId);
+			return ExchangeMessageReference.of(reference, (EmailMessage) f.getMessage().copy(destinationFolderId));
 		} catch (Exception e) {
 			invalidateConnectionOnRelease = true;
 			throw new FileSystemException(e);
@@ -666,33 +680,36 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 	@Override
-	public long getFileSize(EmailMessage f) throws FileSystemException {
+	public long getFileSize(ExchangeMessageReference f) throws FileSystemException {
 		try {
-			return f.getSize();
+			return f.getMessage().getSize();
 		} catch (ServiceLocalException e) {
-			throw new FileSystemException("Could not determine size",e);
+			throw new FileSystemException("Could not determine size", e);
 		}
 	}
+
 	@Override
-	public String getName(EmailMessage f) {
+	public String getName(ExchangeMessageReference f) {
 		try {
-			if (f.getId()==null) {
+			final ItemId itemId = f.getMessage().getId();
+			if (itemId == null) {
 				return null; // attachments don't have an id, but appear to be loaded at the same time as the main message
 			}
-			return f.getId().toString();
+			return itemId.toString();
 		} catch (ServiceLocalException e) {
-			throw new RuntimeException("Could not determine Name",e);
+			throw new RuntimeException("Could not determine Name", e);
 		}
 	}
+
 	@Override
-	public String getParentFolder(EmailMessage f) throws FileSystemException {
-		ExchangeService exchangeService = getConnection();
+	public String getParentFolder(ExchangeMessageReference f) throws FileSystemException {
+		ExchangeService exchangeService = getConnection(f.getMailFolder());
 		boolean invalidateConnectionOnRelease = false;
 		try {
-			FolderId folderId = f.getParentFolderId();
+			FolderId folderId = f.getMessage().getParentFolderId();
 			Folder folder = Folder.bind(exchangeService, folderId);
 			return folder.getDisplayName();
-		} catch(Exception e) {
+		} catch (Exception e) {
 			invalidateConnectionOnRelease = true;
 			throw new FileSystemException(e);
 		} finally {
@@ -701,23 +718,24 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 	@Override
-	public String getCanonicalName(EmailMessage f) throws FileSystemException {
+	public String getCanonicalName(ExchangeMessageReference f) throws FileSystemException {
 		try {
-			if (f.getId()==null) {
+			final ItemId itemId = f.getMessage().getId();
+			if (itemId == null) {
 				return null; // attachments don't have an id, but appear to be loaded at the same time as the main message
 			}
-			return f.getId().getUniqueId();
+			return itemId.getUniqueId();
 		} catch (ServiceLocalException e) {
-			throw new FileSystemException("Could not determine CanonicalName",e);
+			throw new FileSystemException("Could not determine CanonicalName", e);
 		}
 	}
 
 	@Override
-	public Date getModificationTime(EmailMessage f) throws FileSystemException {
+	public Date getModificationTime(ExchangeMessageReference f) throws FileSystemException {
 		try {
-			return f.getLastModifiedTime();
+			return f.getMessage().getLastModifiedTime();
 		} catch (ServiceLocalException e) {
-			throw new FileSystemException("Could not determine modification time",e);
+			throw new FileSystemException("Could not determine modification time", e);
 		}
 	}
 
@@ -735,7 +753,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 	private List<String> asList(EmailAddressCollection addressCollection) {
-		if (addressCollection==null) {
+		if (addressCollection == null) {
 			return Collections.emptyList();
 		}
 		return addressCollection
@@ -747,14 +765,15 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 
 
 	@Override
-	public Map<String, Object> getAdditionalFileProperties(EmailMessage f) throws FileSystemException {
-		EmailMessage emailMessage = f;
+	public Map<String, Object> getAdditionalFileProperties(ExchangeMessageReference f) throws FileSystemException {
+		final EmailMessage emailMessage = f.getMessage();
 		try {
-			if (emailMessage.getId()!=null) {
+			final ItemId emailMessageId = emailMessage.getId();
+			if (emailMessageId != null) {
 				emailMessage.load(PropertySet.FirstClassProperties);
 			}
 
-			Map<String, Object> result=new LinkedHashMap<String,Object>();
+			final Map<String, Object> result = new LinkedHashMap<>();
 			result.put(IMailFileSystem.TO_RECEPIENTS_KEY, asList(emailMessage.getToRecipients()));
 			result.put(IMailFileSystem.CC_RECEPIENTS_KEY, asList(emailMessage.getCcRecipients()));
 			result.put(IMailFileSystem.BCC_RECEPIENTS_KEY, asList(emailMessage.getBccRecipients()));
@@ -763,117 +782,122 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			result.put(IMailFileSystem.REPLY_TO_RECEPIENTS_KEY, getReplyTo(emailMessage));
 			result.put(IMailFileSystem.DATETIME_SENT_KEY, getDateTimeSent(emailMessage));
 			result.put(IMailFileSystem.DATETIME_RECEIVED_KEY, getDateTimeReceived(emailMessage));
-			try {
-				InternetMessageHeaderCollection internetMessageHeaders = emailMessage.getInternetMessageHeaders();
-				if (internetMessageHeaders!=null) {
-					for(InternetMessageHeader internetMessageHeader : internetMessageHeaders) {
-						Object curEntry = result.get(internetMessageHeader.getName());
-						if (curEntry==null) {
-							result.put(internetMessageHeader.getName(), internetMessageHeader.getValue());
-							continue;
-						}
-						List<Object> values;
-						if (curEntry instanceof List) {
-							values = (List<Object>)curEntry;
-						} else {
-							values = new LinkedList<>();
-							values.add(curEntry);
-							result.put(internetMessageHeader.getName(),values);
-						}
-						values.add(internetMessageHeader.getValue());
-					}
-				}
-			} catch (ServiceLocalException e) {
-				log.warn("Message ["+f.getId()+"] Cannot load message headers: "+ e.getMessage());
-			}
-			result.put(IMailFileSystem.BEST_REPLY_ADDRESS_KEY, MailFileSystemUtils.findBestReplyAddress(result,getReplyAddressFields()));
+
+			result.putAll(extractInternetMessageHeaders(emailMessage, emailMessageId));
+
+			result.put(IMailFileSystem.BEST_REPLY_ADDRESS_KEY, MailFileSystemUtils.findBestReplyAddress(result, getReplyAddressFields()));
 			return result;
 		} catch (Exception e) {
 			throw new FileSystemException(e);
 		}
 	}
 
+	private Map<String, Object> extractInternetMessageHeaders(EmailMessage emailMessage, ItemId emailMessageId) {
+		final InternetMessageHeaderCollection internetMessageHeaders;
+		try {
+			internetMessageHeaders = emailMessage.getInternetMessageHeaders();
+		} catch (ServiceLocalException e) {
+			log.warn("Message [{}] Cannot load message headers: {}", emailMessageId, e.getMessage());
+			return Collections.emptyMap();
+		}
+		if (internetMessageHeaders == null) {
+			return Collections.emptyMap();
+		}
+		final Map<String, Object> result = new LinkedHashMap<>();
+		for (InternetMessageHeader internetMessageHeader : internetMessageHeaders) {
+			if (!result.containsKey(internetMessageHeader.getName())) {
+				result.put(internetMessageHeader.getName(), internetMessageHeader.getValue());
+				continue;
+			}
+			// Multiple occurrences found of header, collate into a list
+			final Object curEntry = result.get(internetMessageHeader.getName());
+			final List<Object> values;
+			if (curEntry instanceof List) {
+				// Already multiple values found for header
+				values = (List<Object>) curEntry;
+			} else {
+				// Rewrite existing single entry to list, for now the header has multiple values
+				values = new LinkedList<>();
+				values.add(curEntry);
+				result.replace(internetMessageHeader.getName(), values);
+			}
+			values.add(internetMessageHeader.getValue());
+		}
+		return result;
+	}
+
 
 	@Override
-	public void forwardMail(EmailMessage emailMessage, String destination) throws FileSystemException {
+	public void forwardMail(ExchangeMessageReference emailMessage, String destination) throws FileSystemException {
 		try {
-			ResponseMessage forward = emailMessage.createForward();
+			ResponseMessage forward = emailMessage.getMessage().createForward();
 			forward.getToRecipients().clear();
 			forward.getToRecipients().add(destination);
 
-//			if(forwardMessage != null){
-//				forward.setBodyPrefix(MessageBody.getMessageBodyFromText(forwardMessage));
-//			}
-
-//			if(getSaveCopy() == true){
-//				if(getFolderNameToSaveCopy() != null){
-//					forward.sendAndSaveCopy(retrieveFolderIdByFolderName(getFolderNameToSaveCopy()));
-//				} else {
-//					forward.sendAndSaveCopy();
-//				}
-//			} else {
-				forward.send();
-//			}
+			forward.send();
 		} catch (Exception e) {
 			throw new FileSystemException(e);
 		}
 	}
 
 	@Override
-	public Iterator<Attachment> listAttachments(EmailMessage f) throws FileSystemException {
-		List<Attachment> result = new LinkedList<Attachment>();
-		EmailMessage emailMessage = f;
+	public Iterator<ExchangeAttachmentReference> listAttachments(ExchangeMessageReference f) throws FileSystemException {
+		List<ExchangeAttachmentReference> result = new LinkedList<>();
+		EmailMessage emailMessage = f.getMessage();
 		try {
-			if (emailMessage.getId()!=null) {
+			if (emailMessage.getId() != null) {
 				PropertySet ps = new PropertySet(EmailMessageSchema.Attachments);
 				emailMessage.load(ps);
 			}
 			AttachmentCollection attachmentCollection = emailMessage.getAttachments();
 			for (Attachment attachment : attachmentCollection) {
-				result.add(attachment);
+				result.add(ExchangeAttachmentReference.of(f.getMailFolder(), attachment));
 			}
 			return result.iterator();
 		} catch (Exception e) {
-			throw new FileSystemException("cannot read attachments",e);
+			throw new FileSystemException("cannot read attachments", e);
 		}
 	}
 
 
 	@Override
-	public String getAttachmentName(Attachment a) {
-		return a.getName();
+	public String getAttachmentName(ExchangeAttachmentReference a) {
+		return a.getAttachment().getName();
 	}
 
 
 	@Override
-	public Message readAttachment(Attachment a) throws FileSystemException, IOException {
+	public Message readAttachment(ExchangeAttachmentReference ref) throws FileSystemException, IOException {
+		final Attachment a = ref.getAttachment();
 		try {
 			a.load();
 		} catch (Exception e) {
-			throw new FileSystemException("Cannot load attachment",e);
-		}
-		byte[] content = null;
-		if (a instanceof FileAttachment) {
-			content=((FileAttachment)a).getContent();
+			throw new FileSystemException("Cannot load attachment", e);
 		}
 		if (a instanceof ItemAttachment) {
-			ItemAttachment itemAttachment=(ItemAttachment)a;
-			EmailMessage attachmentItem = (EmailMessage)itemAttachment.getItem();
-			return readFile(attachmentItem, null); // we don't know the charset here, leave it null for now
+			final ItemAttachment itemAttachment = (ItemAttachment) a;
+			final EmailMessage attachmentItem = (EmailMessage) itemAttachment.getItem();
+			return readFile(ExchangeMessageReference.of(ref.getMailFolder(), attachmentItem), null); // we don't know the charset here, leave it null for now
 		}
-		if (content==null) {
-			log.warn("content of attachment is null");
-			content = new byte[0];
+		if (a instanceof FileAttachment) {
+			final byte[] content = ((FileAttachment) a).getContent();
+			if (content == null) {
+				log.warn("content of attachment is null");
+				return new Message(EMPTY_MESSAGE_CONTENT);
+			}
+			return new Message(content);
 		}
-		return new Message(content);
+		log.warn("Attachment of unknown type: {}, returning empty message", a.getClass().getName());
+		return new Message(EMPTY_MESSAGE_CONTENT);
 	}
 
 	@Override
-	public EmailMessage getFileFromAttachment(Attachment attachment) throws FileSystemException {
+	public ExchangeMessageReference getFileFromAttachment(final ExchangeAttachmentReference ref) throws FileSystemException {
+		Attachment attachment = ref.getAttachment();
 		if (attachment instanceof ItemAttachment) {
 			Item item = ((ItemAttachment) attachment).getItem();
 			if (item instanceof EmailMessage) {
-				return (EmailMessage) item;
+				return ExchangeMessageReference.of(ref.getMailFolder(), (EmailMessage) item);
 			}
 		}
 		// Attachment is not an EmailMessage itself, no need to parse further, can just return null
@@ -882,9 +906,9 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 
 
 	@Override
-	public long getAttachmentSize(Attachment a) throws FileSystemException {
+	public long getAttachmentSize(ExchangeAttachmentReference a) throws FileSystemException {
 		try {
-			return a.getSize();
+			return a.getAttachment().getSize();
 		} catch (ServiceVersionException e) {
 			throw new FileSystemException(e);
 		}
@@ -892,28 +916,29 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 
 
 	@Override
-	public String getAttachmentContentType(Attachment a) throws FileSystemException {
-		return a.getContentType();
+	public String getAttachmentContentType(final ExchangeAttachmentReference a) throws FileSystemException {
+		return a.getAttachment().getContentType();
 	}
 
 	@Override
-	public String getAttachmentFileName(Attachment a) throws FileSystemException {
+	public String getAttachmentFileName(final ExchangeAttachmentReference ref) throws FileSystemException {
+		final Attachment a = ref.getAttachment();
 		if (a instanceof FileAttachment) {
-			return ((FileAttachment)a).getFileName();
+			return ((FileAttachment) a).getFileName();
 		}
 		return null;
 	}
 
 
 	@Override
-	public Map<String, Object> getAdditionalAttachmentProperties(Attachment a) throws FileSystemException {
+	public Map<String, Object> getAdditionalAttachmentProperties(final ExchangeAttachmentReference ref) throws FileSystemException {
+		final Attachment a = ref.getAttachment();
 		Map<String, Object> result = new LinkedHashMap<>();
 		result.put("id", a.getId());
 		result.put("contentId", a.getContentId());
 		result.put("contentLocation", a.getContentLocation());
 		return result;
 	}
-
 
 
 	@Override
@@ -927,7 +952,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 			folder.save(reference.getBaseFolderId());
 		} catch (Exception e) {
 			invalidateConnectionOnRelease = true;
-			throw new FileSystemException("cannot create folder ["+reference.getObjectName()+"]", e);
+			throw new FileSystemException("cannot create folder [" + reference.getObjectName() + "]", e);
 		} finally {
 			releaseConnection(exchangeService, invalidateConnectionOnRelease);
 		}
@@ -942,7 +967,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		try {
 			FolderId folderId = findFolder(exchangeService, reference);
 			Folder folder = Folder.bind(exchangeService, folderId);
-			if(removeNonEmptyFolder) {
+			if (removeNonEmptyFolder) {
 				folder.empty(DeleteMode.HardDelete, true);
 			}
 			folder.delete(DeleteMode.HardDelete);
@@ -959,46 +984,17 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		try {
 			return cleanAddress(emailMessage.getFrom());
 		} catch (ServiceLocalException e) {
-			log.warn("Could not get From Address: "+ e.getMessage());
+			log.warn("Could not get From Address: {}", e.getMessage());
 			return null;
-		}
-	}
-
-	protected String getReceivedBy(EmailMessage emailMessage) throws ServiceResponseException, FileSystemException {
-		log.trace("getReceivedBy - extract 'receivedBy' property from message");
-		try {
-			emailMessage.load(PropertySet.FirstClassProperties);
-			EmailAddress receivedBy = emailMessage.getReceivedBy();
-			EmailAddress receivedRepresenting = emailMessage.getReceivedRepresenting();
-			if (receivedBy == null) {
-				SoapFaultDetails soapFaultDetails = new SoapFaultDetails() {
-					@Override
-					public ServiceError getResponseCode() {
-						return ServiceError.ErrorItemNotFound;
-					}
-				};
-				throw new ServiceResponseException(new ServiceResponse(soapFaultDetails));
-			}
-			log.debug("Mail message [{}] was received by mail address [{}]; received-representing: {}",
-				emailMessage.getId(), receivedBy.getAddress(), receivedRepresenting.getAddress());
-			return receivedBy.getAddress();
-		} catch (ServiceResponseException e) {
-			ServiceError errorCode = e.getErrorCode();
-			if (errorCode == ServiceError.ErrorItemNotFound) {
-				throw e;
-			}
-			throw new FileSystemException(e);
-		} catch (Exception e) {
-			throw new FileSystemException("Could not extract ReceivedBy address", e);
 		}
 	}
 
 	protected String getSender(EmailMessage emailMessage) {
 		try {
 			EmailAddress sender = emailMessage.getSender();
-			return sender==null ? null : cleanAddress(sender);
+			return sender == null ? null : cleanAddress(sender);
 		} catch (ServiceLocalException e) {
-			log.warn("Could not get Sender Address: "+ e.getMessage());
+			log.warn("Could not get Sender Address: {}", e.getMessage());
 			return null;
 		}
 	}
@@ -1007,7 +1003,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		try {
 			return asList(emailMessage.getReplyTo());
 		} catch (ServiceLocalException e) {
-			log.warn("Could not get ReplyTo Addresses: "+ e.getMessage());
+			log.warn("Could not get ReplyTo Addresses: {}", e.getMessage());
 			return null;
 		}
 	}
@@ -1016,7 +1012,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		try {
 			return emailMessage.getDateTimeSent();
 		} catch (ServiceLocalException e) {
-			log.warn("Could not get DateTimeSent: "+ e.getMessage());
+			log.warn("Could not get DateTimeSent: {}", e.getMessage());
 			return null;
 		}
 	}
@@ -1025,22 +1021,23 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		try {
 			return emailMessage.getDateTimeReceived();
 		} catch (ServiceLocalException e) {
-			log.warn("Could not get getDateTimeReceived: "+ e.getMessage());
+			log.warn("Could not get getDateTimeReceived: {}", e.getMessage());
 			return null;
 		}
 	}
 
 	@Override
-	public String getSubject(EmailMessage emailMessage) throws FileSystemException {
-		ItemId id=null;
+	public String getSubject(ExchangeMessageReference ref) throws FileSystemException {
+		final EmailMessage emailMessage = ref.getMessage();
+		ItemId id = null;
 		try {
 			id = emailMessage.getId();
-			if (id!=null) { // attachments don't have an id, but appear to be loaded at the same time as the main message
+			if (id != null) { // attachments don't have an id, but appear to be loaded at the same time as the main message
 				emailMessage.load(new PropertySet(ItemSchema.Subject));
 			}
 			return emailMessage.getSubject();
 		} catch (Exception e) {
-			if (id==null) {
+			if (id == null) {
 				log.warn("Could not get Subject for message without ItemId", e);
 				return null;
 			}
@@ -1050,10 +1047,11 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 
 
 	@Override
-	public Message getMimeContent(EmailMessage emailMessage) throws FileSystemException {
+	public Message getMimeContent(ExchangeMessageReference ref) throws FileSystemException {
+		final EmailMessage emailMessage = ref.getMessage();
 		try {
 			emailMessage.load(new PropertySet(ItemSchema.MimeContent));
-			MimeContent mc = emailMessage.getMimeContent();
+			final MimeContent mc = emailMessage.getMimeContent();
 			return new Message(mc.getContent());
 		} catch (Exception e) {
 			throw new FileSystemException("Could not get MimeContent", e);
@@ -1061,15 +1059,16 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 	@Override
-	public void extractEmail(EmailMessage emailMessage, SaxElementBuilder emailXml) throws FileSystemException {
+	public void extractEmail(ExchangeMessageReference ref, SaxElementBuilder emailXml) throws FileSystemException {
+		final EmailMessage emailMessage = ref.getMessage();
 		try {
-			if (emailMessage.getId()!=null) {
+			if (emailMessage.getId() != null) {
 				PropertySet ps = new PropertySet(EmailMessageSchema.DateTimeSent, EmailMessageSchema.DateTimeReceived, EmailMessageSchema.From,
-						EmailMessageSchema.ToRecipients, EmailMessageSchema.CcRecipients, EmailMessageSchema.BccRecipients, EmailMessageSchema.Subject,
-						EmailMessageSchema.Body, EmailMessageSchema.Attachments);
+					EmailMessageSchema.ToRecipients, EmailMessageSchema.CcRecipients, EmailMessageSchema.BccRecipients, EmailMessageSchema.Subject,
+					EmailMessageSchema.Body, EmailMessageSchema.Attachments);
 				emailMessage.load(ps);
 			}
-			MailFileSystemUtils.addEmailInfo(this, emailMessage, emailXml);
+			MailFileSystemUtils.addEmailInfo(this, ref, emailXml);
 		} catch (FileSystemException e) {
 			throw e;
 		} catch (Exception e) {
@@ -1078,17 +1077,17 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	}
 
 	@Override
-	public void extractAttachment(Attachment attachment, SaxElementBuilder attachmentsXml) throws FileSystemException {
+	public void extractAttachment(ExchangeAttachmentReference ref, SaxElementBuilder attachmentsXml) throws FileSystemException {
+		final Attachment attachment = ref.getAttachment();
 		try {
 			attachment.load();
-			MailFileSystemUtils.addAttachmentInfo(this, attachment, attachmentsXml);
+			MailFileSystemUtils.addAttachmentInfo(this, ref, attachmentsXml);
 		} catch (FileSystemException e) {
 			throw e;
 		} catch (Exception e) {
 			throw new FileSystemException(e);
 		}
 	}
-
 
 
 	@Override
@@ -1111,7 +1110,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		return Misc.concatStrings("url [" + url + "] mailAddress [" + (getMailAddress() == null ? "" : getMailAddress()) + "]", " ", result);
 	}
 
-	private void setMailboxOnService(ExchangeService service, String mailbox){
+	private void setMailboxOnService(ExchangeService service, String mailbox) {
 		log.debug("Set mailservice mailbox to [{}]", mailbox);
 		service.getHttpHeaders().put(ANCHOR_HEADER, mailbox);
 
@@ -1127,9 +1126,9 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		return asObjectReference(objectName, basefolderId);
 	}
 
-	private ExchangeObjectReference asObjectReference(String objectName, FolderId baseFolderId){
+	private ExchangeObjectReference asObjectReference(String objectName, FolderId baseFolderId) {
 		ExchangeObjectReference reference = new ExchangeObjectReference(objectName, getMailAddress(), baseFolderId, getMailboxObjectSeparator());
-		if(!reference.isStatic()){
+		if (!reference.isStatic()) {
 			reference.setBaseFolderId(baseFolderId);
 		}
 		return reference;
@@ -1156,36 +1155,47 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		}
 	}
 
-	/** The mail address of the mailbox connected to (also used for auto discovery) */
+	/**
+	 * The mail address of the mailbox connected to (also used for auto discovery)
+	 */
 	public void setMailAddress(String mailAddress) {
 		this.mailAddress = mailAddress;
 	}
 
 	/**
 	 * When <code>true</code>, all redirect uris are accepted when connecting to the server
+	 *
 	 * @ff.default true
 	 */
 	public void setValidateAllRedirectUrls(boolean validateAllRedirectUrls) {
 		this.validateAllRedirectUrls = validateAllRedirectUrls;
 	}
 
-	/** Url of the Exchange server. Set to e.g. https://outlook.office365.com/EWS/Exchange.asmx to speed up start up, leave empty to use autodiscovery */
+	/**
+	 * Url of the Exchange server. Set to e.g. https://outlook.office365.com/EWS/Exchange.asmx to speed up start up, leave empty to use autodiscovery
+	 */
 	public void setUrl(String url) {
 		this.url = url;
 	}
 
 
-	/** Client ID that represents a registered application in Azure AD which could be found at Azure AD -> App Registrations -> MyApp -> Overview. */
+	/**
+	 * Client ID that represents a registered application in Azure AD which could be found at Azure AD -> App Registrations -> MyApp -> Overview.
+	 */
 	public void setClientId(String clientId) {
 		this.clientId = clientId;
 	}
 
-	/** Client secret that belongs to registered application in Azure AD which could be found at Azure AD -> App Registrations -> MyApp -> Certificates and Secrets */
+	/**
+	 * Client secret that belongs to registered application in Azure AD which could be found at Azure AD -> App Registrations -> MyApp -> Certificates and Secrets
+	 */
 	public void setClientSecret(String clientSecret) {
 		this.clientSecret = clientSecret;
 	}
 
-	/** Tenant ID that represents the tenant in which the registered application exists within Azure AD which could be found at Azure AD -> App Registrations -> MyApp -> Overview. */
+	/**
+	 * Tenant ID that represents the tenant in which the registered application exists within Azure AD which could be found at Azure AD -> App Registrations -> MyApp -> Overview.
+	 */
 	public void setTenantId(String tenantId) {
 		this.tenantId = tenantId;
 	}
@@ -1200,7 +1210,9 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		super.setAuthAlias(authAlias);
 	}
 
-	/** Username for authentication to Exchange mail server. Ignored when tenantId is also specified */
+	/**
+	 * Username for authentication to Exchange mail server. Ignored when tenantId is also specified
+	 */
 	@Deprecated
 	@ConfigurationWarning("Authentication to Exchange Web Services with username and password will be disabled 2021-Q3. Please migrate to modern authentication using clientId and clientSecret!")
 	@Override
@@ -1209,7 +1221,9 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		setClientId(username);
 	}
 
-	/** Password for authentication to Exchange mail server. Ignored when tenantId is also specified */
+	/**
+	 * Password for authentication to Exchange mail server. Ignored when tenantId is also specified
+	 */
 	@Deprecated
 	@ConfigurationWarning("Authentication to Exchange Web Services with username and password will be disabled 2021-Q3. Please migrate to modern authentication using clientId and clientSecret!")
 	@Override
@@ -1218,41 +1232,54 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		setClientSecret(password);
 	}
 
-	/** If empty, all mails are retrieved. If set to <code>NDR</code> only Non-Delivery Report mails ('bounces') are retrieved */
+	/**
+	 * If empty, all mails are retrieved. If set to <code>NDR</code> only Non-Delivery Report mails ('bounces') are retrieved
+	 */
 	public void setFilter(String filter) {
 		this.filter = filter;
 	}
 
 
-	/** proxy host */
+	/**
+	 * proxy host
+	 */
 	public void setProxyHost(String proxyHost) {
 		this.proxyHost = proxyHost;
 	}
 
 	/**
 	 * proxy port
+	 *
 	 * @ff.default 8080
 	 */
 	public void setProxyPort(int proxyPort) {
 		this.proxyPort = proxyPort;
 	}
 
-	/** proxy username */
+	/**
+	 * proxy username
+	 */
 	public void setProxyUsername(String proxyUsername) {
 		this.proxyUsername = proxyUsername;
 	}
 
-	/** proxy password */
+	/**
+	 * proxy password
+	 */
 	public void setProxyPassword(String proxyPassword) {
 		this.proxyPassword = proxyPassword;
 	}
 
-	/** proxy authAlias */
+	/**
+	 * proxy authAlias
+	 */
 	public void setProxyAuthAlias(String proxyAuthAlias) {
 		this.proxyAuthAlias = proxyAuthAlias;
 	}
 
-	/** proxy domain */
+	/**
+	 * proxy domain
+	 */
 	public void setProxyDomain(String proxyDomain) {
 		this.proxyDomain = proxyDomain;
 	}
@@ -1260,6 +1287,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 	/**
 	 * Separator character used when working with multiple mailboxes, specified before the separator in the object name <code>test@organisation.com|My sub folder</code> or <code>test@organisation.com|AAMkADljZDMxYzIzLTFlMjYtNGY4Mi1hM2Y1LTc2MjE5ZjIyZmMyNABGAAAAAAAu/9EmV5M6QokBRZwID1Q6BwDXQXY+F44hRbDfTB9v8jRfAAAEUqUVAADXQXY+F44hRbDfTB9v8jRfAAKA4F+pAAA=</code>.
 	 * Please consider when moving emails across mailboxes that there will be a null value returned instead of the newly created identifier.
+	 *
 	 * @ff.default |
 	 */
 	public void setMailboxObjectSeparator(String separator) {

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -125,8 +125,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 	public static final byte[] EMPTY_MESSAGE_CONTENT = new byte[0];
 	private final @Getter(onMethod = @__(@Override)) String domain = "Exchange";
 	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
-	private @Getter
-	@Setter ApplicationContext applicationContext;
+	private @Getter @Setter ApplicationContext applicationContext;
 	private @Getter String name = "ExchangeFileSystem";
 
 	private @Getter String mailAddress;
@@ -150,41 +149,24 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 	private @Getter String tenantId = null;
 
 	/* SSL */
-	private @Getter
-	@Setter String keystore;
-	private @Getter
-	@Setter String keystoreAuthAlias;
-	private @Getter
-	@Setter String keystorePassword;
-	private @Getter
-	@Setter KeystoreType keystoreType = KeystoreType.PKCS12;
-	private @Getter
-	@Setter String keystoreAlias;
-	private @Getter
-	@Setter String keystoreAliasAuthAlias;
-	private @Getter
-	@Setter String keystoreAliasPassword;
-	private @Getter
-	@Setter String keyManagerAlgorithm = null;
+	private @Getter @Setter String keystore;
+	private @Getter @Setter String keystoreAuthAlias;
+	private @Getter @Setter String keystorePassword;
+	private @Getter @Setter KeystoreType keystoreType = KeystoreType.PKCS12;
+	private @Getter @Setter String keystoreAlias;
+	private @Getter @Setter String keystoreAliasAuthAlias;
+	private @Getter @Setter String keystoreAliasPassword;
+	private @Getter @Setter String keyManagerAlgorithm = null;
 
-	private @Getter
-	@Setter String truststore = null;
-	private @Getter
-	@Setter String truststoreAuthAlias;
-	private @Getter
-	@Setter String truststorePassword = null;
-	private @Getter
-	@Setter KeystoreType truststoreType = KeystoreType.JKS;
-	private @Getter
-	@Setter String trustManagerAlgorithm = null;
-	private @Getter
-	@Setter boolean allowSelfSignedCertificates = false;
-	private @Getter
-	@Setter boolean verifyHostname = true;
-	private @Getter
-	@Setter boolean ignoreCertificateExpiredException = false;
-	private @Getter
-	@Setter boolean enableConnectionTracing = false;
+	private @Getter @Setter String truststore = null;
+	private @Getter @Setter String truststoreAuthAlias;
+	private @Getter @Setter String truststorePassword = null;
+	private @Getter @Setter KeystoreType truststoreType = KeystoreType.JKS;
+	private @Getter @Setter String trustManagerAlgorithm = null;
+	private @Getter @Setter boolean allowSelfSignedCertificates = false;
+	private @Getter @Setter boolean verifyHostname = true;
+	private @Getter @Setter boolean ignoreCertificateExpiredException = false;
+	private @Getter @Setter boolean enableConnectionTracing = false;
 
 	private @Getter CredentialFactory credentials = null;
 	private @Getter CredentialFactory proxyCredentials = null;
@@ -629,11 +611,14 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 
 		try {
 			if (emailMessage.getId() != null) {
-				PropertySet ps = new PropertySet(EmailMessageSchema.DateTimeReceived,
-					EmailMessageSchema.From, EmailMessageSchema.Subject,
+				PropertySet ps = new PropertySet(
+					EmailMessageSchema.DateTimeReceived,
+					EmailMessageSchema.From,
+					EmailMessageSchema.Subject,
 					EmailMessageSchema.DateTimeSent,
 					EmailMessageSchema.LastModifiedTime,
-					EmailMessageSchema.Size);
+					EmailMessageSchema.Size
+				);
 				if (isReadMimeContents()) {
 					ps.add(ItemSchema.MimeContent);
 				} else {

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -1117,7 +1117,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 		// only set impersonated user in oauth situation
 		if (client != null) {
 			ImpersonatedUserId impersonatedUserId = new ImpersonatedUserId(ConnectingIdType.SmtpAddress, mailbox);
-			log.debug("Set mailservice impersonated user ID to [{}]", impersonatedUserId.getId());
+			log.debug("Set mailservice impersonated user ID to [{}]", impersonatedUserId::getId);
 			service.setImpersonatedUserId(impersonatedUserId);
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -122,7 +122,6 @@ import nl.nn.adapterframework.xml.SaxElementBuilder;
  * @author Gerrit van Brakel
  */
 public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageReference, ExchangeAttachmentReference, ExchangeService> implements HasKeystore, HasTruststore {
-	public static final byte[] EMPTY_MESSAGE_CONTENT = new byte[0];
 	private final @Getter(onMethod = @__(@Override)) String domain = "Exchange";
 	private @Getter ClassLoader configurationClassLoader = Thread.currentThread().getContextClassLoader();
 	private @Getter @Setter ApplicationContext applicationContext;
@@ -176,7 +175,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 	private ExecutorService executor;
 	private ClientCredentialParameters clientCredentialParam;
 
-	private FolderId basefolderId;
+	private FolderId baseFolderId;
 
 	@Override
 	public void configure() throws ConfigurationException {
@@ -258,7 +257,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 				throw new FileSystemException("Failed to initialize MSAL ConfidentialClientApplication.", e);
 			}
 		}
-		basefolderId = getBaseFolderId(getMailAddress(), getBaseFolder());
+		baseFolderId = getBaseFolderId(getMailAddress(), getBaseFolder());
 	}
 
 	@Override
@@ -883,12 +882,12 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 			final byte[] content = ((FileAttachment) a).getContent();
 			if (content == null) {
 				log.warn("content of attachment is null");
-				return new Message(EMPTY_MESSAGE_CONTENT);
+				return Message.nullMessage();
 			}
 			return new Message(content);
 		}
 		log.warn("Attachment of unknown type: {}, returning empty message", a.getClass().getName());
-		return new Message(EMPTY_MESSAGE_CONTENT);
+		return Message.nullMessage();
 	}
 
 	@Override
@@ -1123,7 +1122,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 	}
 
 	private ExchangeObjectReference asObjectReference(String objectName) {
-		return asObjectReference(objectName, basefolderId);
+		return asObjectReference(objectName, baseFolderId);
 	}
 
 	private ExchangeObjectReference asObjectReference(String objectName, FolderId baseFolderId) {
@@ -1172,7 +1171,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 	}
 
 	/**
-	 * Url of the Exchange server. Set to e.g. https://outlook.office365.com/EWS/Exchange.asmx to speed up start up, leave empty to use autodiscovery
+	 * Url of the Exchange server. Set to e.g. https://outlook.office365.com/EWS/Exchange.asmx to speed up startup, leave empty to use autodiscovery
 	 */
 	public void setUrl(String url) {
 		this.url = url;
@@ -1240,9 +1239,7 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 	}
 
 
-	/**
-	 * proxy host
-	 */
+	/** proxy host */
 	public void setProxyHost(String proxyHost) {
 		this.proxyHost = proxyHost;
 	}
@@ -1256,30 +1253,22 @@ public class ExchangeFileSystem extends MailFileSystemBase<ExchangeMessageRefere
 		this.proxyPort = proxyPort;
 	}
 
-	/**
-	 * proxy username
-	 */
+	/** proxy username */
 	public void setProxyUsername(String proxyUsername) {
 		this.proxyUsername = proxyUsername;
 	}
 
-	/**
-	 * proxy password
-	 */
+	/** proxy password */
 	public void setProxyPassword(String proxyPassword) {
 		this.proxyPassword = proxyPassword;
 	}
 
-	/**
-	 * proxy authAlias
-	 */
+	/** proxy authAlias */
 	public void setProxyAuthAlias(String proxyAuthAlias) {
 		this.proxyAuthAlias = proxyAuthAlias;
 	}
 
-	/**
-	 * proxy domain
-	 */
+	/** proxy domain */
 	public void setProxyDomain(String proxyDomain) {
 		this.proxyDomain = proxyDomain;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeFileSystem.java
@@ -513,12 +513,12 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 
 
 	@Override
-	public DirectoryStream<EmailMessage> listFiles(String folder) throws FileSystemException {
+	public DirectoryStream<EmailMessage> listFiles(final String folder) throws FileSystemException {
 		if (!isOpen()) {
 			return null;
 		}
-		ExchangeObjectReference reference = asObjectReference(folder);
-		ExchangeService exchangeService = getConnection(reference);
+		final ExchangeObjectReference reference = asObjectReference(folder);
+		final ExchangeService exchangeService = getConnection(reference);
 		boolean invalidateConnectionOnRelease = false;
 		boolean closeConnectionOnExit = true;
 		try {
@@ -738,7 +738,11 @@ public class ExchangeFileSystem extends MailFileSystemBase<EmailMessage,Attachme
 		if (addressCollection==null) {
 			return Collections.emptyList();
 		}
-		return addressCollection.getItems().stream().map(this::cleanAddress).collect(Collectors.toList());
+		return addressCollection
+			.getItems()
+			.stream()
+			.map(this::cleanAddress)
+			.collect(Collectors.toList());
 	}
 
 

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeMessageReference.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeMessageReference.java
@@ -1,0 +1,45 @@
+/*
+   Copyright 2022 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.filesystem;
+
+import javax.annotation.Nonnull;
+
+import lombok.Getter;
+import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
+
+/**
+ * This is a wrapper around an Exchange {@link EmailMessage}, and a reference to the mailbox from which the message
+ * was read.
+ * <p/>
+ * This wrapper class is so that we can restore the connection to the correct mailbox in later processing.
+ */
+public class ExchangeMessageReference {
+	private final @Getter @Nonnull ExchangeObjectReference mailFolder;
+	private final @Getter @Nonnull EmailMessage message;
+
+	private ExchangeMessageReference(final @Nonnull ExchangeObjectReference mailFolder, final @Nonnull EmailMessage message) {
+		this.mailFolder = mailFolder;
+		this.message = message;
+	}
+
+	public String getMailAddress() {
+		return mailFolder.getMailbox();
+	}
+
+	public static ExchangeMessageReference of(final @Nonnull ExchangeObjectReference mailFolder, final @Nonnull EmailMessage message) {
+		return new ExchangeMessageReference(mailFolder, message);
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeMessageReference.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeMessageReference.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeObjectReference.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/ExchangeObjectReference.java
@@ -15,12 +15,15 @@
 */
 package nl.nn.adapterframework.filesystem;
 
-import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 import lombok.Getter;
+import lombok.Setter;
 import microsoft.exchange.webservices.data.property.complex.FolderId;
 
+/**
+ * A reference to an Exchange folder or object and its mailbox.
+ */
 public class ExchangeObjectReference {
 
 	private final @Getter boolean isStatic;

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/FileSystemListener.java
@@ -270,7 +270,7 @@ public abstract class FileSystemListener<F, FS extends IBasicFileSystem<F>> impl
 			}
 		} else {
 			@SuppressWarnings("unchecked")
-			F rawMessage = (F)rawMessageOrWrapper; // if it is not a wrapper, than it must be an F
+			F rawMessage = (F)rawMessageOrWrapper; // if it is not a wrapper, then it must be an F
 			try {
 				if (isDelete() && (processResult.isSuccessful() || StringUtils.isEmpty(getErrorFolder()))) {
 					fileSystem.deleteFile(rawMessage);

--- a/core/src/main/java/nl/nn/adapterframework/receivers/ExchangeMailListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/ExchangeMailListener.java
@@ -17,13 +17,13 @@ package nl.nn.adapterframework.receivers;
 
 import org.apache.commons.lang3.StringUtils;
 
-import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
-import microsoft.exchange.webservices.data.property.complex.Attachment;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.configuration.ConfigurationWarning;
 import nl.nn.adapterframework.doc.Category;
 import nl.nn.adapterframework.encryption.KeystoreType;
+import nl.nn.adapterframework.filesystem.ExchangeAttachmentReference;
 import nl.nn.adapterframework.filesystem.ExchangeFileSystem;
+import nl.nn.adapterframework.filesystem.ExchangeMessageReference;
 import nl.nn.adapterframework.filesystem.MailListener;
 
 /**
@@ -32,7 +32,7 @@ import nl.nn.adapterframework.filesystem.MailListener;
  * @author Gerrit van Brakel
  */
 @Category("Advanced")
-public class ExchangeMailListener extends MailListener<EmailMessage,Attachment,ExchangeFileSystem> {
+public class ExchangeMailListener extends MailListener<ExchangeMessageReference, ExchangeAttachmentReference,ExchangeFileSystem> {
 
 	public final String EXCHANGE_FILE_SYSTEM ="nl.nn.adapterframework.filesystem.ExchangeFileSystem";
 

--- a/core/src/main/java/nl/nn/adapterframework/senders/ExchangeFolderSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/ExchangeFolderSender.java
@@ -15,17 +15,17 @@
  */
 package nl.nn.adapterframework.senders;
 
-import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 import nl.nn.adapterframework.configuration.ConfigurationWarning;
 import nl.nn.adapterframework.encryption.KeystoreType;
 import nl.nn.adapterframework.filesystem.ExchangeFileSystem;
+import nl.nn.adapterframework.filesystem.ExchangeMessageReference;
 import nl.nn.adapterframework.filesystem.FileSystemSender;
 /**
- * Implementation of a {@link FileSystemSender} that enables to manipulate messages in a Exchange folder.
+ * Implementation of a {@link FileSystemSender} that enables to manipulate messages in an Exchange folder.
  *
  * @author Gerrit van Brakel
  */
-public class ExchangeFolderSender extends FileSystemSender<EmailMessage,ExchangeFileSystem> {
+public class ExchangeFolderSender extends FileSystemSender<ExchangeMessageReference,ExchangeFileSystem> {
 
 	public final String EXCHANGE_FILE_SYSTEM ="nl.nn.adapterframework.filesystem.ExchangeFileSystem";
 

--- a/test-integration/pom.xml
+++ b/test-integration/pom.xml
@@ -53,14 +53,13 @@
 		<dependency>
 			<groupId>org.junit.vintage</groupId>
 			<artifactId>junit-vintage-engine</artifactId>
-			<version>[5.9.1,)</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>[5.9.1,)</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
 </project>
+

--- a/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ExchangeFileSystemTest.java
+++ b/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ExchangeFileSystemTest.java
@@ -8,13 +8,11 @@ import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
-import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
-import microsoft.exchange.webservices.data.property.complex.Attachment;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.receivers.ExchangeMailListener;
 import nl.nn.adapterframework.testutil.PropertyUtil;
 
-public class ExchangeFileSystemTest extends MailFileSystemTestBase<EmailMessage, Attachment, ExchangeFileSystem>{
+public class ExchangeFileSystemTest extends MailFileSystemTestBase<ExchangeMessageReference, ExchangeAttachmentReference, ExchangeFileSystem>{
 
 	//private String DEFAULT_URL = "https://outlook.office365.com/EWS/Exchange.asmx";
 
@@ -34,8 +32,6 @@ public class ExchangeFileSystemTest extends MailFileSystemTestBase<EmailMessage,
 		ExchangeFileSystem fileSystem = new ExchangeFileSystem();
 		if (StringUtils.isNotEmpty(url)) fileSystem.setUrl(url);
 		fileSystem.setMailAddress(mailaddress);
-		fileSystem.setUsername(username);
-		fileSystem.setPassword(password);
 		fileSystem.setBaseFolder(basefolder1);
 		fileSystem.setClientId(client_id);
 		fileSystem.setClientSecret(client_secr);
@@ -54,8 +50,6 @@ public class ExchangeFileSystemTest extends MailFileSystemTestBase<EmailMessage,
 		autowireByName(listener);
 		if (StringUtils.isNotEmpty(url)) listener.setUrl(url);
 		listener.setMailAddress(mailaddress);
-		listener.setUsername(username);
-		listener.setPassword(password);
 		listener.setBaseFolder(basefolder1);
 		listener.setInputFolder(sourceFolder);
 		if (inProcessFolder!=null) listener.setInProcessFolder(inProcessFolder);
@@ -69,7 +63,7 @@ public class ExchangeFileSystemTest extends MailFileSystemTestBase<EmailMessage,
 		String sourceFolder = "SourceFolder";
 		String inProcessFolder = "InProcessFolder";
 
-		EmailMessage orgMsg = prepareFolderAndGetFirstMessage(sourceFolder, null);
+		ExchangeMessageReference orgMsg = prepareFolderAndGetFirstMessage(sourceFolder, null);
 		if (!fileSystem.folderExists(inProcessFolder)) {
 			fileSystem.createFolder(inProcessFolder);
 		}
@@ -81,12 +75,12 @@ public class ExchangeFileSystemTest extends MailFileSystemTestBase<EmailMessage,
 		Map<String,Object> threadContext1 = new HashMap<>();
 		Map<String,Object> threadContext2 = new HashMap<>();
 
-		EmailMessage msg1 = listener1.getRawMessage(threadContext1);
+		ExchangeMessageReference msg1 = listener1.getRawMessage(threadContext1);
 		String msgId1 = listener1.getIdFromRawMessage(msg1, threadContext1);
 		System.out.println("1st msgid ["+msgId1+"], filename ["+fileSystem.getName(msg1)+"]");
 
 
-		EmailMessage msg2 = listener2.getRawMessage(threadContext2);
+		ExchangeMessageReference msg2 = listener2.getRawMessage(threadContext2);
 		String msgId2 = listener2.getIdFromRawMessage(msg2, threadContext2);
 		System.out.println("2nd msgid ["+msgId2+"], filename ["+fileSystem.getName(msg2)+"]");
 

--- a/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ExchangeMailListenerTest.java
+++ b/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ExchangeMailListenerTest.java
@@ -9,8 +9,6 @@ import java.util.Map;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
-import microsoft.exchange.webservices.data.core.service.item.Item;
 import nl.nn.adapterframework.core.PipeLine.ExitState;
 import nl.nn.adapterframework.core.PipeLineResult;
 import nl.nn.adapterframework.receivers.ExchangeMailListener;
@@ -31,14 +29,14 @@ public class ExchangeMailListenerTest extends ExchangeMailListenerTestBase {
 		String recipient=mailaddress_fancy;
 		String from=recipient;
 		String subject="With Attachements";
-		
+
 		configureAndOpen(targetFolder,null);
-		
+
 		Map<String,Object> threadContext=new HashMap<String,Object>();
-		EmailMessage rawMessage = mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNotNull(rawMessage);
 		String message = mailListener.extractMessage(rawMessage, threadContext).asString();
-		
+
 		System.out.println("message ["+message+"]");
 		//assertEquals("name","x",fileSystem.getName(file));
 
@@ -54,14 +52,14 @@ public class ExchangeMailListenerTest extends ExchangeMailListenerTestBase {
 		String recipient=mailaddress_fancy;
 		String from=recipient;
 		String subject="With Attachements";
-		
+
 		configureAndOpen(targetFolder,null);
-		
+
 		Map<String,Object> threadContext=new HashMap<String,Object>();
-		EmailMessage rawMessage = mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNotNull(rawMessage);
 		String message = mailListener.extractMessage(rawMessage, threadContext).asString();
-		
+
 		System.out.println("message ["+message+"]");
 		//assertEquals("name","x",fileSystem.getName(file));
 
@@ -81,30 +79,30 @@ public class ExchangeMailListenerTest extends ExchangeMailListenerTestBase {
 //		String subfolder="Basic";
 //		String filename = "readFile";
 //		String contents = "Tekst om te lezen";
-		
+
 		mailListener.setBaseFolder(baseFolder);
 		mailListener.setProcessedFolder(processedFolder);
 		mailListener.setLogFolder(logFolder);
 		mailListener.setCreateFolders(true);
 		configureAndOpen(targetFolder,null);
-		
+
 //		if (!folderContainsMessages(subfolder)) {
 //			createFile(null, filename, contents);
 //			waitForActionToFinish();
 //		}
-		
+
 		Map<String,Object> threadContext=new HashMap<String,Object>();
-		Item rawMessage = (Item)mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNotNull("no message found", rawMessage);
 
 		PipeLineResult plr = new PipeLineResult();
 		plr.setState(ExitState.SUCCESS);
 		plr.setResult(new Message("ResultOfPipeline"));
 		plr.setExitCode(200);
-		
+
 		mailListener.afterMessageProcessed(plr, rawMessage, threadContext);
 
-		
+
 	}
 
 }

--- a/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ExchangeMailListenerTestBase.java
+++ b/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ExchangeMailListenerTestBase.java
@@ -15,7 +15,6 @@ import java.util.Properties;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import microsoft.exchange.webservices.data.core.service.item.EmailMessage;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.IMessageBrowser;
 import nl.nn.adapterframework.core.IMessageBrowsingIterator;
@@ -285,8 +284,9 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 
 		Map<String,Object> threadContext=new HashMap<String,Object>();
 
-		EmailMessage rawMessage = mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNotNull(rawMessage);
+		assertNotNull(rawMessage.getMessage());
 		String message = mailListener.extractMessage(rawMessage, threadContext).asString();
 
 		System.out.println("message ["+message+"]");
@@ -330,8 +330,9 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 
 		Map<String,Object> threadContext=new HashMap<String,Object>();
 
-		EmailMessage rawMessage = mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNotNull(rawMessage);
+		assertNotNull(rawMessage.getMessage());
 		String message = mailListener.extractMessage(rawMessage, threadContext).asString();
 
 		System.out.println("message ["+message+"]");
@@ -381,8 +382,9 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 
 		Map<String,Object> threadContext=new HashMap<String,Object>();
 
-		EmailMessage rawMessage = mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNotNull(rawMessage);
+		assertNotNull(rawMessage.getMessage());
 		String message = mailListener.extractMessage(rawMessage, threadContext).asString();
 
 		System.out.println("message ["+message+"]");
@@ -432,8 +434,9 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 
 		Map<String,Object> threadContext=new HashMap<String,Object>();
 
-		EmailMessage rawMessage = mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNotNull(rawMessage);
+		assertNotNull(rawMessage.getMessage());
 		String message = mailListener.extractMessage(rawMessage, threadContext).asString();
 
 		System.out.println("message ["+message+"]");
@@ -468,7 +471,7 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 
 		Map<String,Object> threadContext=new HashMap<String,Object>();
 
-		EmailMessage rawMessage = mailListener.getRawMessage(threadContext);
+		ExchangeMessageReference rawMessage = mailListener.getRawMessage(threadContext);
 		assertNull(rawMessage);
 	}
 
@@ -571,7 +574,7 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 		mailListener.configure();
 		mailListener.open();
 
-		IMessageBrowser<EmailMessage> browser = mailListener.getMessageBrowser(ProcessState.DONE);
+		IMessageBrowser<ExchangeMessageReference> browser = mailListener.getMessageBrowser(ProcessState.DONE);
 		assertNotNull(browser);
 
 		int messageCount = browser.getMessageCount();
@@ -590,7 +593,7 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 			}
 		}
 		for (String id:itemIds) {
-			EmailMessage email = browser.browseMessage(id);
+			ExchangeMessageReference email = browser.browseMessage(id);
 			Message message = mailListener.getFileSystem().readFile(email, null);
 			log.debug("Id: "+id+"\nEmail: "+message.asString());
 		}
@@ -604,7 +607,7 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 		mailListener.open();
 		mailListener.close();
 
-		IMessageBrowser<EmailMessage> browser = mailListener.getMessageBrowser(ProcessState.DONE);
+		IMessageBrowser<ExchangeMessageReference> browser = mailListener.getMessageBrowser(ProcessState.DONE);
 		assertNotNull(browser);
 
 		assertEquals(-1, browser.getMessageCount());
@@ -622,7 +625,7 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 			}
 		}
 		for (String id:itemIds) {
-			EmailMessage email = browser.browseMessage(id);
+			ExchangeMessageReference email = browser.browseMessage(id);
 			Message message = mailListener.getFileSystem().readFile(email, null);
 			log.debug("Id: "+id+"\nEmail: "+message.asString());
 		}
@@ -634,7 +637,7 @@ public abstract class ExchangeMailListenerTestBase extends HelperedFileSystemTes
 		mailListener.configure();
 		mailListener.open();
 
-		IMessageBrowser<EmailMessage> browser = mailListener.getMessageBrowser(ProcessState.DONE);
+		IMessageBrowser<ExchangeMessageReference> browser = mailListener.getMessageBrowser(ProcessState.DONE);
 		assertNotNull(browser);
 
 		MessageBrowsingFilter filter = new MessageBrowsingFilter();

--- a/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ImapFileSystemTest.java
+++ b/test-integration/src/test/java/nl/nn/adapterframework/filesystem/ImapFileSystemTest.java
@@ -1,8 +1,7 @@
 package nl.nn.adapterframework.filesystem;
 
-import javax.mail.Message;
-import javax.mail.internet.MimeBodyPart;
-
+import jakarta.mail.Message;
+import jakarta.mail.internet.MimeBodyPart;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.testutil.PropertyUtil;
 
@@ -15,7 +14,7 @@ public class ImapFileSystemTest  extends MailFileSystemTestBase<Message, MimeBod
 	private String username    = PropertyUtil.getProperty(PROPERTY_FILE, "username");
 	private String password    = PropertyUtil.getProperty(PROPERTY_FILE, "password");
 	private String basefolder1 = PropertyUtil.getProperty(PROPERTY_FILE, "basefolder1");
-	
+
 
 	@Override
 	protected ImapFileSystem createFileSystem() throws ConfigurationException {

--- a/test-integration/src/test/java/nl/nn/adapterframework/filesystem/MailFileSystemTestBase.java
+++ b/test-integration/src/test/java/nl/nn/adapterframework/filesystem/MailFileSystemTestBase.java
@@ -28,7 +28,7 @@ import nl.nn.adapterframework.xml.SaxElementBuilder;
  *
  * creates a number of fs_test... folders
  */
-public abstract class MailFileSystemTestBase<M,A,FS> extends SelfContainedBasicFileSystemTest<M, IMailFileSystem<M,A>>{
+public abstract class MailFileSystemTestBase<M,A,FS extends IMailFileSystem<M, A>> extends SelfContainedBasicFileSystemTest<M, FS>{
 
 	protected String PROPERTY_FILE = "ExchangeMail.properties";
 

--- a/test-integration/src/test/java/nl/nn/adapterframework/http/OAuthAccessTokenManagerTest.java
+++ b/test-integration/src/test/java/nl/nn/adapterframework/http/OAuthAccessTokenManagerTest.java
@@ -44,7 +44,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, httpSender, expiry);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, false, httpSender, expiry);
 
 		String accessToken = accessTokenManager.getAccessToken(null, true);
 
@@ -60,7 +60,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, httpSender, expiry);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, false, httpSender, expiry);
 
 		String accessToken = accessTokenManager.getAccessToken(null, true);
 
@@ -76,7 +76,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, httpSender, expiry);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, false, httpSender, expiry);
 
 		HttpAuthenticationException exception = assertThrows(HttpAuthenticationException.class, ()->accessTokenManager.getAccessToken(null, true));
 		assertThat(exception.getMessage(), containsString("unauthorized_client"));
@@ -91,7 +91,7 @@ public class OAuthAccessTokenManagerTest {
 
 		CredentialFactory client_cf = new CredentialFactory(null, clientId, clientSecret);
 
-		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, httpSender, expiry);
+		OAuthAccessTokenManager accessTokenManager = new OAuthAccessTokenManager(tokenEndpoint, scope, client_cf, true, false, httpSender, expiry);
 
 		HttpAuthenticationException exception = assertThrows(HttpAuthenticationException.class, ()->accessTokenManager.getAccessToken(null, true));
 		assertThat(exception.getMessage(), containsString("404"));


### PR DESCRIPTION
These are changes to make sure we can always reconnect a mail-message with the mailbox from which it was read.

This still needs to be tested against an actual exchange service.