### PR TITLE
Upgrade Aspose, implement OfflineResourceLoader in mail&slides convertors and set default strategy to SKIP

### DIFF
--- a/aspose/pom.xml
+++ b/aspose/pom.xml
@@ -12,7 +12,7 @@
 
 	<properties>
 		<!-- NOTE: some dependencies require the classifier tag to be set to jdk16 (1.6) -->
-		<aspose.version>19.1</aspose.version>
+		<aspose.version>23.1</aspose.version>
 	</properties>
 
 	<dependencies>
@@ -264,9 +264,9 @@
 		<dependency>
 			<groupId>com.aspose</groupId>
 			<artifactId>aspose-imaging</artifactId>
-			<!-- for some reason version 19.1 does not exist for aspose-imaging -->
+			<!-- for some reason version 23.1 does not exist for aspose-imaging -->
 <!-- 			<version>${aspose.version}</version> -->
-			<version>18.11</version>
+			<version>22.10</version>
 		</dependency>
 
 		<!-- test scoped dependencies -->

--- a/aspose/pom.xml
+++ b/aspose/pom.xml
@@ -266,6 +266,7 @@
 			<artifactId>aspose-imaging</artifactId>
 			<!-- for some reason version 23.1 does not exist for aspose-imaging -->
 <!-- 			<version>${aspose.version}</version> -->
+			<classifier>jdk16</classifier>
 			<version>22.9</version>
 		</dependency>
 

--- a/aspose/pom.xml
+++ b/aspose/pom.xml
@@ -266,7 +266,7 @@
 			<artifactId>aspose-imaging</artifactId>
 			<!-- for some reason version 23.1 does not exist for aspose-imaging -->
 <!-- 			<version>${aspose.version}</version> -->
-			<version>22.10</version>
+			<version>22.9</version>
 		</dependency>
 
 		<!-- test scoped dependencies -->

--- a/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/OfflineResourceLoader.java
+++ b/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/OfflineResourceLoader.java
@@ -16,11 +16,10 @@
 package nl.nn.adapterframework.extensions.aspose.services.conv.impl.convertors;
 
 import com.aspose.slides.IResourceLoadingArgs;
-import com.aspose.words.IResourceLoadingCallback;
 import com.aspose.words.ResourceLoadingAction;
 import com.aspose.words.ResourceLoadingArgs;
 
-public class OfflineResourceLoader implements IResourceLoadingCallback, com.aspose.slides.IResourceLoadingCallback {
+public class OfflineResourceLoader implements com.aspose.words.IResourceLoadingCallback, com.aspose.slides.IResourceLoadingCallback {
 
 	@Override
 	public int resourceLoading(IResourceLoadingArgs resourceLoadingArgs) {

--- a/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/OfflineResourceLoader.java
+++ b/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/OfflineResourceLoader.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -15,17 +15,23 @@
 */
 package nl.nn.adapterframework.extensions.aspose.services.conv.impl.convertors;
 
+import com.aspose.slides.IResourceLoadingArgs;
 import com.aspose.words.IResourceLoadingCallback;
 import com.aspose.words.ResourceLoadingAction;
 import com.aspose.words.ResourceLoadingArgs;
 
-public class OfflineResourceLoader implements IResourceLoadingCallback {
+public class OfflineResourceLoader implements IResourceLoadingCallback, com.aspose.slides.IResourceLoadingCallback {
+
 	@Override
-	public int resourceLoading(ResourceLoadingArgs resourceLoadingArgs) throws Exception {
-		String originalUri = resourceLoadingArgs.getOriginalUri();
-		if(originalUri.startsWith("https://") || originalUri.startsWith("http://")){
-			return ResourceLoadingAction.SKIP;
-		}
-		return ResourceLoadingAction.DEFAULT;
+	public int resourceLoading(IResourceLoadingArgs resourceLoadingArgs) {
+		return canLoadResource(resourceLoadingArgs.getOriginalUri());
 	}
+	@Override
+	public int resourceLoading(ResourceLoadingArgs resourceLoadingArgs) {
+		return canLoadResource(resourceLoadingArgs.getOriginalUri());
+	}
+	private int canLoadResource(String resourceUri) {
+		return ResourceLoadingAction.SKIP;
+	}
+
 }

--- a/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/SlidesConvertor.java
+++ b/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/SlidesConvertor.java
@@ -63,7 +63,7 @@ public class SlidesConvertor extends AbstractConvertor {
 		}
 		try (InputStream inputStream = message.asInputStream(charset)) {
 			LoadOptions loadOptions = MEDIA_TYPE_LOAD_FORMAT_MAPPING.get(mediaType);
-			if(configuration.isLoadExternalResources()){
+			if(!configuration.isLoadExternalResources()){
 				loadOptions.setResourceLoadingCallback(new OfflineResourceLoader());
 			}
 			Presentation presentation = new Presentation(inputStream, loadOptions);

--- a/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/SlidesConvertor.java
+++ b/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/SlidesConvertor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019, 2021-2022 WeAreFrank!
+   Copyright 2019, 2021-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -62,7 +62,11 @@ public class SlidesConvertor extends AbstractConvertor {
 			throw new IllegalArgumentException("Unsupported mediaType " + mediaType + " should never happen here!");
 		}
 		try (InputStream inputStream = message.asInputStream(charset)) {
-			Presentation presentation = new Presentation(inputStream, MEDIA_TYPE_LOAD_FORMAT_MAPPING.get(mediaType));
+			LoadOptions loadOptions = MEDIA_TYPE_LOAD_FORMAT_MAPPING.get(mediaType);
+			if(configuration.isLoadExternalResources()){
+				loadOptions.setResourceLoadingCallback(new OfflineResourceLoader());
+			}
+			Presentation presentation = new Presentation(inputStream, loadOptions);
 			long startTime = new Date().getTime();
 			presentation.save(result.getPdfResultFile().getAbsolutePath(), SaveFormat.Pdf);
 			long endTime = new Date().getTime();

--- a/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/WordConvertor.java
+++ b/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/WordConvertor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019, 2021-2022 WeAreFrank!
+   Copyright 2019, 2021-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -90,8 +90,7 @@ class WordConvertor extends AbstractConvertor {
 			if (loadOptionsSupplier!=null) {
 				loadOptions = loadOptionsSupplier.get();
 				if(!cisConfiguration.isLoadExternalResources()){
-					OfflineResourceLoader resourceLoader = new OfflineResourceLoader();
-					loadOptions.setResourceLoadingCallback(resourceLoader);
+					loadOptions.setResourceLoadingCallback(new OfflineResourceLoader());
 				}
 			}
 


### PR DESCRIPTION
We have made the following custom changes to the framework:

- Upgrade Aspose to 23.1
- Implement OfflineResourceLoader in MailConvertor & SlidesConvertor
- Set default strategy to SKIP