### PR TITLE
Make convertToType more generic, and reduce empty value console warnings

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/configuration/digester/ValidateAttributeRule.java
+++ b/core/src/main/java/nl/nn/adapterframework/configuration/digester/ValidateAttributeRule.java
@@ -98,8 +98,13 @@ public class ValidateAttributeRule extends DigesterRuleBase {
 				log.warn("error while invoking method [{}] with value [{}] on bean [{}]", m, value, getBean(), e);
 				addLocalWarning(e.getCause().getMessage());
 			} catch (IllegalArgumentException e) {
-				log.warn("unable to populate attribute [{}] on method [{}] with value [{}] on bean [{}]", name, m, value, getBean(), e);
-				addLocalWarning(e.getMessage());
+				log.debug("unable to set attribute [{}] on method [{}] with value [{}]", name, m, value, e);
+				// When it's unable to convert to the provided type and:
+				// The type is not a String AND The value is empty
+				// Do not create a warning.
+				if(!"".equals(value)) {
+					addLocalWarning(e.getMessage());
+				}
 			}
 		}
 	}
@@ -135,7 +140,7 @@ public class ValidateAttributeRule extends DigesterRuleBase {
 		}
 
 		try {
-			return ClassUtils.convertToType(defaultValue.getClass(), "", value).equals(defaultValue);
+			return ClassUtils.convertToType(defaultValue.getClass(), value).equals(defaultValue);
 		} catch (IllegalArgumentException e) {
 			return false;
 		}

--- a/core/src/test/java/nl/nn/adapterframework/configuration/digester/ValidateAttributeRuleTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/configuration/digester/ValidateAttributeRuleTest.java
@@ -128,6 +128,23 @@ public class ValidateAttributeRuleTest extends Mockito {
 	}
 
 	@Test
