### PR TITLE
Create bean to validate database connectivity

### DIFF
--- a/cmis/pom.xml
+++ b/cmis/pom.xml
@@ -73,6 +73,13 @@
 			<version>${cxf.version}</version>
 		</dependency>
 
+		<dependency><!-- is added in the JDK 9 profile in CXF-Parent -->
+			<groupId>org.apache.geronimo.specs</groupId>
+			<artifactId>geronimo-jta_1.1_spec</artifactId>
+			<version>${geronimo.jta.spec.version}</version>
+			<scope>provided</scope>
+		</dependency>
+
 		<dependency>
 			<groupId>org.ibissource</groupId>
 			<artifactId>ibis-adapterframework-core</artifactId>

--- a/cmis/pom.xml
+++ b/cmis/pom.xml
@@ -23,6 +23,7 @@
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 		</dependency>
+
 		<dependency>
 			<groupId>org.apache.chemistry.opencmis</groupId>
 			<artifactId>chemistry-opencmis-client-impl</artifactId>
@@ -60,24 +61,33 @@
 					<groupId>jakarta.activation</groupId>
 					<artifactId>jakarta.activation-api</artifactId>
 				</exclusion>
+				<exclusion><!-- added by the JDK 9 profile in CXF-Parent -->
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jta_1.1_spec</artifactId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-transports-http</artifactId>
 			<version>${cxf.version}</version>
+			<exclusions>
+				<exclusion><!-- added by the JDK 9 profile in CXF-Parent -->
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jta_1.1_spec</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.cxf</groupId>
 			<artifactId>cxf-rt-ws-policy</artifactId>
 			<version>${cxf.version}</version>
-		</dependency>
-
-		<dependency><!-- is added in the JDK 9 profile in CXF-Parent -->
-			<groupId>org.apache.geronimo.specs</groupId>
-			<artifactId>geronimo-jta_1.1_spec</artifactId>
-			<version>${geronimo.jta.spec.version}</version>
-			<scope>provided</scope>
+			<exclusions>
+				<exclusion><!-- added by the JDK 9 profile in CXF-Parent -->
+					<groupId>org.apache.geronimo.specs</groupId>
+					<artifactId>geronimo-jta_1.1_spec</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -115,7 +115,6 @@
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>
 			<artifactId>geronimo-jms_1.1_spec</artifactId>
