### PR TITLE
Fix authAlias in SftpSession.java

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/ftp/SftpSession.java
+++ b/core/src/main/java/nl/nn/adapterframework/ftp/SftpSession.java
@@ -133,9 +133,9 @@ public class SftpSession implements IConfigurable {
 
 			Session sftpSession = jsch.getSession(credentialFactory.getUsername(), host, port);
 
-			if (StringUtils.isNotEmpty(getPassword())) {
+			if (StringUtils.isNotEmpty(credentialFactory.getPassword())) {
 				sftpSession.setConfig("PreferredAuthentications", "password");
-				sftpSession.setPassword(getPassword());
+				sftpSession.setPassword(credentialFactory.getPassword());
 			} else {
 				sftpSession.setConfig("PreferredAuthentications", "publickey");
 			}


### PR DESCRIPTION
Only the `username` and `password` properties were working. 
The password is now retrieved from the `credentialFactory` so `authAlias` works again.