### PR TITLE
Fix Samba2 authentication to use CredentialProvider

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
@@ -39,7 +39,6 @@ import javax.security.auth.login.LoginContext;
 
 import org.apache.commons.lang3.StringUtils;
 import org.ietf.jgss.GSSCredential;
-import org.ietf.jgss.GSSException;
 import org.ietf.jgss.GSSManager;
 import org.ietf.jgss.GSSName;
 import org.ietf.jgss.Oid;
@@ -200,12 +199,7 @@ public class Samba2FileSystem extends FileSystemBase<String> implements IWritabl
 							throw new IllegalArgumentException("No mechanism found");
 						}
 
-						GSSCredential creds = Subject.doAs(subject, new PrivilegedExceptionAction<GSSCredential>() {
-							@Override
-							public GSSCredential run() throws GSSException {
-								return manager.createCredential(name, GSSCredential.DEFAULT_LIFETIME, mech, GSSCredential.INITIATE_ONLY);
-							}
-						});
+						GSSCredential creds = Subject.doAs(subject, (PrivilegedExceptionAction<GSSCredential>) () -> manager.createCredential(name, GSSCredential.DEFAULT_LIFETIME, mech, GSSCredential.INITIATE_ONLY));
 
 						return new GSSAuthenticationContext(krbPrincipal.getName(), krbPrincipal.getRealm(), subject, creds);
 					} catch (Exception e) {

--- a/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/Samba2FileSystem.java
@@ -121,7 +121,8 @@ public class Samba2FileSystem extends FileSystemBase<String> implements IWritabl
 			}
 			session = connection.authenticate(auth);
 			if(session == null) {
-				throw new FileSystemException("Cannot create session for user ["+username+"] on domain ["+authenticationDomain+"]");
+				throw new FileSystemException("Cannot create session for alias [" +
+						authAlias + "] / user ["+username+"] on domain ["+authenticationDomain+"]");
 			}
 			diskShare = (DiskShare) session.connectShare(getShare());
 			if(diskShare == null) {
@@ -163,7 +164,7 @@ public class Samba2FileSystem extends FileSystemBase<String> implements IWritabl
 		if (StringUtils.isNotEmpty(credentialFactory.getUsername())) {
 			switch(authType) {
 				case NTLM:
-					return new AuthenticationContext(getUsername(), password.toCharArray(), getAuthenticationDomain());
+					return new AuthenticationContext(credentialFactory.getUsername(), credentialFactory.getPassword().toCharArray(), getAuthenticationDomain());
 				case SPNEGO:
 					if(!StringUtils.isEmpty(getKdc()) && !StringUtils.isEmpty(getRealm())) {
 						System.setProperty("java.security.krb5.kdc", getKdc());
@@ -171,11 +172,11 @@ public class Samba2FileSystem extends FileSystemBase<String> implements IWritabl
 					}
 
 					HashMap<String, String> loginParams = new HashMap<>();
-					loginParams.put("principal", getUsername());
+					loginParams.put("principal", credentialFactory.getUsername());
 					LoginContext lc;
 					try {
-						lc = new LoginContext(getUsername(), null,
-								new UsernameAndPasswordCallbackHandler(getUsername(), getPassword()),
+						lc = new LoginContext(credentialFactory.getUsername(), null,
+								new UsernameAndPasswordCallbackHandler(credentialFactory.getUsername(), credentialFactory.getPassword()),
 								new KerberosLoginConfiguration(loginParams));
 						lc.login();
 
@@ -497,7 +498,7 @@ public class Samba2FileSystem extends FileSystemBase<String> implements IWritabl
 	}
 
 	/**
-	 * Type of the authentication either 'NTLM' or 'SPNEGO' 
+	 * Type of the authentication either 'NTLM' or 'SPNEGO'
 	 * @ff.default SPNEGO
 	 */
 	public void setAuthType(Samba2AuthType authType) {


### PR DESCRIPTION
No tests yet -- there are no tests on this code.

I can try to add some simple tests if wanted, but then only to verify CredentialProvider is used. Prefer to focus now on memory usage.