### PR TITLE
Fix imports from the credential-provider project

### DIFF
--- a/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvokerTest.java
+++ b/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/CmisHttpInvokerTest.java
@@ -26,7 +26,7 @@ import org.mockito.MockitoAnnotations;
 import nl.nn.adapterframework.http.HttpResponseMock;
 import nl.nn.adapterframework.testutil.TestAssertions;
 import nl.nn.adapterframework.testutil.TestFileUtils;
-import nl.nn.credentialprovider.util.Misc;
+import nl.nn.adapterframework.util.Misc;
 
 public class CmisHttpInvokerTest extends Mockito {
 
@@ -45,13 +45,13 @@ public class CmisHttpInvokerTest extends Mockito {
 			protected CmisHttpSender createSender() {
 				try {
 					CmisHttpSender sender = spy(super.createSender());
-	
+
 					CloseableHttpClient httpClient = mock(CloseableHttpClient.class);
-	
+
 					//Mock all requests
 					when(httpClient.execute(any(HttpHost.class), any(HttpRequestBase.class), any(HttpContext.class))).thenAnswer(new HttpResponseMock());
 					when(sender.getHttpClient()).thenReturn(httpClient);
-	
+
 					return sender;
 				} catch (Throwable t) {
 					t.printStackTrace();

--- a/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/CmisSenderTestBase.java
+++ b/cmis/src/test/java/nl/nn/adapterframework/extensions/cmis/CmisSenderTestBase.java
@@ -42,7 +42,7 @@ import nl.nn.adapterframework.core.PipeLineSession;
 import nl.nn.adapterframework.extensions.cmis.CmisSessionBuilder.BindingTypes;
 import nl.nn.adapterframework.senders.SenderTestBase;
 import nl.nn.adapterframework.testutil.TestFileUtils;
-import nl.nn.credentialprovider.util.Misc;
+import nl.nn.adapterframework.util.Misc;
 
 public class CmisSenderTestBase extends SenderTestBase<CmisSender> {
 	protected static final boolean STUBBED = true;

--- a/console/src/test/resources/DeploymentSpecifics.properties
+++ b/console/src/test/resources/DeploymentSpecifics.properties
@@ -1,3 +1,3 @@
 instance.name=TestConfiguration
 instance.name.lc=testconfiguration
-log.dir=${user.dir}\\target\\test-logs
+log.dir=${user.dir}/target/test-logs

--- a/core/src/main/java/nl/nn/adapterframework/errormessageformatters/ErrorMessageFormatter.java
+++ b/core/src/main/java/nl/nn/adapterframework/errormessageformatters/ErrorMessageFormatter.java
@@ -24,15 +24,16 @@ import org.apache.logging.log4j.Logger;
 
 import lombok.Getter;
 import nl.nn.adapterframework.core.IErrorMessageFormatter;
-import nl.nn.adapterframework.core.IScopeProvider;
 import nl.nn.adapterframework.core.INamedObject;
+import nl.nn.adapterframework.core.IScopeProvider;
 import nl.nn.adapterframework.stream.Message;
 import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.ClassUtils;
 import nl.nn.adapterframework.util.LogUtil;
+import nl.nn.adapterframework.util.Misc;
 import nl.nn.adapterframework.util.XmlBuilder;
 import nl.nn.adapterframework.util.XmlUtils;
-import nl.nn.adapterframework.util.Misc;
+
 /**
  * This <code>ErrorMessageFormatter</code> wraps an error in an XML string.
  *

--- a/core/src/main/java/nl/nn/adapterframework/management/bus/endpoints/BusEndpointBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/management/bus/endpoints/BusEndpointBase.java
@@ -31,9 +31,9 @@ import nl.nn.adapterframework.core.Adapter;
 import nl.nn.adapterframework.core.IPipe;
 import nl.nn.adapterframework.management.bus.BusException;
 import nl.nn.adapterframework.receivers.Receiver;
+import nl.nn.adapterframework.util.FilenameUtils;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.SpringUtils;
-import nl.nn.adapterframework.util.FilenameUtils;
 
 public class BusEndpointBase implements ApplicationContextAware, InitializingBean {
 	protected Logger log = LogUtil.getLogger(this);

--- a/core/src/main/java/nl/nn/adapterframework/util/Misc.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/Misc.java
@@ -172,7 +172,7 @@ public class Misc {
 
 		//Unique string is <ipaddress with length 4*3><currentTime with length 13><hashcode with length 6>
 		StringBuilder s = new StringBuilder();
-		s.append(ia).append(getCurrentTimeMillis()).append(hash);
+		s.append(ia).append(System.currentTimeMillis()).append(hash);
 
 		return s.toString();
 	}
@@ -189,13 +189,6 @@ public class Misc {
 	 */
 	public static int unsignedByteToInt(byte b) {
 		return b & 0xFF;
-	}
-
-	/**
-	 * @return the current time in milliseconds.
-	 */
-	public static synchronized long getCurrentTimeMillis(){
-		return System.currentTimeMillis();
 	}
 
 	public static String insertAuthorityInUrlString(String url, String authAlias, String username, String password) {

--- a/core/src/test/java/nl/nn/adapterframework/management/bus/endpoints/TestDatabaseMigrator.java
+++ b/core/src/test/java/nl/nn/adapterframework/management/bus/endpoints/TestDatabaseMigrator.java
@@ -31,8 +31,8 @@ import nl.nn.adapterframework.management.bus.BusTopic;
 import nl.nn.adapterframework.management.bus.ResponseMessage;
 import nl.nn.adapterframework.testutil.TestFileUtils;
 import nl.nn.adapterframework.testutil.TestScopeProvider;
-import nl.nn.adapterframework.util.StreamUtil;
 import nl.nn.adapterframework.util.Misc;
+import nl.nn.adapterframework.util.StreamUtil;
 
 public class TestDatabaseMigrator extends BusTestBase {
 

--- a/core/src/test/java/nl/nn/adapterframework/stream/MessageTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/stream/MessageTest.java
@@ -55,10 +55,10 @@ import nl.nn.adapterframework.testutil.SerializationTester;
 import nl.nn.adapterframework.testutil.TestAppender;
 import nl.nn.adapterframework.testutil.TestFileUtils;
 import nl.nn.adapterframework.util.LogUtil;
+import nl.nn.adapterframework.util.Misc;
 import nl.nn.adapterframework.util.StreamUtil;
 import nl.nn.adapterframework.util.XmlUtils;
 import nl.nn.adapterframework.xml.XmlWriter;
-import nl.nn.adapterframework.util.Misc;
 
 public class MessageTest {
 	protected Logger log = LogUtil.getLogger(this);

--- a/credentialProvider/src/main/java/nl/nn/credentialprovider/util/Misc.java
+++ b/credentialProvider/src/main/java/nl/nn/credentialprovider/util/Misc.java
@@ -151,7 +151,7 @@ public class Misc {
 
 		//Unique string is <ipaddress with length 4*3><currentTime with length 13><hashcode with length 6>
 		StringBuilder s = new StringBuilder();
-		s.append(ia).append(getCurrentTimeMillis()).append(hash);
+		s.append(ia).append(System.currentTimeMillis()).append(hash);
 
 		return s.toString();
 	}
@@ -168,13 +168,6 @@ public class Misc {
 	 */
 	public static int unsignedByteToInt(byte b) {
 		return (int) b & 0xFF;
-	}
-
-	/**
-	 * @return the current time in milliseconds.
-	 */
-	public static synchronized long getCurrentTimeMillis(){
-		return System.currentTimeMillis();
 	}
 
 	/**
@@ -437,7 +430,7 @@ public class Misc {
 	}
 
 	/**
-	 * Concatenates two strings, if specified, uses the separator in between two strings. 
+	 * Concatenates two strings, if specified, uses the separator in between two strings.
 	 * Does not use any separators if both or one of the strings are empty.
 	 *<p>
 	 *     Example:


### PR DESCRIPTION
Fix imports of `Misc` that were importing from the `credential-provider` module to instead import the version in `core` module.

NB: Moving `Misc` and some other util classes to a separate Maven module will be another PR, first I want to get the imports right.