### PR TITLE
Add warning when transaction-mgr does silent rollback during commit

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationUtils.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/ConfigurationUtils.java
@@ -65,7 +65,7 @@ import nl.nn.adapterframework.util.SpringUtils;
 import nl.nn.adapterframework.util.StreamUtil;
 
 /**
- * Functions to manipulate the configuration. 
+ * Functions to manipulate the configuration.
  *
  * @author  Peter Leeuwenburgh
  * @author  Jaco de Groot
@@ -112,7 +112,7 @@ public class ConfigurationUtils {
 	}
 
 	/**
-	 * Get the version (configuration.version + configuration.timestmap) 
+	 * Get the version (configuration.version + configuration.timestmap)
 	 * from the configuration's AppConstants
 	 */
 	public static String getConfigurationVersion(ClassLoader classLoader) {
@@ -292,7 +292,7 @@ public class ConfigurationUtils {
 			itx.setRollbackOnly();
 			throw new ConfigurationException(e);
 		} finally {
-			itx.commit();
+			itx.complete();
 			JdbcUtil.fullClose(conn, rs);
 			qs.close();
 		}
@@ -415,7 +415,7 @@ public class ConfigurationUtils {
 	}
 
 	/**
-	 * 
+	 *
 	 * @return A map with all configurations to load (KEY = ConfigurationName, VALUE = ClassLoaderType)
 	 */
 	public static Map<String, Class<? extends IConfigurationClassLoader>> retrieveAllConfigNames(ApplicationContext applicationContext) {

--- a/core/src/main/java/nl/nn/adapterframework/core/IbisTransaction.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/IbisTransaction.java
@@ -17,16 +17,16 @@ package nl.nn.adapterframework.core;
 
 import javax.transaction.TransactionManager;
 
-import nl.nn.adapterframework.util.LogUtil;
-import nl.nn.adapterframework.jta.SpringTxManagerProxy;
-
-import nl.nn.adapterframework.util.UUIDUtil;
 import org.apache.logging.log4j.Logger;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.TransactionDefinition;
 import org.springframework.transaction.TransactionStatus;
 import org.springframework.transaction.jta.JtaTransactionManager;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+import nl.nn.adapterframework.jta.SpringTxManagerProxy;
+import nl.nn.adapterframework.util.LogUtil;
+import nl.nn.adapterframework.util.UUIDUtil;
 
 /**
  * Class which generates extra logging when starting and committing transactions.
@@ -122,7 +122,13 @@ public class IbisTransaction {
 		return txStatus.isCompleted();
 	}
 
-	public void commit() {
+	/**
+	 * Complete this transaction by either committing it or rolling it back, depending on the
+	 * transaction status.
+	 *
+	 * In case a rollback is performed, a successful rollback will not raise an exception.
+	 */
+	public void complete() {
 		boolean mustRollback = txStatus.isRollbackOnly();
 		if (txIsNew) {
 			if (mustRollback) {

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcTransactionalStorage.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcTransactionalStorage.java
@@ -729,7 +729,7 @@ public class JdbcTransactionalStorage<S extends Serializable> extends JdbcTableM
 			}
 		} finally {
 			if (itx!=null) {
-				itx.commit();
+				itx.complete();
 			}
 		}
 

--- a/core/src/main/java/nl/nn/adapterframework/processors/TransactionAttributePipeLineProcessor.java
+++ b/core/src/main/java/nl/nn/adapterframework/processors/TransactionAttributePipeLineProcessor.java
@@ -93,7 +93,7 @@ public class TransactionAttributePipeLineProcessor extends PipeLineProcessorBase
 				}
 			} finally {
 				//txManager.commit(txStatus);
-				itx.commit();
+				itx.complete();
 			}
 		} catch (RuntimeException e) {
 			throw new PipeRunException(null, "RuntimeException calling PipeLine with tx attribute ["

--- a/core/src/main/java/nl/nn/adapterframework/processors/TransactionAttributePipeProcessor.java
+++ b/core/src/main/java/nl/nn/adapterframework/processors/TransactionAttributePipeProcessor.java
@@ -83,7 +83,7 @@ public class TransactionAttributePipeProcessor extends PipeProcessorBase {
 				throw new PipeRunException(pipe, "Caught unknown checked exception", t);
 			}
 		} finally {
-			itx.commit();
+			itx.complete();
 		}
 		return pipeRunResult;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/Receiver.java
@@ -1156,7 +1156,7 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IR
 					itx.setRollbackOnly();
 					throw new ListenerException(t);
 				} finally {
-					itx.commit();
+					itx.complete();
 				}
 			} catch (ListenerException e) {
 				IbisTransaction itxErrorStorage = new IbisTransaction(txManager, TXNEW_CTRL, "errorStorage of receiver [" + getName() + "]");
@@ -1174,7 +1174,7 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IR
 					itxErrorStorage.setRollbackOnly();
 					log.warn(getLogPrefix()+"could not update comments in errorStorage",e1);
 				} finally {
-					itxErrorStorage.commit();
+					itxErrorStorage.complete();
 				}
 				throw e;
 			}
