### PR TITLE
Add inheritance to build Docker in submodules and remove a duplicate plugin

### DIFF
--- a/docker/JBoss/pom.xml
+++ b/docker/JBoss/pom.xml
@@ -160,6 +160,10 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/docker/WebSphere/pom.xml
+++ b/docker/WebSphere/pom.xml
@@ -206,6 +206,10 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/docker/WildFly/pom.xml
+++ b/docker/WildFly/pom.xml
@@ -162,6 +162,10 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-antrun-plugin</artifactId>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -36,27 +36,11 @@
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-antrun-plugin</artifactId>
 					<version>1.8</version>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-enforcer-plugin</artifactId>
-					<executions>
-						<execution>
-							<id>enforce-classpath-lib-ban</id>
-							<configuration>
-								<skip>true</skip>
-							</configuration>
-						</execution>
-					</executions>
-				</plugin>
-				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-antrun-plugin</artifactId>
 					<executions>
 						<execution>
 							<id>prepare-package</id>
 							<phase>package</phase>
-							<inherited>false</inherited>
+							<inherited>true</inherited>
 							<configuration>
 								<target>
 									<exec executable="docker" failonerror="true">
@@ -72,6 +56,18 @@
 							<goals>
 								<goal>run</goal>
 							</goals>
+						</execution>
+					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-enforcer-plugin</artifactId>
+					<executions>
+						<execution>
+							<id>enforce-classpath-lib-ban</id>
+							<configuration>
+								<skip>true</skip>
+							</configuration>
 						</execution>
 					</executions>
 				</plugin>


### PR DESCRIPTION
I forgot to enable inheritance in #4774, and I got a warning about duplicate plugins.