+	public void testEmptyAttribute() throws Exception {
+		Map<String, String> attr = new HashMap<>();
+		attr.put("testString", "");
+		attr.put("testInteger", "");
+		attr.put("testBoolean", "");
+
+		ClassWithEnum bean = runRule(ClassWithEnum.class, attr);
+
+		assertEquals("", bean.getTestString(), "empty string value should be empty string");
+		assertEquals(1234, bean.getTestInteger(), "empty int value should be ingored"); //may trigger cannot be converted to int exception
+		assertEquals(false, bean.isTestBoolean(), "empty bool value should be ingored"); //may trigger a default warning exception
+
+		ConfigurationWarnings configWarnings = configuration.getConfigurationWarnings();
+		assertEquals(0, configWarnings.size(), "there should not be any configuration warnings but got: "+configWarnings.getWarnings());
+	}
+
+	@Test
 	public void testAttributeThatDoesntExist() throws Exception {
 		Map<String, String> attr = new HashMap<>();
 		attr.put("do-not-exist", "string value here");
@@ -191,7 +208,7 @@ public class ValidateAttributeRuleTest extends Mockito {
 		// Arrange
 		Map<String, String> attr = new LinkedHashMap<>();
 		attr.put("testString", "test");
-		attr.put("testInteger", "0");
+		attr.put("testInteger", "1234");
 		attr.put("testLong", "0");
 		attr.put("testBoolean", "false");
 		attr.put("testEnum", "one");
@@ -203,7 +220,7 @@ public class ValidateAttributeRuleTest extends Mockito {
 		ConfigurationWarnings configWarnings = configuration.getConfigurationWarnings();
 		assertEquals(5, configWarnings.size());
 		assertEquals("ClassWithEnum attribute [testString] already has a default value [test]", configWarnings.get(0));
-		assertEquals("ClassWithEnum attribute [testInteger] already has a default value [0]", configWarnings.get(1));
+		assertEquals("ClassWithEnum attribute [testInteger] already has a default value [1234]", configWarnings.get(1));
 		assertEquals("ClassWithEnum attribute [testLong] already has a default value [0]", configWarnings.get(2));
 		assertEquals("ClassWithEnum attribute [testBoolean] already has a default value [false]", configWarnings.get(3));
 		assertEquals("ClassWithEnum attribute [testEnum] already has a default value [one]", configWarnings.get(4));
@@ -244,7 +261,7 @@ public class ValidateAttributeRuleTest extends Mockito {
 
 		ConfigurationWarnings configWarnings = configuration.getConfigurationWarnings();
 		assertEquals(1, configWarnings.size());
-		assertEquals("ClassWithEnum cannot set field [testInteger] of type [int]: value [a String] cannot be converted to a number", configWarnings.get(0));
+		assertEquals("ClassWithEnum cannot set field [testInteger]: value [a String] cannot be converted to a number [int]", configWarnings.get(0));
 	}
 
 	@Test
@@ -258,31 +275,31 @@ public class ValidateAttributeRuleTest extends Mockito {
 
 		ConfigurationWarnings configWarnings = configuration.getConfigurationWarnings();
 		assertEquals(1, configWarnings.size());
-		assertEquals("ClassWithEnum cannot set field [testIntegerWithoutGetter] of type [int]: value [a String] cannot be converted to a number", configWarnings.get(0));
+		assertEquals("ClassWithEnum cannot set field [testIntegerWithoutGetter]: value [a String] cannot be converted to a number [int]", configWarnings.get(0));
 	}
 
 	@Test
 	public void testUnparsableEnum() throws Exception {
 		Map<String, String> attr = new HashMap<>();
-		attr.put("testEnum", "unparsable");
+		attr.put("testEnum", "notEnumValue");
 
 		runRule(ClassWithEnum.class, attr);
 
 		ConfigurationWarnings configWarnings = configuration.getConfigurationWarnings();
 		assertEquals(1, configWarnings.size());
-		assertEquals("ClassWithEnum cannot set field [testEnum] to unparsable value [unparsable]. Must be one of [ONE, TWO]", configWarnings.get(0));
+		assertEquals("ClassWithEnum cannot set field [testEnum]: unparsable value [notEnumValue]. Must be one of [ONE, TWO]", configWarnings.get(0));
 	}
 
 	@Test
 	public void testUnparsableEnumWithDifferentFieldName() throws Exception {
 		Map<String, String> attr = new HashMap<>();
-		attr.put("enumWithDifferentName", "unparsable");
+		attr.put("enumWithDifferentName", "notEnumValue");
 
 		runRule(ClassWithEnum.class, attr);
 
 		ConfigurationWarnings configWarnings = configuration.getConfigurationWarnings();
 		assertEquals(1, configWarnings.size());
-		assertEquals("ClassWithEnum cannot set field [enumWithDifferentName] to unparsable value [unparsable]. Must be one of [ONE, TWO]", configWarnings.get(0));
+		assertEquals("ClassWithEnum cannot set field [enumWithDifferentName]: unparsable value [notEnumValue]. Must be one of [ONE, TWO]", configWarnings.get(0));
 	}
 
 	@Test
@@ -447,7 +464,7 @@ public class ValidateAttributeRuleTest extends Mockito {
 		private @Deprecated @Getter @Setter String deprecatedString;
 		private @Getter String configWarningString;
 		private @Getter String deprecatedConfigWarningString;
-		private @Getter @Setter int testInteger = 0;
+		private @Getter @Setter int testInteger = 1234;
 		private @Getter @Setter long testLong = 0L;
 		private @Getter @Setter boolean testBoolean = false;
 		private @Setter String testStringWithoutGetter = "string";

--- a/core/src/test/java/nl/nn/adapterframework/util/ClassUtilsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/ClassUtilsTest.java
@@ -311,19 +311,23 @@ public class ClassUtilsTest {
 		return TestScopeProvider.wrap(cl);
 	}
 
+	private static enum TestEnum {ONE,TWO};
+
 	@Test
 	public void testConvertToType() {
-		String fieldName = "<fieldName>";
+		assertEquals(7, ClassUtils.convertToType(int.class, "7"));
+		assertEquals(7, ClassUtils.convertToType(Integer.class, "7"));
+		assertEquals(7L, ClassUtils.convertToType(long.class, "7"));
+		assertEquals(7L, ClassUtils.convertToType(Long.class, "7"));
+		assertEquals("7", ClassUtils.convertToType(String.class, "7"));
+		assertEquals(true, ClassUtils.convertToType(boolean.class, "true"));
+		assertEquals(true, ClassUtils.convertToType(Boolean.class, "true"));
+		assertEquals(false, ClassUtils.convertToType(Boolean.class, "niet true"));
+		assertEquals(TestEnum.ONE, ClassUtils.convertToType(TestEnum.class, "one"));
 
-		assertEquals(7, ClassUtils.convertToType(int.class, fieldName, "7"));
-		assertEquals(7, ClassUtils.convertToType(Integer.class, fieldName, "7"));
-		assertEquals(7L, ClassUtils.convertToType(long.class, fieldName, "7"));
-		assertEquals(7L, ClassUtils.convertToType(Long.class, fieldName, "7"));
-		assertEquals("7", ClassUtils.convertToType(String.class, fieldName, "7"));
-		assertEquals(true, ClassUtils.convertToType(boolean.class, fieldName, "true"));
-		assertEquals(true, ClassUtils.convertToType(Boolean.class, fieldName, "true"));
-		assertEquals(false, ClassUtils.convertToType(Boolean.class, fieldName, "niet true"));
-		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Object.class, fieldName, "dummy"));
-		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Long.class, fieldName, "dummy"));
+		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Object.class, "dummy"));
+		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Long.class, "dummy"));
+
+		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(int.class, "")); //Empty string
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/util/ClassUtilsTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/util/ClassUtilsTest.java
@@ -2,6 +2,7 @@ package nl.nn.adapterframework.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringStartsWith.startsWith;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -315,19 +316,20 @@ public class ClassUtilsTest {
 
 	@Test
 	public void testConvertToType() {
-		assertEquals(7, ClassUtils.convertToType(int.class, "7"));
-		assertEquals(7, ClassUtils.convertToType(Integer.class, "7"));
-		assertEquals(7L, ClassUtils.convertToType(long.class, "7"));
-		assertEquals(7L, ClassUtils.convertToType(Long.class, "7"));
-		assertEquals("7", ClassUtils.convertToType(String.class, "7"));
-		assertEquals(true, ClassUtils.convertToType(boolean.class, "true"));
-		assertEquals(true, ClassUtils.convertToType(Boolean.class, "true"));
-		assertEquals(false, ClassUtils.convertToType(Boolean.class, "niet true"));
-		assertEquals(TestEnum.ONE, ClassUtils.convertToType(TestEnum.class, "one"));
+		assertAll(
+			() -> assertEquals(7, ClassUtils.convertToType(int.class, "7")),
+			() -> assertEquals(7, ClassUtils.convertToType(Integer.class, "7")),
+			() -> assertEquals(7L, ClassUtils.convertToType(long.class, "7")),
+			() -> assertEquals(7L, ClassUtils.convertToType(Long.class, "7")),
+			() -> assertEquals("7", ClassUtils.convertToType(String.class, "7")),
+			() -> assertEquals(true, ClassUtils.convertToType(boolean.class, "true")),
+			() -> assertEquals(true, ClassUtils.convertToType(Boolean.class, "true")),
+			() -> assertEquals(false, ClassUtils.convertToType(Boolean.class, "niet true")),
+			() -> assertEquals(TestEnum.ONE, ClassUtils.convertToType(TestEnum.class, "one")),
 
-		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Object.class, "dummy"));
-		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Long.class, "dummy"));
-
-		assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(int.class, "")); //Empty string
+			() -> assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Object.class, "dummy")),
+			() -> assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(Long.class, "dummy")),
+			() -> assertThrows(IllegalArgumentException.class, ()->ClassUtils.convertToType(int.class, "")) //Empty string
+		);
 	}
 }

