### PR TITLE
Remove double slash in monitoring url

### DIFF
--- a/webapp/src/main/webapp/iaf/gui/js/controllers.js
+++ b/webapp/src/main/webapp/iaf/gui/js/controllers.js
@@ -2573,7 +2573,7 @@ angular.module('iaf.beheerconsole')
 	});
 
 	function getUrl(monitor, trigger) {
-		var url = "/configurations/"+$scope.selectedConfiguration+"/monitors/"+monitor.name;
+		var url = "configurations/"+$scope.selectedConfiguration+"/monitors/"+monitor.name;
 		if(trigger != undefined && trigger != "") url += "/triggers/"+trigger.id;
 		return url;
 	}


### PR DESCRIPTION
Backport of #4694