### PR TITLE
Fix loadOnStartup check in CmisProxyServlet

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/configuration/ClassLoaderManager.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/ClassLoaderManager.java
@@ -30,6 +30,7 @@ import nl.nn.adapterframework.util.AppConstants;
 import nl.nn.adapterframework.util.ClassUtils;
 import nl.nn.adapterframework.util.LogUtil;
 import nl.nn.adapterframework.util.MessageKeeper.MessageKeeperLevel;
+import nl.nn.adapterframework.util.StringUtil;
 
 /**
  * Loads a ClassLoader on a per Configuration basis. It is possible to specify the ClassLoader type and to make 
@@ -89,7 +90,7 @@ public class ClassLoaderManager {
 				if(!method.getName().startsWith("set") || method.getParameterTypes().length != 1)
 					continue;
 
-				String setter = firstCharToLower(method.getName().substring(3));
+				String setter = StringUtil.lcFirst(method.getName().substring(3));
 				String value = APP_CONSTANTS.getProperty(parentProperty+setter);
 				if(value == null)
 					continue;
@@ -142,10 +143,6 @@ public class ClassLoaderManager {
 			return Integer.parseInt(value);
 		else
 			return value;
-	}
-
-	private String firstCharToLower(String input) {
-		return input.substring(0, 1).toLowerCase() + input.substring(1);
 	}
 
 	private ClassLoader init(String configurationName, String classLoaderType) throws ClassLoaderException {

--- a/core/src/main/java/nl/nn/adapterframework/util/ClassUtils.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/ClassUtils.java
@@ -314,9 +314,7 @@ public abstract class ClassUtils {
 
 	private static Object parseValueToSet(Method m, String value) throws IllegalArgumentException {
 		Class<?> setterArgumentClass = m.getParameters()[0].getType();
-		char[] c = m.getName().substring(3).toCharArray();
-		c[0] = Character.toLowerCase(c[0]);
-		String fieldName = new String(c);
+		String fieldName = StringUtil.lcFirst(m.getName().substring(3));
 
 		//Try to parse as primitive
 		return convertToType(setterArgumentClass, fieldName, value);

--- a/iaf-commons/src/main/java/nl/nn/adapterframework/util/StringUtil.java
+++ b/iaf-commons/src/main/java/nl/nn/adapterframework/util/StringUtil.java
@@ -221,8 +221,6 @@ public class StringUtil {
 		return count;
 	}
 
-	// Not sure what's better here...
-	// return input.substring(0, 1).toLowerCase() + input.substring(1);
 	/**
 	 * Turns the first Char into lower case.
 	 */

--- a/iaf-commons/src/main/java/nl/nn/adapterframework/util/StringUtil.java
+++ b/iaf-commons/src/main/java/nl/nn/adapterframework/util/StringUtil.java
@@ -220,4 +220,24 @@ public class StringUtil {
 			count++;
 		return count;
 	}
+
+	// Not sure what's better here...
+	// return input.substring(0, 1).toLowerCase() + input.substring(1);
+	/**
+	 * Turns the first Char into lower case.
+	 */
+	public static String lcFirst(String input) {
+		char[] c = input.toCharArray();
+		c[0] = Character.toLowerCase(c[0]);
+		return new String(c);
+	}
+
+	/**
+	 * Turns the first Char into upper case.
+	 */
+	public static String ucFirst(String input) {
+		char[] c = input.toCharArray();
+		c[0] = Character.toUpperCase(c[0]);
+		return new String(c);
+	}
 }

--- a/iaf-commons/src/test/java/nl/nn/adapterframework/util/StringUtilTest.java
+++ b/iaf-commons/src/test/java/nl/nn/adapterframework/util/StringUtilTest.java
@@ -95,4 +95,19 @@ class StringUtilTest {
 		assertEquals(4, regexCount);
 	}
 
+	@Test
+	public void testUcFirst() {
+		assertEquals("Test123", StringUtil.ucFirst("test123"));
+		assertEquals("TEST123", StringUtil.ucFirst("tEST123"));
+		assertEquals("TEST123", StringUtil.ucFirst("TEST123"));
+		assertEquals("123test", StringUtil.ucFirst("123test"));
+	}
+
+	@Test
+	public void testLcFirst() {
+		assertEquals("test123", StringUtil.lcFirst("Test123"));
+		assertEquals("tEST123", StringUtil.lcFirst("TEST123"));
+		assertEquals("tEST123", StringUtil.lcFirst("TEST123"));
+		assertEquals("123test", StringUtil.lcFirst("123test"));
+	}
 }


### PR DESCRIPTION
I've done a few UC and LC tests and it turns out the char[] conversion is faster:
char[]  1278314600
substr 1382596200
strbuf 1373397800


```
	public static String charArr(String input) {
		char[] c = input.toCharArray();
		c[0] = Character.toLowerCase(c[0]);
		return new String(c);
	}

	private static String subStr(String input) {
		return input.substring(0, 1).toLowerCase() + input.substring(1);
	}

	private static String strBuff(String input) {
		StringBuffer sb = new StringBuffer(input.length());
		sb.append(Character.toLowerCase(input.charAt(0)));
		sb.append(input.substring(1));
		return sb.toString();
	}
```