### PR TITLE
Fix local resource lookup when preparsing XSD's

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
+++ b/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
@@ -53,7 +53,7 @@ public class IntraGrammarPoolEntityResolver implements XMLEntityResolver { //Cla
 				&& resourceIdentifier.getLiteralSystemId() == null
 				&& resourceIdentifier.getNamespace() == null
 				&& resourceIdentifier.getPublicId() == null) {
-			// The baseSystemId may be resolved to a namespace.
+			// The baseSystemId may be resolved to a namespace with all other values being NULL. This behavior changed between the 7.7 and 7.8 branch.
 			// This seems to happen sometimes. For example with import of
 			// sub01a.xsd and sub05.xsd without namespace in
 			// /XmlValidator/import_include/root.xsd of Ibis4TestIAF. The

--- a/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
+++ b/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
@@ -85,14 +85,9 @@ public class IntraGrammarPoolEntityResolver implements XMLEntityResolver { //Cla
 		// Throw an exception so the XercesValidationErrorHandler picks this up as ERROR.
 		// Do not rely on the fallback resource resolver, this will bypass configuration classloaders.
 		// See https://github.com/ibissource/iaf/issues/3973
-		StringBuilder errorMessage = new StringBuilder("Cannot find resource [");
-		errorMessage.append(resourceIdentifier.getExpandedSystemId());
-		errorMessage.append("] from systemId [");
-		errorMessage.append(resourceIdentifier.getLiteralSystemId());
-		errorMessage.append("] with base [");
-		errorMessage.append(resourceIdentifier.getBaseSystemId());
-		errorMessage.append("]");
-		throw new XNIException(errorMessage.toString());
+		throw new XNIException("Cannot find resource [" + resourceIdentifier.getExpandedSystemId() +
+			"] from systemId [" + resourceIdentifier.getLiteralSystemId() +
+			"] with base [" + resourceIdentifier.getBaseSystemId() + "]");
 	}
 
 }

--- a/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
+++ b/core/src/main/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolver.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -24,6 +24,8 @@ import org.apache.xerces.xni.XNIException;
 import org.apache.xerces.xni.parser.XMLEntityResolver;
 import org.apache.xerces.xni.parser.XMLInputSource;
 
+import nl.nn.adapterframework.core.IScopeProvider;
+import nl.nn.adapterframework.core.Resource;
 import nl.nn.adapterframework.util.LogUtil;
 
 /**
@@ -33,45 +35,64 @@ import nl.nn.adapterframework.util.LogUtil;
  * 
  * @author Gerrit van Brakel
  */