@@ -1332,7 +1332,7 @@ public class Receiver<M> extends TransactionAttributes implements IManagable, IR
 							// NB: Spring will take care of executing a commit or a rollback;
 							// Spring will also ONLY commit the transaction if it was newly created
 							// by the above call to txManager.getTransaction().
-							itx.commit();
+							itx.complete();
 						} else {
 							String msg="Transaction already completed; we didn't expect this";
 							warn(msg);

--- a/core/src/main/java/nl/nn/adapterframework/util/Locker.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/Locker.java
@@ -234,7 +234,7 @@ public class Locker extends JdbcFacade implements HasTransactionAttribute {
 				}
 			} finally {
 				if(itx != null) {
-					itx.commit();
+					itx.complete();
 				}
 			}
 		}
@@ -261,7 +261,7 @@ public class Locker extends JdbcFacade implements HasTransactionAttribute {
 					throw e;
 				} finally {
 					if(itx != null) {
-						itx.commit();
+						itx.complete();
 					}
 				}
 			}

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/ConcurrentManagedTransactionTester.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/ConcurrentManagedTransactionTester.java
@@ -8,7 +8,7 @@ import nl.nn.adapterframework.jta.SpringTxManagerProxy;
 import nl.nn.adapterframework.testutil.ConcurrentActionTester;
 
 public abstract class ConcurrentManagedTransactionTester extends ConcurrentActionTester {
-	
+
 	private PlatformTransactionManager txManager;
 	private IbisTransaction mainItx;
 
@@ -16,7 +16,7 @@ public abstract class ConcurrentManagedTransactionTester extends ConcurrentActio
 		super();
 		this.txManager=txManager;
 	}
-	
+
 	@Override
 	public void initAction() throws Exception {
 		TransactionDefinition txDef = SpringTxManagerProxy.getTransactionDefinition(TransactionDefinition.PROPAGATION_REQUIRES_NEW,20);
@@ -26,8 +26,8 @@ public abstract class ConcurrentManagedTransactionTester extends ConcurrentActio
 	@Override
 	public void finalizeAction() throws Exception {
 		if(mainItx != null) {
-			mainItx.commit();
+			mainItx.complete();
 		}
 	}
-	
+
 }

--- a/core/src/test/java/nl/nn/adapterframework/util/LockerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/LockerTest.java
@@ -337,7 +337,7 @@ public class LockerTest extends TransactionManagerTestBase {
 				log.warn("exception for second insert: "+e.getMessage(), e);
 			} finally {
 				if(mainItx != null) {
-					mainItx.commit();
+					mainItx.complete();
 				}
 			}
 


### PR DESCRIPTION
Add warnings to the `SpringTxManagerProxy.commit()` method when it silently does a rollback instead.

Normally when you commit a transaction marked for rollback-only, then there will be an exception. Current TX manager code does rollback without exception. This can hide the fact that a transaction was not actually committed and we want to find out how that happens and where, and how often.

Rename `IbisTransaction.commit()` to `.complete()` since that is what it is designed to do, not commit.