### PR TITLE
Lcm JDBC code cleanups pt. 3

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/jdbc/DirectQuerySender.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/DirectQuerySender.java
@@ -126,7 +126,7 @@ public class DirectQuerySender extends JdbcQuerySenderBase<Connection>{
 			try {
 				return executeStatementSet(queryExecutionContext, message, session, next);
 			} finally {
-				closeStatementSet(queryExecutionContext, session);
+				closeStatementSet(queryExecutionContext);
 			}
 		} catch (SenderException|TimeoutException e) {
 			throw e;

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/FixedQuerySender.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/FixedQuerySender.java
@@ -47,30 +47,17 @@ public class FixedQuerySender extends JdbcQuerySenderBase<QueryExecutionContext>
 	private @Getter String query=null;
 	private @Getter int batchSize;
 
-	private String convertedQuery;
-
 	@Override
 	public void configure() throws ConfigurationException {
 		super.configure();
 		if (StringUtils.isEmpty(getQuery())) {
 			throw new ConfigurationException(getLogPrefix()+"query must be specified");
 		}
-		try {
-			convertedQuery = convertQuery(getQuery());
-			if (log.isDebugEnabled()) log.debug("converted result query into [" + convertedQuery + "]");
-		} catch (JdbcException | SQLException e) {
-			throw new ConfigurationException("Cannot convert result query",e);
-		}
 	}
 
 	@Override
 	protected String getQuery(Message message) {
 		return getQuery();
-	}
-
-	@Override
-	protected String getConvertedQuery(Message message) throws SenderException {
-		return convertedQuery;
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/FixedQuerySender.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/FixedQuerySender.java
@@ -91,7 +91,7 @@ public class FixedQuerySender extends JdbcQuerySenderBase<QueryExecutionContext>
 	@Override
 	public void closeBlock(QueryExecutionContext blockHandle, PipeLineSession session) throws SenderException {
 		try {
-			super.closeStatementSet(blockHandle, session);
+			super.closeStatementSet(blockHandle);
 		} catch (Exception e) {
 			log.warn("{} Unhandled exception closing statement-set", getLogPrefix(), e);
 		}
@@ -103,7 +103,7 @@ public class FixedQuerySender extends JdbcQuerySenderBase<QueryExecutionContext>
 	}
 
 	@Override
-	protected void closeStatementSet(QueryExecutionContext statementSet, PipeLineSession session) {
+	protected void closeStatementSet(QueryExecutionContext statementSet) {
 		// postpone close to closeBlock()
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/FixedQuerySender.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/FixedQuerySender.java
@@ -47,17 +47,30 @@ public class FixedQuerySender extends JdbcQuerySenderBase<QueryExecutionContext>
 	private @Getter String query=null;
 	private @Getter int batchSize;
 
+	private String convertedQuery;
+
 	@Override
 	public void configure() throws ConfigurationException {
 		super.configure();
 		if (StringUtils.isEmpty(getQuery())) {
 			throw new ConfigurationException(getLogPrefix()+"query must be specified");
 		}
+		try {
+			convertedQuery = convertQuery(getQuery());
+			if (log.isDebugEnabled()) log.debug("converted result query into [" + convertedQuery + "]");
+		} catch (JdbcException | SQLException e) {
+			throw new ConfigurationException("Cannot convert result query",e);
+		}
 	}
 
 	@Override
 	protected String getQuery(Message message) {
 		return getQuery();
+	}
+
+	@Override
+	protected String getConvertedQuery(Message message) throws SenderException {
+		return convertedQuery;
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcListener.java
@@ -39,7 +39,6 @@ import nl.nn.adapterframework.core.ListenerException;
 import nl.nn.adapterframework.core.PipeLineResult;
 import nl.nn.adapterframework.core.PipeLineSession;
 import nl.nn.adapterframework.core.ProcessState;
-import nl.nn.adapterframework.jdbc.JdbcQuerySenderBase.QueryType;
 import nl.nn.adapterframework.receivers.MessageWrapper;
 import nl.nn.adapterframework.receivers.RawMessageWrapper;
 import nl.nn.adapterframework.stream.Message;
@@ -91,13 +90,13 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 	public void configure() throws ConfigurationException {
 		super.configure();
 		try {
-			String convertedSelectQuery = convertQuery(getSelectQuery(), QueryType.SELECT);
+			String convertedSelectQuery = convertQuery(getSelectQuery());
 			preparedSelectQuery = getDbmsSupport().prepareQueryTextForWorkQueueReading(1, convertedSelectQuery);
-			preparedPeekQuery = StringUtils.isNotEmpty(getPeekQuery()) ? convertQuery(getPeekQuery(), QueryType.SELECT) : getDbmsSupport().prepareQueryTextForWorkQueuePeeking(1, convertedSelectQuery);
+			preparedPeekQuery = StringUtils.isNotEmpty(getPeekQuery()) ? convertQuery(getPeekQuery()) : getDbmsSupport().prepareQueryTextForWorkQueuePeeking(1, convertedSelectQuery);
 			Map<ProcessState, String> orderedUpdateStatusQueries = new LinkedHashMap<>();
 			for (ProcessState state : ProcessState.values()) {
 				if(updateStatusQueries.containsKey(state)) {
-					String convertedUpdateStatusQuery = convertQuery(updateStatusQueries.get(state), QueryType.OTHER);
+					String convertedUpdateStatusQuery = convertQuery(updateStatusQueries.get(state));
 					orderedUpdateStatusQueries.put(state, convertedUpdateStatusQuery);
 				}
 			}
@@ -378,13 +377,11 @@ public class JdbcListener<M> extends JdbcFacade implements IPeekableListener<M>,
 		return false;
 	}
 
-	protected String convertQuery(String query, QueryType queryType) throws JdbcException, SQLException {
+	protected String convertQuery(String query) throws JdbcException, SQLException {
 		if (StringUtils.isEmpty(getSqlDialect())) {
 			return query;
 		}
-		QueryExecutionContext qec = new QueryExecutionContext(query, queryType, null);
-		getDbmsSupport().convertQuery(qec, getSqlDialect());
-		return qec.getQuery();
+		return getDbmsSupport().convertQuery(query, getSqlDialect());
 	}
 
 	protected void setUpdateStatusQuery(ProcessState state, String query) {

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcQuerySenderBase.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/JdbcQuerySenderBase.java
@@ -189,16 +189,6 @@ public abstract class JdbcQuerySenderBase<H> extends JdbcSenderBase<H> {
 	 */
 	protected abstract String getQuery(Message message) throws SenderException;
 
-	protected String getConvertedQuery(Message message) throws SenderException {
-		try {
-			String result = convertQuery(getQuery(message));
-			if (log.isDebugEnabled()) log.debug("converted result query into [" + result + "]");
-			return result;
-		} catch (JdbcException | SQLException e) {
-			throw new SenderException("Cannot convert result query",e);
-		}
-	}
-
 	@Override
 	public void open() throws SenderException {
 		super.open();
@@ -228,7 +218,7 @@ public abstract class JdbcQuerySenderBase<H> extends JdbcSenderBase<H> {
 	}
 
 	protected PreparedStatement prepareQuery(@Nonnull Connection con, @Nonnull String query, @Nullable QueryType queryType) throws SQLException, JdbcException {
-		String adaptedQuery = query;
+		String adaptedQuery = convertQuery(query);
 		if (isLockRows()) {
 			adaptedQuery = getDbmsSupport().prepareQueryTextForWorkQueueReading(-1, adaptedQuery, getLockWait());
 		}
@@ -269,7 +259,7 @@ public abstract class JdbcQuerySenderBase<H> extends JdbcSenderBase<H> {
 
 	public QueryExecutionContext getQueryExecutionContext(Connection connection, Message message) throws SenderException, SQLException, ParameterException, JdbcException {
 		ParameterList newParameterList = paramList != null ? (ParameterList) paramList.clone() : new ParameterList();
-		String query = getConvertedQuery(message);
+		String query = getQuery(message);
 		if (BooleanUtils.isTrue(getUseNamedParams()) || (getUseNamedParams() == null && query.contains(UNP_START))) {
 			query = adjustQueryAndParameterListForNamedParameters(newParameterList, query);
 		}

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/QueryExecutionContext.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/QueryExecutionContext.java
@@ -18,17 +18,18 @@ package nl.nn.adapterframework.jdbc;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 
+import lombok.Getter;
 import nl.nn.adapterframework.jdbc.JdbcQuerySenderBase.QueryType;
 import nl.nn.adapterframework.parameters.ParameterList;
 
 public class QueryExecutionContext {
 
-	private String query;
-	private final QueryType queryType;
-	private final ParameterList parameterList;
-	private Connection connection;
-	private PreparedStatement statement;
-	private PreparedStatement resultQueryStatement;
+	@Getter private String query;
+	@Getter private final QueryType queryType;
+	@Getter private final ParameterList parameterList;
+	@Getter private Connection connection;
+	@Getter private PreparedStatement statement;
+	@Getter private PreparedStatement resultQueryStatement;
 	protected int iteration;
 
 	public QueryExecutionContext(String query, QueryType queryType, ParameterList parameterList) {
@@ -37,38 +38,18 @@ public class QueryExecutionContext {
 		this.parameterList = parameterList;
 	}
 
-	public String getQuery() {
-		return query;
-	}
 	public void setQuery(String query) {
 		this.query = query;
 	}
 
-	public QueryType getQueryType() {
-		return queryType;
-	}
-
-	public ParameterList getParameterList() {
-		return parameterList;
-	}
-
-	public Connection getConnection() {
-		return connection;
-	}
 	public void setConnection(Connection connection) {
 		this.connection = connection;
 	}
 
-	public PreparedStatement getStatement() {
-		return statement;
-	}
 	public void setStatement(PreparedStatement statement) {
 		this.statement = statement;
 	}
 
-	public PreparedStatement getResultQueryStatement() {
-		return resultQueryStatement;
-	}
 	public void setResultQueryStatement(PreparedStatement resultQueryStatement) {
 		this.resultQueryStatement = resultQueryStatement;
 	}

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/QueryExecutionContext.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/QueryExecutionContext.java
@@ -24,33 +24,20 @@ import nl.nn.adapterframework.parameters.ParameterList;
 
 public class QueryExecutionContext {
 
-	@Getter private String query;
+	@Getter private final String query;
 	@Getter private final QueryType queryType;
 	@Getter private final ParameterList parameterList;
-	@Getter private Connection connection;
-	@Getter private PreparedStatement statement;
-	@Getter private PreparedStatement resultQueryStatement;
+	@Getter private final Connection connection;
+	@Getter private final PreparedStatement statement;
+	@Getter private final PreparedStatement resultQueryStatement;
 	protected int iteration;
 
-	public QueryExecutionContext(String query, QueryType queryType, ParameterList parameterList) {
+	public QueryExecutionContext(String query, QueryType queryType, ParameterList parameterList, Connection connection, PreparedStatement statement, PreparedStatement resultQueryStatement) {
 		this.query = query;
 		this.queryType = queryType;
 		this.parameterList = parameterList;
-	}
-
-	public void setQuery(String query) {
-		this.query = query;
-	}
-
-	public void setConnection(Connection connection) {
 		this.connection = connection;
-	}
-
-	public void setStatement(PreparedStatement statement) {
 		this.statement = statement;
-	}
-
-	public void setResultQueryStatement(PreparedStatement resultQueryStatement) {
 		this.resultQueryStatement = resultQueryStatement;
 	}
 }

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/XmlQuerySender.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/XmlQuerySender.java
@@ -27,10 +27,12 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
+import java.util.Collections;
+import java.util.List;
 import java.util.StringTokenizer;
-import java.util.Vector;
+import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
 import org.w3c.dom.Element;
@@ -134,7 +136,7 @@ public class XmlQuerySender extends DirectQuerySender {
 				}
 				parameter = n.intValue();
 			} else if (type.equalsIgnoreCase(TYPE_BOOLEAN)) {
-				parameter = new Boolean(value);
+				parameter = Boolean.valueOf(value);
 			} else if (type.equalsIgnoreCase(TYPE_NUMBER)) {
 				DecimalFormatSymbols decimalFormatSymbols = new DecimalFormatSymbols();
 				if (StringUtils.isNotEmpty(decimalSeparator)) {
@@ -152,9 +154,9 @@ public class XmlQuerySender extends DirectQuerySender {
 					throw new SenderException(getLogPrefix() + "got exception parsing value [" + value + "] to Number using decimalSeparator [" + decimalSeparator + "] and groupingSeparator [" + groupingSeparator + "]", e);
 				}
 				if (value.indexOf('.') >= 0) {
-					parameter = new Double(n.doubleValue());
+					parameter = n.doubleValue();
 				} else {
-					parameter = new Integer(n.intValue());
+					parameter = n.intValue();
 				}
 			} else if (type.equalsIgnoreCase(TYPE_DATETIME)) {
 				DateFormat df = new SimpleDateFormat(formatString);
@@ -232,11 +234,11 @@ public class XmlQuerySender extends DirectQuerySender {
 	@Override
 	protected PipeRunResult sendMessageOnConnection(Connection connection, Message message, PipeLineSession session, IForwardTarget next) throws SenderException, TimeoutException {
 		Element queryElement;
-		String tableName = null;
-		Vector<Column> columns = null;
-		String where = null;
-		String order = null;
-		PipeRunResult result = null;
+		String tableName;
+		List<Column> columns;
+		String where;
+		String order;
+		PipeRunResult result;
 		try {
 			queryElement = XmlUtils.buildElement(message.asString());
 			String root = queryElement.getTagName();
@@ -244,6 +246,8 @@ public class XmlQuerySender extends DirectQuerySender {
 			Element columnsElement = XmlUtils.getFirstChildTag(queryElement, "columns");
 			if (columnsElement != null) {
 				columns = getColumns(columnsElement);
+			} else {
+				columns = Collections.emptyList();
 			}
 			where = XmlUtils.getChildTagAsString(queryElement, "where");
 			order = XmlUtils.getChildTagAsString(queryElement, "order");
@@ -288,103 +292,80 @@ public class XmlQuerySender extends DirectQuerySender {
 		return result;
 	}
 
-	private PipeRunResult selectQuery(Connection connection, String tableName, Vector<Column> columns, String where, String order, PipeLineSession session, IForwardTarget next) throws SenderException, JdbcException {
-		String query = "SELECT ";
+	private PipeRunResult selectQuery(Connection connection, String tableName, List<Column> columns, String where, String order, PipeLineSession session, IForwardTarget next) throws SenderException, JdbcException {
+		StringBuilder queryBuilder = new StringBuilder("SELECT ");
+		if (columns != null && !columns.isEmpty()) {
+			String columnSelection = columns.stream()
+					.map(Column::getName)
+					.collect(Collectors.joining(","));
+			queryBuilder.append(columnSelection);
+		} else {
+			queryBuilder.append("*");
+		}
+		queryBuilder.append(" FROM ").append(tableName);
+		if (where != null) {
+			queryBuilder.append(" WHERE ").append(where);
+		}
+		if (order != null) {
+			queryBuilder.append(" ORDER BY ").append(order);
+		}
 		try {
-			if (columns != null) {
-				Iterator<Column> iter = columns.iterator();
-				boolean firstColumn = true;
-				while (iter.hasNext()) {
-					Column column = iter.next();
-					if (firstColumn) {
-						query = query + column.getName();
-						firstColumn = false;
-					} else {
-						query = query + "," + column.getName();
-					}
-				}
-			} else {
-				query = query + "*";
-			}
-			query = query + " FROM " + tableName;
-			if (where != null) {
-				query = query + " WHERE " + where;
-			}
-			if (order != null) {
-				query = query + " ORDER BY " + order;
-			}
+			String query = queryBuilder.toString();
 			PreparedStatement statement = getStatement(connection, query, QueryType.SELECT);
 			statement.setQueryTimeout(getTimeout());
 			setBlobSmartGet(true);
 			return executeSelectQuery(statement,null,null, session, next);
 		} catch (SQLException e) {
-			throw new SenderException(getLogPrefix() + "got exception executing a SELECT SQL command ["+query+"]", e);
+			throw new SenderException(getLogPrefix() + "got exception executing a SELECT SQL command ["+ queryBuilder +"]", e);
 		}
 	}
 
-	private Message insertQuery(Connection connection, String tableName, Vector<Column> columns) throws SenderException {
-		String query=null;
+	private Message insertQuery(Connection connection, String tableName, List<Column> columns) throws SenderException {
+		String queryColumns = columns.stream()
+				.map(Column::getName)
+				.collect(Collectors.joining(","));
+		String queryValues = columns.stream()
+				.map(Column::getQueryValue)
+				.collect(Collectors.joining(","));
+
+		String query ="INSERT INTO " + tableName + " (" + queryColumns + ") VALUES (" + queryValues + ")";
+
 		try {
-			query = "INSERT INTO " + tableName + " (";
-			Iterator<Column> iter = columns.iterator();
-			String queryColumns = null;
-			String queryValues = null;
-			while (iter.hasNext()) {
-				Column column = iter.next();
-				if (queryColumns == null) {
-					queryColumns = column.getName();
-				} else {
-					queryColumns = queryColumns + "," + column.getName();
-				}
-				if (queryValues == null) {
-					queryValues = column.getQueryValue();
-				} else {
-					queryValues = queryValues + "," + column.getQueryValue();
-				}
-			}
-			query = query + queryColumns + ") VALUES (" + queryValues + ")";
 			return executeUpdate(connection, tableName, query, columns);
 		} catch (SenderException t) {
-			throw new SenderException(getLogPrefix() + "got exception executing an INSERT SQL command ["+query+"]", t);
+			throw new SenderException(getLogPrefix() + "got exception executing an INSERT SQL command [" + query + "]", t);
 		}
 	}
 
 	private Message deleteQuery(Connection connection, String tableName, String where) throws SenderException, JdbcException {
-		String query=null;
+		String query = "DELETE FROM " + tableName;
+		if (where != null) {
+			query = query + " WHERE " + where;
+		}
 		try {
-			query = "DELETE FROM " + tableName;
-			if (where != null) {
-				query = query + " WHERE " + where;
-			}
 			PreparedStatement statement = getStatement(connection, query, QueryType.OTHER);
 			statement.setQueryTimeout(getTimeout());
 			return executeOtherQuery(connection, statement, query, null, null, null, null);
 		} catch (SQLException e) {
-			throw new SenderException(getLogPrefix() + "got exception executing a DELETE SQL command ["+query+"]", e);
+			throw new SenderException(getLogPrefix() + "got exception executing a DELETE SQL command [" + query + "]", e);
 		}
 	}
 
-	private Message updateQuery(Connection connection, String tableName, Vector<Column> columns, String where) throws SenderException {
-		String query = "UPDATE " + tableName + " SET ";
+	private Message updateQuery(Connection connection, String tableName, List<Column> columns, String where) throws SenderException {
+		StringBuilder queryBuilder = new StringBuilder("UPDATE " + tableName + " SET ");
+		String querySet = columns.stream()
+				.map(column -> column.getName() + "=" + column.getQueryValue())
+				.collect(Collectors.joining(","));
+
+		queryBuilder.append(querySet);
+		if (where != null) {
+			queryBuilder.append(" WHERE ").append(where);
+		}
 		try {
-			Iterator<Column> iter = columns.iterator();
-			String querySet = null;
-			while (iter.hasNext()) {
-				Column column = iter.next();
-				if (querySet == null) {
-					querySet = column.getName();
-				} else {
-					querySet = querySet + "," + column.getName();
-				}
-				querySet = querySet + "=" + column.getQueryValue();
-			}
-			query = query + querySet;
-			if (where != null) {
-				query = query + " WHERE " + where;
-			}
+			String query = queryBuilder.toString();
 			return executeUpdate(connection, tableName, query, columns);
 		} catch (SenderException t) {
-			throw new SenderException(getLogPrefix() + "got exception executing an UPDATE SQL command ["+query+"]", t);
+			throw new SenderException(getLogPrefix() + "got exception executing an UPDATE SQL command [" + queryBuilder + "]", t);
 		}
 	}
 
@@ -417,7 +398,7 @@ public class XmlQuerySender extends DirectQuerySender {
 		}
 	}
 
-	private Message executeUpdate(Connection connection, String tableName, String query, Vector<Column> columns) throws SenderException {
+	private Message executeUpdate(Connection connection, String tableName, String query, List<Column> columns) throws SenderException {
 		try {
 			if ((existBlob(columns) && getDbmsSupport().mustInsertEmptyBlobBeforeData()) || (existClob(columns) && getDbmsSupport().mustInsertEmptyClobBeforeData())) {
 				CallableStatement callableStatement = getCallWithRowIdReturned(connection, query);
@@ -429,9 +410,7 @@ public class XmlQuerySender extends DirectQuerySender {
 				String rowId = callableStatement.getString(ri);
 				log.debug(getLogPrefix() + "returning ROWID [" + rowId + "]");
 
-				Iterator<Column> iter = columns.iterator();
-				while (iter.hasNext()) {
-					Column column = iter.next();
+				for (Column column : columns) {
 					if (column.getType().equalsIgnoreCase(TYPE_BLOB) || column.getType().equalsIgnoreCase(TYPE_CLOB)) {
 						query = "SELECT " + column.getName() + " FROM " + tableName + " WHERE ROWID=?" + " FOR UPDATE";
 						QueryType queryType;
@@ -461,10 +440,8 @@ public class XmlQuerySender extends DirectQuerySender {
 		}
 	}
 
-	private boolean existBlob(Vector<Column> columns) {
-		Iterator<Column> iter = columns.iterator();
-		while (iter.hasNext()) {
-			Column column = iter.next();
+	private boolean existBlob(List<Column> columns) {
+		for (Column column : columns) {
 			if (column.getType().equalsIgnoreCase(TYPE_BLOB)) {
 				return true;
 			}
@@ -472,10 +449,8 @@ public class XmlQuerySender extends DirectQuerySender {
 		return false;
 	}
 
-	private boolean existClob(Vector<Column> columns) {
-		Iterator<Column> iter = columns.iterator();
-		while (iter.hasNext()) {
-			Column column = iter.next();
+	private boolean existClob(List<Column> columns) {
+		for (Column column : columns) {
 			if (column.getType().equalsIgnoreCase(TYPE_CLOB)) {
 				return true;
 			}
@@ -483,11 +458,9 @@ public class XmlQuerySender extends DirectQuerySender {
 		return false;
 	}
 
-	private int countParameters(Vector<Column> columns) {
+	private int countParameters(List<Column> columns) {
 		int parameterCount = 0;
-		Iterator<Column> iter = columns.iterator();
-		while (iter.hasNext()) {
-			Column column = iter.next();
+		for (Column column : columns) {
 			if (column.getParameter() != null) {
 				parameterCount++;
 			}
@@ -507,56 +480,53 @@ public class XmlQuerySender extends DirectQuerySender {
 		}
 	}
 
-	private Vector<Column> getColumns(Element columnsElement) throws SenderException {
+	private List<Column> getColumns(Element columnsElement) throws SenderException {
 		Collection<Node> columnElements = XmlUtils.getChildTags(columnsElement, "column");
-		Iterator<Node> iter = columnElements.iterator();
-		if (iter.hasNext()) {
-			Vector<Column> columns = new Vector<>();
-			while (iter.hasNext()) {
-				Element columnElement = (Element) iter.next();
-				Element nameElement = XmlUtils.getFirstChildTag(columnElement, "name");
-				String name = null;
-				if (nameElement != null) {
-					name = XmlUtils.getStringValue(nameElement);
-				}
-				Element valueElement = XmlUtils.getFirstChildTag(columnElement, "value");
-				String value = null;
-				if (valueElement != null) {
-					value = XmlUtils.getStringValue(valueElement);
-				}
-				Element typeElement = XmlUtils.getFirstChildTag(columnElement, "type");
-				String type = null;
-				if (typeElement != null) {
-					type = XmlUtils.getStringValue(typeElement);
-				}
-				Element decimalSeparatorElement = XmlUtils.getFirstChildTag(columnElement, "decimalSeparator");
-				String decimalSeparator = null;
-				if (decimalSeparatorElement != null) {
-					decimalSeparator = XmlUtils.getStringValue(decimalSeparatorElement);
-				}
-				Element groupingSeparatorElement = XmlUtils.getFirstChildTag(columnElement, "groupingSeparator");
-				String groupingSeparator = null;
-				if (groupingSeparatorElement != null) {
-					groupingSeparator = XmlUtils.getStringValue(groupingSeparatorElement);
-				}
-				Element formatStringElement = XmlUtils.getFirstChildTag(columnElement, "formatString");
-				String formatString = null;
-				if (formatStringElement != null) {
-					formatString = XmlUtils.getStringValue(formatStringElement);
-				}
-				Column column = new Column(name, value, type, decimalSeparator, groupingSeparator, formatString);
-				columns.add(column);
-			}
-			return columns;
+		if (columnElements.isEmpty()) {
+			return Collections.emptyList();
 		}
-		return null;
+		List<Column> columns = new ArrayList<>();
+		for (Node element : columnElements) {
+			Element columnElement = (Element) element;
+			Element nameElement = XmlUtils.getFirstChildTag(columnElement, "name");
+			String name = null;
+			if (nameElement != null) {
+				name = XmlUtils.getStringValue(nameElement);
+			}
+			Element valueElement = XmlUtils.getFirstChildTag(columnElement, "value");
+			String value = null;
+			if (valueElement != null) {
+				value = XmlUtils.getStringValue(valueElement);
+			}
+			Element typeElement = XmlUtils.getFirstChildTag(columnElement, "type");
+			String type = null;
+			if (typeElement != null) {
+				type = XmlUtils.getStringValue(typeElement);
+			}
+			Element decimalSeparatorElement = XmlUtils.getFirstChildTag(columnElement, "decimalSeparator");
+			String decimalSeparator = null;
+			if (decimalSeparatorElement != null) {
+				decimalSeparator = XmlUtils.getStringValue(decimalSeparatorElement);
+			}
+			Element groupingSeparatorElement = XmlUtils.getFirstChildTag(columnElement, "groupingSeparator");
+			String groupingSeparator = null;
+			if (groupingSeparatorElement != null) {
+				groupingSeparator = XmlUtils.getStringValue(groupingSeparatorElement);
+			}
+			Element formatStringElement = XmlUtils.getFirstChildTag(columnElement, "formatString");
+			String formatString = null;
+			if (formatStringElement != null) {
+				formatString = XmlUtils.getStringValue(formatStringElement);
+			}
+			Column column = new Column(name, value, type, decimalSeparator, groupingSeparator, formatString);
+			columns.add(column);
+		}
+		return columns;
 	}
 
-	private void applyParameters(PreparedStatement statement, Vector<Column> columns) throws SQLException {
-		Iterator<Column> iter = columns.iterator();
+	private void applyParameters(PreparedStatement statement, List<Column> columns) throws SQLException {
 		int var = 1;
-		while (iter.hasNext()) {
-			Column column = iter.next();
+		for (Column column : columns) {
 			if (column.getParameter() != null) {
 				if (column.getParameter() instanceof Integer) {
 					log.debug("parm [" + var + "] is an Integer with value [" + column.getParameter().toString() + "]");
@@ -564,7 +534,7 @@ public class XmlQuerySender extends DirectQuerySender {
 					var++;
 				} else if (column.getParameter() instanceof Boolean) {
 					log.debug("parm [" + var + "] is an Boolean with value [" + column.getParameter().toString() + "]");
-					statement.setBoolean(var, new Boolean(column.getParameter().toString()));
+					statement.setBoolean(var, Boolean.parseBoolean(column.getParameter().toString()));
 					var++;
 				} else if (column.getParameter() instanceof Double) {
 					log.debug("parm [" + var + "] is a Double with value [" + column.getParameter().toString() + "]");

--- a/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/IDbmsSupport.java
+++ b/core/src/main/java/nl/nn/adapterframework/jdbc/dbms/IDbmsSupport.java
@@ -27,8 +27,9 @@ import java.sql.SQLException;
 import java.util.Date;
 import java.util.List;
 
+import javax.annotation.Nonnull;
+
 import nl.nn.adapterframework.jdbc.JdbcException;
-import nl.nn.adapterframework.jdbc.QueryExecutionContext;
 
 /**
  * Interface to define DBMS specific SQL implementations.
@@ -134,7 +135,8 @@ public interface IDbmsSupport {
 
 	String getSchema(Connection conn) throws JdbcException;
 
-	void convertQuery(QueryExecutionContext queryExecutionContext, String sqlDialectFrom) throws SQLException, JdbcException;
+	@Nonnull
+	String convertQuery(@Nonnull String query, @Nonnull String sqlDialectFrom) throws SQLException, JdbcException;
 
 	ResultSet getTableColumns(Connection conn, String tableName) throws JdbcException;
 	ResultSet getTableColumns(Connection conn, String schemaName, String tableName) throws JdbcException;

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/FixedQuerySenderTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/FixedQuerySenderTest.java
@@ -93,9 +93,14 @@ public class FixedQuerySenderTest extends JdbcSenderTestBase<FixedQuerySender> {
 		Message result = sendMessage("dummy");
 		assertEquals("<result><rowsupdated>1</rowsupdated></result>", result.asString());
 
+		sender.close();
+
 		sender.setQuery("SELECT tVARCHAR FROM "+JdbcTestBase.TEST_TABLE+" WHERE tKEY='3'");
 		sender.setQueryType("select");
 		sender.setScalar(true);
+
+		sender.configure();
+		sender.open();
 
 		result = sendMessage("dummy");
 

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/FixedQuerySenderTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/FixedQuerySenderTest.java
@@ -93,14 +93,9 @@ public class FixedQuerySenderTest extends JdbcSenderTestBase<FixedQuerySender> {
 		Message result = sendMessage("dummy");
 		assertEquals("<result><rowsupdated>1</rowsupdated></result>", result.asString());
 
-		sender.close();
-
 		sender.setQuery("SELECT tVARCHAR FROM "+JdbcTestBase.TEST_TABLE+" WHERE tKEY='3'");
 		sender.setQueryType("select");
 		sender.setScalar(true);
-
-		sender.configure();
-		sender.open();
 
 		result = sendMessage("dummy");
 

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTableListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTableListenerTest.java
@@ -517,8 +517,8 @@ public class JdbcTableListenerTest extends JdbcTestBase {
 
 		@Override
 		public void initAction(Connection conn) throws Exception {
-			context = new QueryExecutionContext("UPDATE "+TEST_TABLE+" SET TINT=3 WHERE TINT!=3 AND TKEY=10", QueryType.OTHER, null);
-			dbmsSupport.convertQuery(context, "Oracle");
+			String query = "UPDATE " + TEST_TABLE + " SET TINT=3 WHERE TINT!=3 AND TKEY=10";
+			context = new QueryExecutionContext(dbmsSupport.convertQuery(query, "Oracle"), QueryType.OTHER, null);
 			connection.setAutoCommit(false);
 		}
 

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTableListenerTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTableListenerTest.java
@@ -44,7 +44,6 @@ import nl.nn.adapterframework.core.ListenerException;
 import nl.nn.adapterframework.core.PipeLineSession;
 import nl.nn.adapterframework.core.ProcessState;
 import nl.nn.adapterframework.functional.ThrowingSupplier;
-import nl.nn.adapterframework.jdbc.JdbcQuerySenderBase.QueryType;
 import nl.nn.adapterframework.jdbc.dbms.ConcurrentJdbcActionTester;
 import nl.nn.adapterframework.jdbc.dbms.Dbms;
 import nl.nn.adapterframework.receivers.RawMessageWrapper;
@@ -509,7 +508,7 @@ public class JdbcTableListenerTest extends JdbcTestBase {
 	private class ChangeProcessStateTester extends ConcurrentJdbcActionTester {
 
 		private @Getter int numRowsUpdated=-1;
-		private QueryExecutionContext context;
+		private String query;
 
 		public ChangeProcessStateTester(ThrowingSupplier<Connection,SQLException> connectionSupplier) {
 			super(connectionSupplier);
@@ -517,14 +516,14 @@ public class JdbcTableListenerTest extends JdbcTestBase {
 
 		@Override
 		public void initAction(Connection conn) throws Exception {
-			String query = "UPDATE " + TEST_TABLE + " SET TINT=3 WHERE TINT!=3 AND TKEY=10";
-			context = new QueryExecutionContext(dbmsSupport.convertQuery(query, "Oracle"), QueryType.OTHER, null);
+			String rawQuery = "UPDATE " + TEST_TABLE + " SET TINT=3 WHERE TINT!=3 AND TKEY=10";
+			query = dbmsSupport.convertQuery(rawQuery, "Oracle");
 			connection.setAutoCommit(false);
 		}
 
 		@Override
 		public void action(Connection conn) throws Exception {
-			try (PreparedStatement statement = conn.prepareStatement(context.getQuery())) {
+			try (PreparedStatement statement = conn.prepareStatement(query)) {
 				numRowsUpdated = statement.executeUpdate();
 			}
 		}
@@ -548,7 +547,7 @@ public class JdbcTableListenerTest extends JdbcTestBase {
 		JdbcUtil.executeStatement(dbmsSupport,connection, "INSERT INTO "+TEST_TABLE+" (TKEY,TINT) VALUES (10,1)", null, new PipeLineSession());
 		try (Connection connection1 = getConnection()) {
 			connection1.setAutoCommit(false);
-			RawMessageWrapper rawMessage1 = listener.getRawMessage(connection1, null);
+			RawMessageWrapper<?> rawMessage1 = listener.getRawMessage(connection1, null);
 			assertEquals("10",rawMessage1.getRawMessage());
 			if (listener.changeProcessState(connection1, rawMessage1, ProcessState.INPROCESS, "test")!=null) {
 				connection1.commit();
@@ -569,7 +568,7 @@ public class JdbcTableListenerTest extends JdbcTestBase {
 		JdbcUtil.executeStatement(dbmsSupport,connection, "INSERT INTO "+TEST_TABLE+" (TKEY,TINT) VALUES (10,1)", null, new PipeLineSession());
 		try (Connection connection1 = getConnection()) {
 			connection1.setAutoCommit(false);
-			RawMessageWrapper rawMessage1 = listener.getRawMessage(connection1, null);
+			RawMessageWrapper<?> rawMessage1 = listener.getRawMessage(connection1, null);
 			assertEquals("10",rawMessage1.getRawMessage());
 			if (listener.changeProcessState(connection1, rawMessage1, ProcessState.INPROCESS, "test")!=null) {
 				connection1.commit();

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTestBase.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTestBase.java
@@ -245,16 +245,16 @@ public abstract class JdbcTestBase {
 	}
 
 	protected PreparedStatement executeTranslatedQuery(Connection connection, String query, QueryType queryType, boolean selectForUpdate) throws JdbcException, SQLException {
-		QueryExecutionContext context = new QueryExecutionContext(query, queryType, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		log.debug("executing translated query ["+context.getQuery()+"]");
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+
+		log.debug("executing translated query [{}]", translatedQuery);
 		if (queryType==QueryType.SELECT) {
 			if(!selectForUpdate) {
-				return  connection.prepareStatement(context.getQuery());
+				return  connection.prepareStatement(translatedQuery);
 			}
-			return connection.prepareStatement(context.getQuery(), ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
+			return connection.prepareStatement(translatedQuery, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_UPDATABLE);
 		}
-		JdbcUtil.executeStatement(connection, context.getQuery());
+		JdbcUtil.executeStatement(connection, translatedQuery);
 		return null;
 	}
 

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/DbmsSupportTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/DbmsSupportTest.java
@@ -252,10 +252,10 @@ public class DbmsSupportTest extends JdbcTestBase {
 	@Test
 	public void testNumericAsDouble() throws Exception {
 		String number = "1234.5678";
-		QueryExecutionContext context = new QueryExecutionContext("INSERT INTO "+TEST_TABLE+"(TKEY, TNUMBER) VALUES (3,?)", QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		System.out.println("executing query ["+context.getQuery()+"]");
-		try (PreparedStatement stmt = connection.prepareStatement(context.getQuery())) {
+		String query = "INSERT INTO "+TEST_TABLE+"(TKEY, TNUMBER) VALUES (3,?)";
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		System.out.println("executing query ["+translatedQuery+"]");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery)) {
 			stmt.setDouble(1, Double.parseDouble(number));
 			stmt.execute();
 		}
@@ -270,11 +270,11 @@ public class DbmsSupportTest extends JdbcTestBase {
 	@Test
 	public void testNumericAsFloat() throws Exception {
 		assumeFalse(dbmsSupport.getDbms()==Dbms.POSTGRESQL); // This fails on PostgreSQL, precision of setFloat appears to be too low"
-		Float number = new Float(1234.5677);
-		QueryExecutionContext context = new QueryExecutionContext("INSERT INTO "+TEST_TABLE+"(TKEY, TNUMBER) VALUES (4,?)", QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		System.out.println("executing query ["+context.getQuery()+"]");
-		try (PreparedStatement stmt = connection.prepareStatement(context.getQuery())) {
+		float number = 1234.5677F;
+		String query = "INSERT INTO " + TEST_TABLE + "(TKEY, TNUMBER) VALUES (4,?)";
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		System.out.println("executing query ["+translatedQuery+"]");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery)) {
 			stmt.setFloat(1, number);
 			stmt.execute();
 		}
@@ -313,10 +313,10 @@ public class DbmsSupportTest extends JdbcTestBase {
 		String date = DateUtils.format(new Date(), DateUtils.shortIsoFormat);
 
 		assumeFalse(dbmsSupport.getDbmsName().equals("Oracle")); // This fails on Oracle, cannot set a non-integer number via setString()
-		QueryExecutionContext context = new QueryExecutionContext("INSERT INTO "+TEST_TABLE+"(TKEY, TNUMBER, TDATE, TDATETIME) VALUES (5,?,?,?)", QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		System.out.println("executing query ["+context.getQuery()+"]");
-		try (PreparedStatement stmt = connection.prepareStatement(context.getQuery())) {
+		String query = "INSERT INTO " + TEST_TABLE + "(TKEY, TNUMBER, TDATE, TDATETIME) VALUES (5,?,?,?)";
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		System.out.println("executing query ["+translatedQuery+"]");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery)) {
 			JdbcUtil.setParameter(stmt, 1, number, dbmsSupport.isParameterTypeMatchRequired());
 			JdbcUtil.setParameter(stmt, 2, date, dbmsSupport.isParameterTypeMatchRequired());
 			JdbcUtil.setParameter(stmt, 3, datetime, dbmsSupport.isParameterTypeMatchRequired());
@@ -394,9 +394,9 @@ public class DbmsSupportTest extends JdbcTestBase {
 	@Test
 	public void testWriteClobInOneStep() throws Exception {
 		String clobContents = "Dit is de content van de clob";
-		QueryExecutionContext context = new QueryExecutionContext("INSERT INTO "+TEST_TABLE+" (TKEY,TCLOB) VALUES (12,?)", QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		try (PreparedStatement stmt = connection.prepareStatement(context.getQuery());) {
+		String query = "INSERT INTO " + TEST_TABLE + " (TKEY,TCLOB) VALUES (12,?)";
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery);) {
 			stmt.setString(1, clobContents);
 			stmt.execute();
 		}
@@ -509,9 +509,9 @@ public class DbmsSupportTest extends JdbcTestBase {
 	@Test
 	public void testWriteBlobInOneStep() throws Exception {
 		String blobContents = "Dit is de content van de blob";
-		QueryExecutionContext context = new QueryExecutionContext("INSERT INTO "+TEST_TABLE+" (TKEY,TBLOB) VALUES (24,?)", QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		try (PreparedStatement stmt = connection.prepareStatement(context.getQuery());) {
+		String query = "INSERT INTO " + TEST_TABLE + " (TKEY,TBLOB) VALUES (24,?)";
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery);) {
 			stmt.setBytes(1, blobContents.getBytes("UTF-8"));
 			stmt.execute();
 		}
@@ -544,9 +544,9 @@ public class DbmsSupportTest extends JdbcTestBase {
 	public void testReadBlobAndCLobUsingJdbcUtilGetValue() throws Exception {
 		String blobContents = "Dit is de content van de blob";
 		String clobContents = "Dit is de content van de clob";
-		QueryExecutionContext context = new QueryExecutionContext("INSERT INTO "+TEST_TABLE+" (TKEY,TBLOB,TCLOB) VALUES (24,?,?)", QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		try (PreparedStatement stmt = connection.prepareStatement(context.getQuery());) {
+		String query = "INSERT INTO " + TEST_TABLE + " (TKEY,TBLOB,TCLOB) VALUES (24,?,?)";
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery);) {
 			stmt.setBytes(1, blobContents.getBytes("UTF-8"));
 			stmt.setString(2, clobContents);
 			stmt.execute();

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/H2DbmsSupportTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/H2DbmsSupportTest.java
@@ -15,26 +15,23 @@ public class H2DbmsSupportTest {
 	public void testConvertQueryOracleToH2() throws JdbcException, SQLException {
 		String query = "DROP SEQUENCE SEQ_IBISSTORE";
 		String expected = "DROP SEQUENCE IF EXISTS SEQ_IBISSTORE";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		(new H2DbmsSupport()).convertQuery(queryExecutionContext, "Oracle");
-		assertEquals(expected, queryExecutionContext.getQuery());
+		String translatedQuery = (new H2DbmsSupport()).convertQuery(query, "Oracle");
+		assertEquals(expected, translatedQuery);
 	}
 
 	@Test
 	public void testConvertQueryH2ToH2() throws JdbcException, SQLException {
 		String query = "SELECT COUNT(*) FROM IBISSTORE";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		(new H2DbmsSupport()).convertQuery(queryExecutionContext, "H2");
-		assertEquals(expected, queryExecutionContext.getQuery());
+		String translatedQuery = (new H2DbmsSupport()).convertQuery(query, "H2");
+		assertEquals(expected, translatedQuery);
 	}
 
 	@Test
 	public void testConvertMultipleQueriesOracleToH2() throws JdbcException, SQLException {
 		String query = "--------\n  --drop--\r\n--------\nDROP SEQUENCE SEQ_IBISSTORE;\nselect count(*) from ibisstore;";
 		String expected = "--------\n  --drop--\r\n--------\nDROP SEQUENCE IF EXISTS SEQ_IBISSTORE;\nselect count(*) from ibisstore;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		(new H2DbmsSupport()).convertQuery(queryExecutionContext, "Oracle");
-		assertEquals(expected, queryExecutionContext.getQuery());
+		String translatedQuery = (new H2DbmsSupport()).convertQuery(query, "Oracle");
+		assertEquals(expected, translatedQuery);
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/SqlTranslatorOracleToH2Test.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/SqlTranslatorOracleToH2Test.java
@@ -2,19 +2,16 @@ package nl.nn.adapterframework.jdbc.dbms;
 
 import static org.junit.Assert.assertEquals;
 
-import java.sql.SQLException;
-
 import org.junit.Ignore;
 import org.junit.Test;
 
 import nl.nn.adapterframework.jdbc.JdbcException;
-import nl.nn.adapterframework.jdbc.QueryExecutionContext;
 
-public class SqlTranslatorTestOracleToH2 {
+public class SqlTranslatorOracleToH2Test {
 
-	private String convertQuery(QueryExecutionContext queryExecutionContext, boolean canModifyQueryExecutionContext) throws JdbcException, SQLException {
+	private String convertQuery(String query) throws JdbcException {
 		SqlTranslator translator = new SqlTranslator("Oracle", "H2");
-		return translator.translate(queryExecutionContext.getQuery());
+		return translator.translate(query);
 	}
 
 	private String skipIrrelevantWhitespace(String query) {
@@ -29,151 +26,134 @@ public class SqlTranslatorTestOracleToH2 {
 	}
 
 	@Test
-	public void testConvertQuerySelect() throws JdbcException, SQLException {
+	public void testConvertQuerySelect() throws JdbcException {
 		String query   = " SELECT FIELD1, FIELD2, DECODE(FIELD3,'Y','true','N','false',NULL,'true') AS FIELD3, LISTAGG(FIELD4, ' + ') WITHIN GROUP (ORDER BY FIELD4) AS FIELD4 FROM TABLE1 GROUP BY FIELD1, FIELD2, FIELD3, FIELD4 ORDER BY FIELD4, FIELD2  \n";
 		String expected = "SELECT FIELD1, FIELD2, DECODE(FIELD3, 'Y', 'true', 'N', 'false', NULL, 'true') AS FIELD3, group_concat(FIELD4 ORDER BY FIELD4 SEPARATOR ' + ') AS FIELD4 FROM TABLE1 GROUP BY FIELD1, FIELD2, FIELD3, FIELD4 ORDER BY FIELD4, FIELD2";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateSequence() throws JdbcException, SQLException {
+	public void testConvertQueryCreateSequence() throws JdbcException {
 		String query = "CREATE SEQUENCE SEQ_IBISSTORE INCREMENT BY 1 MAXVALUE 999999999999999999999999999 MINVALUE 1 CACHE 20 NOORDER;";
 		String expected = "CREATE SEQUENCE SEQ_IBISSTORE INCREMENT BY 1 MAXVALUE 999999999999999999 MINVALUE 1 CACHE 20;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateTable() throws JdbcException, SQLException {
+	public void testConvertQueryCreateTable() throws JdbcException {
 		String query = "CREATE TABLE TABLE1 (FIELD1 NUMBER(10, 0) NOT NULL, FIELD2 CHAR(2 CHAR), FIELD3 NUMBER(*, 0), FIELD4 VARCHAR2(35 CHAR), CONSTRAINT PK_TABLE1 PRIMARY KEY (FIELD1)) LOGGING NOCOMPRESS NOCACHE NOPARALLEL NOMONITORING";
 		String expected = "CREATE TABLE TABLE1(FIELD1 NUMBER(10, 0) NOT NULL, FIELD2 CHAR(2 CHAR), FIELD3 NUMBER(38, 0), FIELD4 VARCHAR2(35 CHAR), CONSTRAINT PK_TABLE1 PRIMARY KEY(FIELD1))";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Ignore("too hard for SqlTranslator to create identity column")
 	@Test
-	public void testConvertQueryCreateTableIbisStore() throws JdbcException, SQLException {
+	public void testConvertQueryCreateTableIbisStore() throws JdbcException {
 		String query = "CREATE TABLE IBISSTORE (MESSAGEKEY NUMBER(10) NOT NULL, TYPE CHAR(1 CHAR), SLOTID VARCHAR2(100 CHAR), HOST VARCHAR2(100 CHAR), MESSAGEID VARCHAR2(100 CHAR), CORRELATIONID VARCHAR2(256 CHAR), MESSAGEDATE TIMESTAMP(6), COMMENTS VARCHAR2(1000 CHAR), MESSAGE BLOB, EXPIRYDATE TIMESTAMP(6), LABEL VARCHAR2(100 CHAR), CONSTRAINT PK_IBISSTORE PRIMARY KEY (MESSAGEKEY));";
 		String expected = "CREATE TABLE IBISSTORE(MESSAGEKEY INT IDENTITY NOT NULL, TYPE CHAR(1 CHAR), SLOTID VARCHAR2(100 CHAR), HOST VARCHAR2(100 CHAR), MESSAGEID VARCHAR2(100 CHAR), CORRELATIONID VARCHAR2(256 CHAR), MESSAGEDATE TIMESTAMP(6), COMMENTS VARCHAR2(1000 CHAR), MESSAGE BLOB, EXPIRYDATE TIMESTAMP(6), LABEL VARCHAR2(100 CHAR), CONSTRAINT PK_IBISSTORE PRIMARY KEY(MESSAGEKEY));";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryDropSequence() throws JdbcException, SQLException {
+	public void testConvertQueryDropSequence() throws JdbcException {
 		String query = "--------\n  --drop--\r\n--------\nDROP SEQUENCE SEQ_IBISSTORE";
 		String expected = "--------" + System.lineSeparator() + " --drop--" + System.lineSeparator() + "--------" + System.lineSeparator() + "DROP SEQUENCE IF EXISTS SEQ_IBISSTORE";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateIndex() throws JdbcException, SQLException {
+	public void testConvertQueryCreateIndex() throws JdbcException {
 		String query = "CREATE INDEX FBIX_TABLE1 ON TABLE1 (LOWER(FIELD3)) NOLOGGING PARALLEL;";
 		String expected = "CREATE INDEX FBIX_TABLE1 ON TABLE1(FIELD3);";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateUniqueIndex() throws JdbcException, SQLException {
+	public void testConvertQueryCreateUniqueIndex() throws JdbcException {
 		String query = "CREATE UNIQUE INDEX FBIX_TABLE1 ON TABLE1 (LOWER(FIELD3))";
 		String expected = "CREATE UNIQUE INDEX FBIX_TABLE1 ON TABLE1 (FIELD3)";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryAlterTable() throws JdbcException, SQLException {
+	public void testConvertQueryAlterTable() throws JdbcException {
 		String query = "ALTER TABLE TABLE1 ADD CONSTRAINT FK_FIELD1 FOREIGN KEY (FIELD1) REFERENCES TABLE2 (FIELD1) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE VALIDATE;";
 		String expected = "ALTER TABLE TABLE1 ADD CONSTRAINT FK_FIELD1 FOREIGN KEY(FIELD1) REFERENCES TABLE2(FIELD1) ON DELETE CASCADE;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testSetDefineOff() throws JdbcException, SQLException {
+	public void testSetDefineOff() throws JdbcException {
 		String query = "Set define off;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, null, result);
 	}
 
 	@Test
-	public void testIgnoreCreateOrReplaceTrigger() throws JdbcException, SQLException {
+	public void testIgnoreCreateOrReplaceTrigger() throws JdbcException {
 		String query = "create or replace TRIGGER TRIGGER1 AFTER DELETE ON FIELD1 FOR EACH ROW DECLARE BEGIN DELETE FROM TABEL2 WHERE FIELD3 = FIELD1; END;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, null, result);
 	}
 
 	@Test
-	public void testIgnoreAlterTrigger() throws JdbcException, SQLException {
+	public void testIgnoreAlterTrigger() throws JdbcException {
 		String query = "ALTER TRIGGER TRIGGER1 ENABLE;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, null, result);
 	}
 
 	@Ignore("too hard for SqlTranslator to create identity column")
 	@Test
-	public void testIgnoreAlterTableIbisStore() throws JdbcException, SQLException {
+	public void testIgnoreAlterTableIbisStore() throws JdbcException {
 		String query = "ALTER TABLE IBISSTORE ADD (CONSTRAINT PK_IBISSTORE PRIMARY KEY (MESSAGEKEY));";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, null, result);
 	}
 
 	@Test
-	public void testExit() throws JdbcException, SQLException {
+	public void testExit() throws JdbcException {
 		String query = "exit;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, null, result);
 	}
 
 	@Test
-	public void testConvertQueryInsertInto() throws JdbcException, SQLException {
+	public void testConvertQueryInsertInto() throws JdbcException {
 		String query = "INSERT INTO IBISTEMP (tkey,tblob) VALUES (SEQ_IBISTEMP.NEXTVAL,EMPTY_BLOB());";
 		String expected = "INSERT INTO IBISTEMP(tkey, tblob) VALUES(NEXT VALUE FOR SEQ_IBISTEMP, '');";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQuerySelectOneWhereForUpdate() throws JdbcException, SQLException {
+	public void testConvertQuerySelectOneWhereForUpdate() throws JdbcException {
 		String query = " SELECT FIELD2 FROM TABLE1 WHERE FIELD1=? AND FIELD3 = ? FOR UPDATE";
 		String expected = "SELECT FIELD2, FIELD1 FROM TABLE1 WHERE FIELD1=? AND FIELD3=? FOR UPDATE";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, true);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryUpdateSet() throws JdbcException, SQLException {
+	public void testConvertQueryUpdateSet() throws JdbcException {
 		String query = "UPDATE IBISTEMP SET tblob1=EMPTY_BLOB() WHERE tkey=?;";
 		String expected = "UPDATE IBISTEMP SET tblob1='' WHERE tkey=?;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testNotConverted() throws JdbcException, SQLException {
+	public void testNotConverted() throws JdbcException {
 		String query = "SELECT COUNT(*) FROM IBISSTORE";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, query, result);
 	}
 

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/SqlTranslatorOracleToMsSqlTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/SqlTranslatorOracleToMsSqlTest.java
@@ -2,18 +2,15 @@ package nl.nn.adapterframework.jdbc.dbms;
 
 import static org.junit.Assert.assertEquals;
 
-import java.sql.SQLException;
-
 import org.junit.Test;
 
 import nl.nn.adapterframework.jdbc.JdbcException;
-import nl.nn.adapterframework.jdbc.QueryExecutionContext;
 
-public class SqlTranslatorTestOracleToMsSql {
+public class SqlTranslatorOracleToMsSqlTest {
 
-	private String convertQuery(QueryExecutionContext queryExecutionContext, boolean canModifyQueryExecutionContext) throws JdbcException, SQLException {
+	private String convertQuery(String query) throws JdbcException {
 		SqlTranslator translator = new SqlTranslator("Oracle", "MS SQL");
-		return translator.translate(queryExecutionContext.getQuery());
+		return translator.translate(query);
 	}
 
 	private String skipIrrelevantWhitespace(String query) {
@@ -23,143 +20,127 @@ public class SqlTranslatorTestOracleToMsSql {
 	}
 
 	@Test
-	public void testNotConverted() throws JdbcException, SQLException {
+	public void testNotConverted() throws JdbcException {
 		String query = "SELECT COUNT(*) FROM IBISSTORE";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals("unchanged", skipIrrelevantWhitespace(query), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryInsertInto() throws JdbcException, SQLException {
+	public void testConvertQueryInsertInto() throws JdbcException {
 		String query = "INSERT INTO IBISTEMP (tkey,tblob1) VALUES (SEQ_IBISTEMP.NEXTVAL,EMPTY_BLOB());";
 		String expected = "INSERT INTO IBISTEMP(tkey, tblob1) VALUES(NEXT VALUE FOR SEQ_IBISTEMP, 0x);";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 
 	@Test
-	public void testSelectCurrentValueOfSequence() throws JdbcException, SQLException {
+	public void testSelectCurrentValueOfSequence() throws JdbcException {
 		String query = "SELECT SEQ_IBISTEMP.NEXTVAL FROM DuaL";
 		String expected = "SELECT NEXT VALUE FOR SEQ_IBISTEMP";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testSelectForUpdate() throws JdbcException, SQLException {
+	public void testSelectForUpdate() throws JdbcException {
 		String query    = "SELECT tblob1 FROM ibistemp WHERE tkey=? FOR UPDATE;";
 		String expected = "SELECT tblob1 FROM ibistemp WHERE tkey=? FOR UPDATE;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQuerySelect() throws JdbcException, SQLException {
+	public void testConvertQuerySelect() throws JdbcException {
 		String query   = " SELECT FIELD1, FIELD2, DECODE(FIELD3,'Y','true','N','false',NULL,'true') AS FIELD3, LISTAGG(FIELD4, ' + ') WITHIN GROUP (ORDER BY FIELD4) AS FIELD4 FROM TABLE1 GROUP BY FIELD1, FIELD2, FIELD3, FIELD4 ORDER BY FIELD4, FIELD2  \n";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateSequence() throws JdbcException, SQLException {
+	public void testConvertQueryCreateSequence() throws JdbcException {
 		String query = "CREATE SEQUENCE SEQ_IBISSTORE INCREMENT BY 1 MAXVALUE 999999999999999999999999999 MINVALUE 1 CACHE 20 NOORDER;";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateTable() throws JdbcException, SQLException {
+	public void testConvertQueryCreateTable() throws JdbcException {
 		String query = "CREATE TABLE TABLE1 (FIELD1 NUMBER(10, 0) NOT NULL, FIELD2 CHAR(2 CHAR), FIELD3 NUMBER(*, 0), FIELD4 VARCHAR2(35 CHAR), CONSTRAINT PK_TABLE1 PRIMARY KEY (FIELD1)) LOGGING NOCOMPRESS NOCACHE NOPARALLEL NOMONITORING";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateTableIbisStore() throws JdbcException, SQLException {
+	public void testConvertQueryCreateTableIbisStore() throws JdbcException {
 		String query = "CREATE TABLE IBISSTORE (MESSAGEKEY NUMBER(10) NOT NULL, TYPE CHAR(1 CHAR), SLOTID VARCHAR2(100 CHAR), HOST VARCHAR2(100 CHAR), MESSAGEID VARCHAR2(100 CHAR), CORRELATIONID VARCHAR2(256 CHAR), MESSAGEDATE TIMESTAMP(6), COMMENTS VARCHAR2(1000 CHAR), MESSAGE BLOB, EXPIRYDATE TIMESTAMP(6), LABEL VARCHAR2(100 CHAR), CONSTRAINT PK_IBISSTORE PRIMARY KEY (MESSAGEKEY));";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryDropSequence() throws JdbcException, SQLException {
+	public void testConvertQueryDropSequence() throws JdbcException {
 		String query = "--------\n  --drop--\r\n--------\nDROP SEQUENCE SEQ_IBISSTORE";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateIndex() throws JdbcException, SQLException {
+	public void testConvertQueryCreateIndex() throws JdbcException {
 		String query = "CREATE INDEX FBIX_TABLE1 ON TABLE1 (LOWER(FIELD3)) NOLOGGING PARALLEL;";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryCreateUniqueIndex() throws JdbcException, SQLException {
+	public void testConvertQueryCreateUniqueIndex() throws JdbcException {
 		String query = "CREATE UNIQUE INDEX FBIX_TABLE1 ON TABLE1 (LOWER(FIELD3))";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testConvertQueryAlterTable() throws JdbcException, SQLException {
+	public void testConvertQueryAlterTable() throws JdbcException {
 		String query = "ALTER TABLE TABLE1 ADD CONSTRAINT FK_FIELD1 FOREIGN KEY (FIELD1) REFERENCES TABLE2 (FIELD1) ON DELETE CASCADE NOT DEFERRABLE INITIALLY IMMEDIATE VALIDATE;";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 
 	@Test
-	public void testSetDefineOff() throws JdbcException, SQLException {
+	public void testSetDefineOff() throws JdbcException {
 		String query = "Set define off;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, result);
 	}
 
 	@Test
-	public void testCreateOrReplaceTrigger() throws JdbcException, SQLException {
+	public void testCreateOrReplaceTrigger() throws JdbcException {
 		String query = "create or replace TRIGGER TRIGGER1 AFTER DELETE ON FIELD1 FOR EACH ROW DECLARE BEGIN DELETE FROM TABEL2 WHERE FIELD3 = FIELD1; END;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, result);
 	}
 
 	@Test
-	public void testExit() throws JdbcException, SQLException {
+	public void testExit() throws JdbcException {
 		String query = "exit;";
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, false);
+		String result = convertQuery(query);
 		assertEquals(query, result);
 	}
 
 	@Test
-	public void testConvertQuerySelectOneWhereForUpdate() throws JdbcException, SQLException {
+	public void testConvertQuerySelectOneWhereForUpdate() throws JdbcException {
 		String query = " SELECT FIELD2 FROM TABLE1 WHERE FIELD1=? AND FIELD3 = ? FOR UPDATE";
 		String expected = query;
-		QueryExecutionContext queryExecutionContext = new QueryExecutionContext(query, null, null);
-		String result = convertQuery(queryExecutionContext, true);
+		String result = convertQuery(query);
 		assertEquals(query,  skipIrrelevantWhitespace(expected), skipIrrelevantWhitespace(result));
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/TestBlobs.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/TestBlobs.java
@@ -10,6 +10,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Reader;
 import java.io.Writer;
+import java.nio.charset.StandardCharsets;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.function.Consumer;
@@ -20,7 +21,6 @@ import org.junit.Test;
 
 import nl.nn.adapterframework.jdbc.JdbcQuerySenderBase.QueryType;
 import nl.nn.adapterframework.jdbc.JdbcTestBase;
-import nl.nn.adapterframework.jdbc.QueryExecutionContext;
 import nl.nn.adapterframework.util.StreamUtil;
 
 @Ignore("Tests for Blobs take too much time and memory to test regularly")
@@ -123,13 +123,12 @@ public class TestBlobs extends JdbcTestBase {
 	public void testWriteAndReadBlobUsingDbmsSupport(int numOfBlocks, int blockSize) throws Exception {
 		String block = getBigString(1,blockSize);
 		String query = "INSERT INTO "+TEST_TABLE+" (TKEY,TBLOB) VALUES (20,?)";
-		QueryExecutionContext context = new QueryExecutionContext(query, QueryType.OTHER, null);
 		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
 		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery)) {
 			Object blobInsertHandle = dbmsSupport.getBlobHandle(stmt, 1);
 			try (OutputStream blobStream = dbmsSupport.getBlobOutputStream(stmt, 1, blobInsertHandle)) {
 				for (int i=0; i<numOfBlocks; i++) {
-					blobStream.write(block.getBytes("UTF-8"));
+					blobStream.write(block.getBytes(StandardCharsets.UTF_8));
 				}
 			}
 			dbmsSupport.applyBlobParameter(stmt, 1, blobInsertHandle);

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/TestBlobs.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/dbms/TestBlobs.java
@@ -93,9 +93,8 @@ public class TestBlobs extends JdbcTestBase {
 	public void testWriteAndReadBlobUsingSetBytes(int numBlocks, int blockSize) throws Exception {
 		String blobContents = getBigString(numBlocks, blockSize);
 		String query = "INSERT INTO "+TEST_TABLE+" (TKEY,TBLOB) VALUES (20,?)";
-		QueryExecutionContext context = new QueryExecutionContext(query, QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		try (PreparedStatement stmt = connection.prepareStatement(query)) {
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery)) {
 			stmt.setBytes(1, blobContents.getBytes("UTF-8"));
 			stmt.execute();
 		}
@@ -125,8 +124,8 @@ public class TestBlobs extends JdbcTestBase {
 		String block = getBigString(1,blockSize);
 		String query = "INSERT INTO "+TEST_TABLE+" (TKEY,TBLOB) VALUES (20,?)";
 		QueryExecutionContext context = new QueryExecutionContext(query, QueryType.OTHER, null);
-		dbmsSupport.convertQuery(context, "Oracle");
-		try (PreparedStatement stmt = connection.prepareStatement(query)) {
+		String translatedQuery = dbmsSupport.convertQuery(query, "Oracle");
+		try (PreparedStatement stmt = connection.prepareStatement(translatedQuery)) {
 			Object blobInsertHandle = dbmsSupport.getBlobHandle(stmt, 1);
 			try (OutputStream blobStream = dbmsSupport.getBlobOutputStream(stmt, 1, blobInsertHandle)) {
 				for (int i=0; i<numOfBlocks; i++) {


### PR DESCRIPTION
Make QueryExecutionContext a mostly read-only structure and simplify methods that use just the query-string, to take that query string as parameter so that fewer unneeded instances of QEC are created.

In FixedQuerySender, translate query only once instead of on every invocation.