-			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.messaginghub</groupId>

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcListener.java
@@ -182,19 +182,19 @@ public class JdbcListener<M extends Object> extends JdbcFacade implements IPeeka
 	public M getRawMessage(Map<String,Object> threadContext) throws ListenerException {
 		if (isConnectionsArePooled()) {
 			try (Connection c = getConnection()) {
-				return getRawMessage(c,threadContext);
+				return getRawMessage(c, threadContext);
 			} catch (JdbcException | SQLException e) {
 				throw new ListenerException(e);
 			}
 		}
 		synchronized (connection) {
-			return getRawMessage(connection,threadContext);
+			return getRawMessage(connection, threadContext);
 		}
 	}
 
 	protected M getRawMessage(Connection conn, Map<String,Object> threadContext) throws ListenerException {
-		String query=preparedSelectQuery;
-		try (Statement stmt= conn.createStatement()) {
+		String query = preparedSelectQuery;
+		try (Statement stmt = conn.createStatement()) {
 			stmt.setFetchSize(1);
 			if (trace && log.isDebugEnabled()) log.debug("executing query for ["+query+"]");
 			try (ResultSet rs=stmt.executeQuery(query)) {

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcMessageBrowser.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcMessageBrowser.java
@@ -317,7 +317,7 @@ public abstract class JdbcMessageBrowser<M> extends JdbcFacade implements IMessa
 				}
 			}
 		} catch (Exception e) {
-			throw new ListenerException("cannot determine message count",e);
+			throw new ListenerException("cannot determine message count", e);
 		}
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/JdbcSession.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/JdbcSession.java
@@ -15,11 +15,11 @@
 */
 package nl.nn.adapterframework.jdbc.dbms;
 
-import java.sql.SQLException;
+import nl.nn.adapterframework.jdbc.JdbcException;
 
 public abstract class JdbcSession implements AutoCloseable {
 
 	@Override
-	public abstract void close() throws SQLException;
+	public abstract void close() throws JdbcException;
 
 }

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/MariaDbDbmsSupport.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/MariaDbDbmsSupport.java
@@ -84,13 +84,21 @@ public class MariaDbDbmsSupport extends MySqlDbmsSupport {
 		return selectQuery+(batchSize>0?" LIMIT "+batchSize:"")+" FOR UPDATE WAIT "+wait;
 	}
 
+	/*
+	 * See: https://dev.mysql.com/doc/refman/8.0/en/innodb-consistent-read.html
+	 * 
+	 * Consistent read is the default mode in which InnoDB processes SELECT statements in
+	 * READ COMMITTED and REPEATABLE READ isolation levels. A consistent read does not set
+	 * any locks on the tables it accesses, and therefore other sessions are free to modify
+	 * those tables at the same time a consistent read is being performed on the table.
+	 */
 	@Override
 	public String prepareQueryTextForWorkQueuePeeking(int batchSize, String selectQuery, int wait) throws JdbcException {
 		if (StringUtils.isEmpty(selectQuery) || !selectQuery.toLowerCase().startsWith(KEYWORD_SELECT)) {
 			throw new JdbcException("query ["+selectQuery+"] must start with keyword ["+KEYWORD_SELECT+"]");
 		}
 		if (wait < 0) {
-			return selectQuery+(batchSize>0?" LIMIT "+batchSize:""); // Mariadb has no 'skip locked'
+			return selectQuery+(batchSize>0?" LIMIT "+batchSize:"");
 		}
 		throw new IllegalArgumentException(getDbms()+" does not support setting lock wait timeout in query");
 	}

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/MySqlDbmsSupport.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/MySqlDbmsSupport.java
@@ -100,12 +100,12 @@ public class MySqlDbmsSupport extends GenericDbmsSupport {
 	// commented out prepareSessionForNonLockingRead(), see https://dev.mysql.com/doc/refman/8.0/en/innodb-consistent-read.html
 //	@Override
 //	public JdbcSession prepareSessionForNonLockingRead(Connection conn) throws JdbcException {
-//		JdbcUtil.executeStatement(conn, "SET TRANSACTION ISOLATION LEVEL READ COMMITTED");
+//		JdbcUtil.executeStatement(conn, "SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED");
 //		JdbcUtil.executeStatement(conn, "START TRANSACTION");
 //		return new JdbcSession() {
 //
 //			@Override
-//			public void close() throws Exception {
+//			public void close() throws JdbcException {
 //				JdbcUtil.executeStatement(conn, "COMMIT");
 //			}
 //

--- a/core/src/main/java/nl/nn/adapterframework/lifecycle/IbisApplicationContext.java
+++ b/core/src/main/java/nl/nn/adapterframework/lifecycle/IbisApplicationContext.java
@@ -245,7 +245,11 @@ public class IbisApplicationContext implements Closeable {
 	 * TODO: retrieve this (automatically/) through Spring
 	 */
 	private void lookupApplicationModules() {
-		List<String> modulesToScanFor = new ArrayList<String>();
+		if(!iafModules.isEmpty()) {
+			return;
+		}
+
+		List<String> modulesToScanFor = new ArrayList<>();
 
 		modulesToScanFor.add("ibis-adapterframework-akamai");
 		modulesToScanFor.add("ibis-adapterframework-cmis");
@@ -259,6 +263,8 @@ public class IbisApplicationContext implements Closeable {
 		modulesToScanFor.add("ibis-adapterframework-sap");
 		modulesToScanFor.add("ibis-adapterframework-tibco");
 		modulesToScanFor.add("ibis-adapterframework-webapp");
+		modulesToScanFor.add("ibis-adapterframework-console");
+		modulesToScanFor.add("ibis-adapterframework-aws");
 
 		registerApplicationModules(modulesToScanFor);
 	}

--- a/core/src/main/java/nl/nn/adapterframework/lifecycle/VerifyDatabaseConnectionBean.java
+++ b/core/src/main/java/nl/nn/adapterframework/lifecycle/VerifyDatabaseConnectionBean.java
@@ -1,0 +1,90 @@
+/*
+   Copyright 2023 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.lifecycle;
+
+import java.sql.Connection;
+
+import javax.annotation.Nonnull;
+import javax.naming.NamingException;
+import javax.sql.DataSource;
+
+import org.apache.logging.log4j.Logger;
+import org.springframework.beans.BeanInstantiationException;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.DefaultTransactionDefinition;
+
+import lombok.Setter;
+import nl.nn.adapterframework.jdbc.IDataSourceFactory;
+import nl.nn.adapterframework.jndi.JndiDataSourceFactory;
+import nl.nn.adapterframework.util.AppConstants;
+import nl.nn.adapterframework.util.LogUtil;
+
+public class VerifyDatabaseConnectionBean implements ApplicationContextAware, InitializingBean {
+
+	private Logger log = LogUtil.getLogger(this);
+	private String defaultDatasource = AppConstants.getInstance().getProperty(JndiDataSourceFactory.DEFAULT_DATASOURCE_NAME_PROPERTY);
+	private boolean requiresDatabase = AppConstants.getInstance().getBoolean("jdbc.required", true);
+	private @Setter ApplicationContext applicationContext;
+
+	@Override
+	public void afterPropertiesSet() throws Exception {
+		if(requiresDatabase) {
+			PlatformTransactionManager transactionManager = getTransactionManager();
+
+			//Try to create a new transaction to check if there is a connection to the database
+			TransactionStatus status = transactionManager.getTransaction(new DefaultTransactionDefinition());
+
+			try (Connection connection = getDefaultDataSource().getConnection()) {
+				int isolationLevel = connection.getTransactionIsolation();
+				if(isolationLevel != Connection.TRANSACTION_NONE) {
+					log.info("expected a transacted connection got isolation level [{}]", isolationLevel);
+				}
+			}
+
+			if(status != null) { //If there is a transaction close it!
+				transactionManager.commit(status);
+			}
+		}
+	}
+
+	private @Nonnull PlatformTransactionManager getTransactionManager() {
+		try {
+			PlatformTransactionManager txManager;
+			txManager = applicationContext.getBean("txManager", PlatformTransactionManager.class);
+			log.info("found transaction manager to [{}]", txManager);
+			return txManager;
+		} catch (BeanCreationException | BeanInstantiationException | NoSuchBeanDefinitionException e) {
+			throw new IllegalStateException("no TransactionManager found or configured", e);
+		}
+	}
+
+	private @Nonnull DataSource getDefaultDataSource() {
+		try {
+			IDataSourceFactory dsf = applicationContext.getBean(IDataSourceFactory.class);
+			return dsf.getDataSource(defaultDatasource);
+		} catch (BeanCreationException | BeanInstantiationException | NoSuchBeanDefinitionException e) {
+			throw new IllegalStateException("no DataSourceFactory found or configured", e);
+		} catch (NamingException e) {
+			throw new IllegalStateException("no default datasource found", e);
+		}
+	}
+}

--- a/core/src/main/java/nl/nn/adapterframework/lifecycle/VerifyDatabaseConnectionBean.java
+++ b/core/src/main/java/nl/nn/adapterframework/lifecycle/VerifyDatabaseConnectionBean.java
@@ -55,7 +55,7 @@ public class VerifyDatabaseConnectionBean implements ApplicationContextAware, In
 
 			try (Connection connection = getDefaultDataSource().getConnection()) {
 				int isolationLevel = connection.getTransactionIsolation();
-				if(isolationLevel != Connection.TRANSACTION_NONE) {
+				if(isolationLevel == Connection.TRANSACTION_NONE) {
 					log.info("expected a transacted connection got isolation level [{}]", isolationLevel);
 				}
 			}

--- a/core/src/main/java/nl/nn/adapterframework/management/bus/endpoints/AdapterStatus.java
+++ b/core/src/main/java/nl/nn/adapterframework/management/bus/endpoints/AdapterStatus.java
@@ -462,7 +462,9 @@ public class AdapterStatus extends BusEndpointBase {
 					try {
 						errorStoreMessageCount += esmb.getMessageCount();
 					} catch (ListenerException e) {
-						log.warn("Cannot determine number of messages in errorstore of ["+rcv.getName()+"]", e);
+						// Only log the stacktrace when loglevel == INFO. Otherwise it will pollute the log too much.
+						if(log.isInfoEnabled()) log.warn("Cannot determine number of messages in errorstore of [{}]", rcv.getName(), e);
+						else log.warn("Cannot determine number of messages in errorstore of [{}]: {}", rcv::getName, e::getMessage);
 					}
 				}
 				IMessageBrowser<?> mlmb = rcv.getMessageBrowser(ProcessState.DONE);
@@ -470,7 +472,9 @@ public class AdapterStatus extends BusEndpointBase {
 					try {
 						messageLogMessageCount += mlmb.getMessageCount();
 					} catch (ListenerException e) {
-						log.warn("Cannot determine number of messages in messagelog of ["+rcv.getName()+"]", e);
+						// Only log the stacktrace when loglevel == INFO. Otherwise it will pollute the log too much.
+						if(log.isInfoEnabled()) log.warn("Cannot determine number of messages in errorstore of [{}]", rcv.getName(), e);
+						else log.warn("Cannot determine number of messages in errorstore of [{}]: {}", rcv::getName, e::getMessage);
 					}
 				}
 			}

--- a/core/src/main/resources/SpringApplicationContext.xml
+++ b/core/src/main/resources/SpringApplicationContext.xml
@@ -39,6 +39,8 @@
 
 	<bean id="jdbcPropertySourceFactory" class="nl.nn.adapterframework.jdbc.JdbcPropertySourceFactory" />
 
+	<bean id="VerifyDatabaseConnectionBean" class="nl.nn.adapterframework.lifecycle.VerifyDatabaseConnectionBean" />
+
 	<bean
 		name="hostnamePropertySourcePostProcessor"
 		class="nl.nn.adapterframework.configuration.HostnamePropertySourcePostProcessor"

--- a/core/src/main/resources/springUnmanagedDeployment.xml
+++ b/core/src/main/resources/springUnmanagedDeployment.xml
@@ -29,7 +29,6 @@
 		class="nl.nn.adapterframework.unmanaged.DefaultIbisManager"
 		autowire="byName"
 		>
-		<property name="transactionManager" ref="txManager"/>
 	</bean>
 
 	<bean

--- a/core/src/test/java/nl/nn/adapterframework/testutil/mock/MockIbisManager.java
+++ b/core/src/test/java/nl/nn/adapterframework/testutil/mock/MockIbisManager.java
@@ -34,8 +34,4 @@ public class MockIbisManager extends DefaultIbisManager implements ApplicationCo
 		unload((String) null);
 	}
 
-	@Override
-	public void afterPropertiesSet() throws Exception {
-		// Don't initialize a TransactionManager
-	}
 }

--- a/pom.xml
+++ b/pom.xml
@@ -752,6 +752,17 @@
 										</excludes>
 										<message>the implementation com.sun.activation:jakarta.activation is included and it contains the api classes too</message>
 									</bannedDependencies>
+									<bannedDependencies>
+										<excludes>
+											<exclude>org.apache.geronimo.specs:geronimo-jms_1.1_spec:*:jar:compile</exclude>
+											<exclude>org.apache.geronimo.specs:geronimo-jms_2.0_spec:*:jar:compile</exclude>
+											<exclude>org.apache.geronimo.javamail:geronimo-javamail_1.4_mail:*:jar:compile</exclude>
+											<exclude>org.apache.geronimo.specs:geronimo-jta_1.1_spec:*:jar:compile</exclude>
+											<exclude>javax.servlet:javax.servlet-api:*:jar:compile</exclude>
+											<exclude>jakarta.servlet:jakarta.servlet-api:*:jar:compile</exclude>
+										</excludes>
+										<message>These dependencies should be provided by the Application Server!</message>
+									</bannedDependencies>
 								</rules>
 							</configuration>
 						</execution>


### PR DESCRIPTION
In CXF-Parent the `geronimo-jta_1.1_spec` is added through a profile (`java9-plus`), see [pom.xml](https://repo1.maven.org/maven2/org/apache/cxf/cxf-parent/3.5.5/cxf-parent-3.5.5.pom).