-public class IntraGrammarPoolEntityResolver implements XMLEntityResolver {
+public class IntraGrammarPoolEntityResolver implements XMLEntityResolver { //ClassLoaderXmlEntityResolver 
 	protected Logger log = LogUtil.getLogger(this);
 
-	private List<Schema> schemas;
+	private final List<Schema> schemas;
+	private final IScopeProvider scopeProvider;
 
-	public IntraGrammarPoolEntityResolver(List<Schema> schemas) {
+	public IntraGrammarPoolEntityResolver(IScopeProvider scopeProvider, List<Schema> schemas) {
 		this.schemas = schemas;
+		this.scopeProvider = scopeProvider;
 	}
 
 	@Override
 	public XMLInputSource resolveEntity(XMLResourceIdentifier resourceIdentifier) throws XNIException, IOException {
 		if (log.isDebugEnabled()) log.debug("resolveEntity publicId ["+resourceIdentifier.getPublicId()+"] baseSystemId ["+resourceIdentifier.getBaseSystemId()+"] expandedSystemId ["+resourceIdentifier.getExpandedSystemId()+"] literalSystemId ["+resourceIdentifier.getLiteralSystemId()+"] namespace ["+resourceIdentifier.getNamespace()+"]");
-		if (resourceIdentifier.getBaseSystemId() == null
-				&& resourceIdentifier.getExpandedSystemId() == null
+		if (resourceIdentifier.getExpandedSystemId() == null
 				&& resourceIdentifier.getLiteralSystemId() == null
 				&& resourceIdentifier.getNamespace() == null
 				&& resourceIdentifier.getPublicId() == null) {
+			// The baseSystemId may be resolved to a namespace.
 			// This seems to happen sometimes. For example with import of
 			// sub01a.xsd and sub05.xsd without namespace in
 			// /XmlValidator/import_include/root.xsd of Ibis4TestIAF. The
 			// default resolve entity implementation seems to ignore it, hence
 			// return null.
-			if (log.isTraceEnabled()) log.trace("all relevant Ids are null, returning null");
+			log.trace("all relevant Ids are null, returning null. baseSystemId [{}]", resourceIdentifier::getBaseSystemId);
 			return null;
 		}
 
 		String targetNamespace = resourceIdentifier.getNamespace();
-		if (targetNamespace!=null) {
+		if (targetNamespace != null) {
 			for(Schema schema:schemas) {
 				if (log.isTraceEnabled()) log.trace("matching namespace ["+targetNamespace+"] to schema ["+schema.getSystemId()+"]");
 				if (targetNamespace.equals(schema.getSystemId())) {
 					return new XMLInputSource(null, targetNamespace, null, schema.getReader(), null);
 				}
 			}
+
 			log.warn("namespace ["+targetNamespace+"] not found in list of schemas");
 		}
-		log.warn("resolveEntity publicId ["+resourceIdentifier.getPublicId()+"] baseSystemId ["+resourceIdentifier.getBaseSystemId()+"] expandedSystemId ["+resourceIdentifier.getExpandedSystemId()+"] literalSystemId ["+resourceIdentifier.getLiteralSystemId()+"] namespace ["+resourceIdentifier.getNamespace()+"] falling back to external resource");
-		// return explicit resource reference, do not rely on default mechanism by returning null. This appears to be unreliable. See https://github.com/ibissource/iaf/issues/3973
-		return new XMLInputSource(resourceIdentifier);
+
+		if(resourceIdentifier.getExpandedSystemId() != null) {
+			Resource resource = Resource.getResource(scopeProvider, resourceIdentifier.getExpandedSystemId());
+			if(resource != null) {
+				return resource.asXMLInputSource();
+			}
+		}
+
+		// Throw an exception so the XercesValidationErrorHandler picks this up as ERROR.
+		// Do not rely on the fallback resource resolver, this will bypass configuration classloaders.
+		// See https://github.com/ibissource/iaf/issues/3973
+		StringBuilder errorMessage = new StringBuilder("Cannot find resource [");
+		errorMessage.append(resourceIdentifier.getExpandedSystemId());
+		errorMessage.append("] from systemId [");
+		errorMessage.append(resourceIdentifier.getLiteralSystemId());
+		errorMessage.append("] with base [");
+		errorMessage.append(resourceIdentifier.getBaseSystemId());
+		errorMessage.append("]");
+		throw new XNIException(errorMessage.toString());
 	}
 
 }

--- a/core/src/main/java/nl/nn/adapterframework/validation/XSD.java
+++ b/core/src/main/java/nl/nn/adapterframework/validation/XSD.java
@@ -46,6 +46,7 @@ import org.xml.sax.InputSource;
 import lombok.Getter;
 import lombok.Setter;
 import nl.nn.adapterframework.configuration.ConfigurationException;
+import nl.nn.adapterframework.configuration.classloaders.ClassLoaderBase;
 import nl.nn.adapterframework.core.IScopeProvider;
 import nl.nn.adapterframework.util.ClassUtils;
 import nl.nn.adapterframework.util.LogUtil;
@@ -390,10 +391,10 @@ public class XSD implements Schema, Comparable<XSD> {
 
 	@Override
 	public String getSystemId() {
-		if (url == null) {
+		if (resource == null) {
 			return getTargetNamespace(); // used by IntraGrammarPoolEntityResolver
 		}
-		return url.toExternalForm();
+		return ClassLoaderBase.CLASSPATH_RESOURCE_SCHEME+resource; //Must prefix this with the `classpath:` protocol else Xerces will append the `file:` protocol
 	}
 
 	public boolean hasDependency(Set<XSD> xsds) {

--- a/core/src/main/java/nl/nn/adapterframework/validation/XercesXmlValidator.java
+++ b/core/src/main/java/nl/nn/adapterframework/validation/XercesXmlValidator.java
@@ -186,7 +186,7 @@ public class XercesXmlValidator extends AbstractXmlValidator {
 		XMLGrammarPool grammarPool = new XMLGrammarPoolImpl();
 		Set<String> namespaceSet = new HashSet<String>();
 		XMLGrammarPreparser preparser = new XMLGrammarPreparser(symbolTable);
-		preparser.setEntityResolver(new IntraGrammarPoolEntityResolver(schemas));
+		preparser.setEntityResolver(new IntraGrammarPoolEntityResolver(this, schemas));
 		preparser.registerPreparser(XMLGrammarDescription.XML_SCHEMA, null);
 		preparser.setProperty(GRAMMAR_POOL, grammarPool);
 		preparser.setFeature(NAMESPACES_FEATURE_ID, true);
@@ -221,7 +221,7 @@ public class XercesXmlValidator extends AbstractXmlValidator {
 		return preparseResult;
 	}
 
-	private static Grammar preparse(XMLGrammarPreparser preparser, String schemasId, Schema schema) throws ConfigurationException {
+	private Grammar preparse(XMLGrammarPreparser preparser, String schemasId, Schema schema) throws ConfigurationException {
 		try {
 			return preparser.preparseGrammar(XMLGrammarDescription.XML_SCHEMA, schemaToXMLInputSource(schema));
 		} catch (IOException e) {
@@ -433,8 +433,7 @@ class XercesValidationErrorHandler implements XMLErrorHandler {
 
 	@Override
 	public void error(String domain, String key, XMLParseException e) throws XNIException {
-		// In case the XSD doesn't exist throw an exception to prevent the
-		// the adapter from starting.
+		// In case the XSD doesn't exist re-throw the XNIException to prevent the adapter from starting.
 		if (e.getMessage() != null && e.getMessage().startsWith("schema_reference.4: Failed to read schema document '")) {
 			throw e;
 		}

--- a/core/src/test/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolverTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/validation/IntraGrammarPoolEntityResolverTest.java
@@ -1,0 +1,199 @@
+package nl.nn.adapterframework.validation;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.io.Reader;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarFile;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.xerces.xni.XMLResourceIdentifier;
+import org.apache.xerces.xni.XNIException;
+import org.apache.xerces.xni.parser.XMLInputSource;
+import org.junit.Test;
+
+import lombok.Getter;
+import lombok.Setter;
+import nl.nn.adapterframework.configuration.classloaders.ClassLoaderBase;
+import nl.nn.adapterframework.configuration.classloaders.JarFileClassLoader;
+import nl.nn.adapterframework.core.IScopeProvider;
+import nl.nn.adapterframework.core.Resource;
+import nl.nn.adapterframework.testutil.TestAssertions;
+import nl.nn.adapterframework.testutil.TestFileUtils;
+import nl.nn.adapterframework.testutil.TestScopeProvider;
+import nl.nn.adapterframework.util.StreamUtil;
+
+public class IntraGrammarPoolEntityResolverTest {
+
+	private static final IScopeProvider scopeProvider = new TestScopeProvider();
+	private static final List<Schema> EMPTY_SCHEMAS_LIST = Collections.emptyList();
+
+	private String publicId="fakePublicId";
+	public static final String JAR_FILE = "/ClassLoader/zip/classLoader-test.zip";
+
+	private XMLResourceIdentifier getXMLResourceIdentifier(String href, String namespace) {
+		XMLResourceIdentifier resourceIdentifier = new ResourceIdentifier();
+		resourceIdentifier.setPublicId(publicId);
+
+		if(namespace != null) {
+			resourceIdentifier.setNamespace(namespace);
+		}
+
+		resourceIdentifier.setBaseSystemId(ClassLoaderBase.CLASSPATH_RESOURCE_SCHEME+"Xslt/importDocument/importLookupRelative1.xsl");
+		resourceIdentifier.setExpandedSystemId(ClassLoaderBase.CLASSPATH_RESOURCE_SCHEME+href);
+		if(href.startsWith("../")) {
+			resourceIdentifier.setExpandedSystemId(ClassLoaderBase.CLASSPATH_RESOURCE_SCHEME+"Xslt/"+href.substring(3));
+		}
+		resourceIdentifier.setLiteralSystemId(ClassLoaderBase.CLASSPATH_RESOURCE_SCHEME+href); // this file is known to be in the root of the classpath
+		return resourceIdentifier;
+	}
+
+	public void noClassPathSchemaResource(String base) throws Exception {
+		List<Schema> schemas = new ArrayList<>();
+		schemas.add(new ResourceSchema("namespace1", "AppConstants.properties"));
+		schemas.add(new ResourceSchema("namespace2", "dummy.properties"));
+
+		IntraGrammarPoolEntityResolver resolver = new IntraGrammarPoolEntityResolver(scopeProvider, schemas);
+
+		XMLResourceIdentifier resourceIdentifier = getXMLResourceIdentifier(base+"AppConstants.properties", "namespace1");
+
+		XMLInputSource inputSource = resolver.resolveEntity(resourceIdentifier);
+		assertNotNull(inputSource);
+
+		String expected = TestFileUtils.getTestFile("/AppConstants.properties");
+		TestAssertions.assertEqualsIgnoreCRLF(expected, xmlInputSource2String(inputSource));
+	}
+
+	@Test
+	public void noClassPathSchemaResourceRelative() throws Exception {
+		noClassPathSchemaResource("./");
+		noClassPathSchemaResource("non/existing/folder/");
+		noClassPathSchemaResource("/non/existing/folder/");
+		noClassPathSchemaResource("./non/../folder/");
+		noClassPathSchemaResource(ClassLoaderBase.CLASSPATH_RESOURCE_SCHEME+"./non/../folder/");
+	}
+
+	@Test
+	public void importFromSchemaWithoutNamespaceWithClassPathPrefixInJarBytesClassLoaderWithParent() throws Exception {
+		List<Schema> schemas = new ArrayList<>();
+		ClassLoader localClassLoader = Thread.currentThread().getContextClassLoader();
+		try {
+			ClassLoader bytesClassLoader = createBytesClassLoaderWithNoLocalAccess();
+			Thread.currentThread().setContextClassLoader(bytesClassLoader);
+			IntraGrammarPoolEntityResolver resolver = new IntraGrammarPoolEntityResolver(scopeProvider, schemas);
+
+			XMLResourceIdentifier resourceIdentifier = getXMLResourceIdentifier("../../ClassLoader/subfolder/fileOnlyOnLocalClassPath.xml", "unused");
+
+			XMLInputSource inputSource = resolver.resolveEntity(resourceIdentifier);
+			assertNotNull(inputSource);
+
+			String expected = TestFileUtils.getTestFile("/ClassLoader/subfolder/fileOnlyOnLocalClassPath.xml");
+			TestAssertions.assertEqualsIgnoreCRLF(expected, xmlInputSource2String(inputSource));
+		} finally {
+			Thread.currentThread().setContextClassLoader(localClassLoader);
+		}
+	}
+
+	@Test
+	public void importFromSchemaWithoutNamespaceWithClassPathPrefixInJarBytesClassLoaderWithNoParent() throws Exception {
+		ClassLoader localClassLoader = Thread.currentThread().getContextClassLoader();
+		try {
+			ClassLoader bytesClassLoader = createBytesClassLoaderWithNoLocalAccess();
+			Thread.currentThread().setContextClassLoader(bytesClassLoader);
+			IntraGrammarPoolEntityResolver resolver = new IntraGrammarPoolEntityResolver(TestScopeProvider.wrap(bytesClassLoader), EMPTY_SCHEMAS_LIST);
+
+			XMLResourceIdentifier resourceIdentifier = getXMLResourceIdentifier("../../ClassLoader/subfolder/fileOnlyOnLocalClassPath.xml", "unused");
+
+			XNIException thrown = assertThrows(XNIException.class, () -> resolver.resolveEntity(resourceIdentifier));
+			assertThat(thrown.getMessage(), startsWith("Cannot find resource ["));
+		} finally {
+			Thread.currentThread().setContextClassLoader(localClassLoader);
+		}
+	}
+
+	@Test //See issue #3973. Should throw an XNIException to trigger XercesValidationErrorHandler#error which rethrows the Exception.
+	public void localClassPathAbsoluteRef() throws Exception {
+		IntraGrammarPoolEntityResolver resolver = new IntraGrammarPoolEntityResolver(scopeProvider, EMPTY_SCHEMAS_LIST);
+
+		XMLResourceIdentifier resourceIdentifier = getXMLResourceIdentifier("/this/schema/does/not/exist.xsd", null);
+
+		XNIException thrown = assertThrows(XNIException.class, () -> resolver.resolveEntity(resourceIdentifier));
+		assertThat(thrown.getMessage(), startsWith("Cannot find resource ["));
+	}
+
+	@Test
+	public void classLoaderXmlEntityResolverCannotLoadExternalEntities() throws Exception {
+		IntraGrammarPoolEntityResolver resolver = new IntraGrammarPoolEntityResolver(scopeProvider, EMPTY_SCHEMAS_LIST);
+
+		XMLResourceIdentifier resourceIdentifier = getXMLResourceIdentifier("ftp://share.host.org/UDTSchema.xsd", null);
+		URL url = this.getClass().getResource("/ClassLoader/request-ftp.xsd");
+		assertNotNull(url);
+		resourceIdentifier.setBaseSystemId(url.toExternalForm());
+
+		XNIException thrown = assertThrows(XNIException.class, () -> {
+			resolver.resolveEntity(resourceIdentifier);
+		});
+
+		assertThat(thrown.getMessage(), startsWith("Cannot find resource ["));
+	}
+
+	public static ClassLoader createBytesClassLoaderWithNoLocalAccess() throws Exception {
+		URL file = TestFileUtils.class.getResource(JAR_FILE);
+		assertNotNull("jar url not found", file);
+		JarFile jarFile = new JarFile(file.getFile());
+		assertNotNull("jar file not found", jarFile);
+
+		JarFileClassLoader cl = new JarFileClassLoader(new ClassLoader(null) {}); //No parent classloader, getResource and getResources will not fall back
+		cl.setJar(file.getFile());
+		cl.configure(null, "");
+		return cl;
+	}
+
+	private class ResourceIdentifier implements XMLResourceIdentifier {
+		private @Getter @Setter String publicId;
+		private @Getter @Setter String expandedSystemId;
+		private @Getter @Setter String literalSystemId;
+		private @Getter @Setter String baseSystemId;
+		private @Getter @Setter String namespace;
+	}
+
+	private static String xmlInputSource2String(XMLInputSource inputSource) throws IOException {
+		Reader reader = null;
+		if(inputSource.getCharacterStream() != null) {
+			reader = inputSource.getCharacterStream();
+		} else if(inputSource.getByteStream() != null) {
+			reader = StreamUtil.getCharsetDetectingInputStreamReader(inputSource.getByteStream());
+		}
+		if(reader == null) {
+			throw new IOException("unable to read XMLInputSource, no Character nor Byte stream available");
+		}
+		return IOUtils.toString(reader);
+	}
+
+	private static class ResourceSchema implements Schema {
+		private final String alias;
+		private final Resource resource;
+
+		public ResourceSchema(String alias, String lookup) {
+			this.resource = Resource.getResource(scopeProvider, lookup);
+			this.alias = alias;
+		}
+
+		@Override
+		public Reader getReader() throws IOException {
+			return StreamUtil.getCharsetDetectingInputStreamReader(resource.openStream());
+		}
+
+		@Override
+		public String getSystemId() {
+			return alias;
+		}
+	}
+}

--- a/core/src/test/java/nl/nn/adapterframework/validation/Json2XmlValidatorTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/validation/Json2XmlValidatorTest.java
@@ -189,7 +189,7 @@ public class Json2XmlValidatorTest extends XmlValidatorTestBase {
 	}
 
 	@Test
-	public void issue3973MissingLocalWarning() throws Exception { //waar test je de local warning?
+	public void issue3973MissingLocalWarning() throws Exception {
 		TestConfiguration config = new TestConfiguration();
 
 		Json2XmlValidator json2xml = config.createBean(Json2XmlValidator.class);

--- a/core/src/test/resources/Validation/IncludeNonExistingResource/main.xsd
+++ b/core/src/test/resources/Validation/IncludeNonExistingResource/main.xsd
@@ -4,7 +4,7 @@
 	elementFormDefault="qualified" 
 	attributeFormDefault="unqualified"
 >
-	<xsd:include schemaLocation="CommonResponse.xsd"/>
+	<xsd:include namespace="http://waf.nl/XSD/Generic/Response" schemaLocation="CommonResponse.xsd"/>
 	<xsd:element name="GetDocument_Request">
 		<xsd:complexType>
 			<xsd:sequence>


### PR DESCRIPTION
There were several defects in the `IntraGrammarPoolEntityResolver`.
- When a resources cannot be found it should throw an `XNIException`, see [ClassLoaderXmlEntityResolver](https://github.com/ibissource/iaf/blob/7.7-release/core/src/main/java/nl/nn/adapterframework/xml/ClassLoaderXmlEntityResolver.java#L77). This in turn should trigger an `error` in the [XercesXmlValidator preparser ErrorHandler](https://github.com/ibissource/iaf/blob/7.7-release/core/src/main/java/nl/nn/adapterframework/validation/XercesXmlValidator.java#L467).
The exception is rethrown, causing the validator/pipe to not start, and thus give the developer feedback of a missing import.

 - When using absolute file paths Xerces appends the file protocol to each imported systemId. By manually prepending the `classpath` protocol this no longer happens and relative imports can be used.
 - The IntraGrammarPoolEntityResolver should have a fallback mechanism to find imports without namespaces (and thus are not present in the `schemas` cache.

After fixing these issues, it became apparent that the `XMLResourceIdentifier`s in the `XmlEntityResolver` may contain resources with only a baseSystemId (with as value the namespace of the root document). This behavior has changed since the 7.7-release branch where all fields (including the baseSystemId) where NULL. 


For the gross of changes between 7.7 and 7.8, see the original [ClassLoaderXmlEntityResolver](https://github.com/ibissource/iaf/blame/3ef19c8c5e330ac381a250dbd1c2189d5967dcbf/core/src/main/java/nl/nn/adapterframework/xml/ClassLoaderXmlEntityResolver.java) and prs #3017 and #3262.

To me it's unfortunately still unclear why the baseSystemId behavior has changed, and as such I don't have an explicit test for this.