--- a/test/src/main/resources/DeploymentSpecifics.properties
+++ b/test/src/main/resources/DeploymentSpecifics.properties
@@ -53,9 +53,12 @@ jms.destination.prefix.mq=jms/
 jms.destination.prefix.aws_sqs=
 jms.destination.prefix=${jms.destination.prefix.${jms.provider.default}}
 
-jms.destination.i4testiaf_ff=${jms.destination.prefix}i4testiaf_ff
-jms.destination.i4testiaf_in=${jms.destination.prefix}i4testiaf_in
-jms.destination.i4testiaf_out=${jms.destination.prefix}i4testiaf_out
+# Defaults to empty, exists because both ActiveMQ and Artemis are configured simultaneously on JBoss and WildFly.
+jms.destination.suffix=
+
+jms.destination.i4testiaf_ff=${jms.destination.prefix}i4testiaf_ff${jms.destination.suffix}
+jms.destination.i4testiaf_in=${jms.destination.prefix}i4testiaf_in${jms.destination.suffix}
+jms.destination.i4testiaf_out=${jms.destination.prefix}i4testiaf_out${jms.destination.suffix}
 jms.destination.fxf=${jms.destination.prefix}fxf_request
 
 


### PR DESCRIPTION
Make `ClassUtils#convertToType` more generic
Reduce empty value console warnings
Add tests to cover #2763
Revert iaf-test jms queue suffix removal #4749