### PR TITLE
Fix cred provider build breakage

### DIFF
--- a/credentialProvider/pom.xml
+++ b/credentialProvider/pom.xml
@@ -117,6 +117,28 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-checkstyle-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<version>3.4.1</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<createDependencyReducedPom>true</createDependencyReducedPom>
+							<dependencyReducedPomLocation>
+								${java.io.tmpdir}/dependency-reduced-pom.xml
+							</dependencyReducedPomLocation>
+							<minimizeJar>true</minimizeJar>
+							<shadedArtifactAttached>true</shadedArtifactAttached>
+							<shadedClassifierName>fatjar</shadedClassifierName>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/credentialProvider/src/test/java/nl/nn/credentialprovider/PropertyFileCredentialFactoryTest.java
+++ b/credentialProvider/src/test/java/nl/nn/credentialprovider/PropertyFileCredentialFactoryTest.java
@@ -122,6 +122,6 @@ public class PropertyFileCredentialFactoryTest {
 
 		// Arrange
 		List<String> sortedAliases = aliases.stream().sorted().collect(Collectors.toList());
-		assertEquals("[noUsername, singleValue, straight]", sortedAliases.toString());
+		assertEquals("[noUsername, singleValue, slash, straight]", sortedAliases.toString());
 	}
 }

--- a/docker/Tomcat/webapp/pom.xml
+++ b/docker/Tomcat/webapp/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>org.ibissource</groupId>
 			<artifactId>credentialprovider</artifactId>
+			<version>${project.version}</version>
 			<classifier>fatjar</classifier>
 		</dependency>
 		<dependency>

--- a/docker/Tomcat/webapp/pom.xml
+++ b/docker/Tomcat/webapp/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>org.ibissource</groupId>
 			<artifactId>credentialprovider</artifactId>
+			<classifier>fatjar</classifier>
 		</dependency>
 		<dependency>
 			<groupId>${oracle.driver.groupid}</groupId>


### PR DESCRIPTION
- Fix a unit test that broke
- Fix Tomcat startup by building Credential Provider as a fatjar, and depending on that.

Local build of Tomcat Docker image seems to work and start up.