### PR TITLE
Add deprecation filter for older API endpoints

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -31,6 +31,7 @@ Upcoming (7.9)
     `servlet.WebServices10.enabled=true`,
     `servlet.WebServices11.enabled=true` or 
     `servlet.BrowserBinding.enabled=true`
+- Some API endpoints have been deprecated. Users are encouraged to change over to the new API, however in order to restore the deprecated functionality the property 'iaf-api.allowDeprecated' can be set to true.
 
 
 7.8-RC1

--- a/console/backend/pom.xml
+++ b/console/backend/pom.xml
@@ -166,6 +166,11 @@
 			<artifactId>hamcrest-all</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/console/backend/src/main/java/nl/nn/adapterframework/management/web/CompatibilityShowScheduler.java
+++ b/console/backend/src/main/java/nl/nn/adapterframework/management/web/CompatibilityShowScheduler.java
@@ -1,0 +1,96 @@
+/*
+   Copyright 2023 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.management.web;
+
+import java.util.Map;
+
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.jaxrs.ext.multipart.MultipartBody;
+
+/**
+ * This class exists to provide backwards compatibility for endpoints from before #4069.
+ * 
+ * @since	7.8.1
+ * @author	Niels Meijer
+ */
+@Path("/")
+public final class CompatibilityShowScheduler extends ShowScheduler {
+
+	@GET
+	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})
+	@Path("/schedules/{groupName}/job/{jobName}")
+	@Relation("schedules")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Deprecated
+	public Response getScheduleOld(@PathParam("jobName") String jobName, @PathParam("groupName") String groupName) {
+		return getSchedule(jobName, groupName);
+	}
+
+	@PUT
+	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
+	@Path("/schedules/{groupName}/job/{jobName}")
+	@Relation("schedules")
+	@Consumes(MediaType.APPLICATION_JSON)
+	@Produces(MediaType.APPLICATION_JSON)
+	@Deprecated
+	public Response triggerOld(@PathParam("jobName") String jobName, @PathParam("groupName") String groupName, Map<String, Object> json) {
+		return trigger(jobName, groupName, json);
+	}
+
+
+	// Database jobs
+
+	@PUT
+	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
+	@Path("/schedules/{groupName}/job/{jobName}")
+	@Consumes(MediaType.MULTIPART_FORM_DATA)
+	@Produces(MediaType.APPLICATION_JSON)
+	@Deprecated
+	public Response updateScheduleOld(@PathParam("groupName") String groupName, @PathParam("jobName") String jobName, MultipartBody input) {
+		return updateSchedule(groupName, jobName, input);
+	}
+
+	@POST
+	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
+	@Path("/schedules/{groupName}/job")
+	@Relation("schedules")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Deprecated
+	public Response createScheduleInJobGroupOld(@PathParam("groupName") String groupName, MultipartBody input) {
+		return createScheduleInJobGroup(groupName, input);
+	}
+
+	@DELETE
+	@RolesAllowed({"IbisDataAdmin", "IbisAdmin", "IbisTester"})
+	@Path("/schedules/{groupName}/job/{jobName}")
+	@Relation("schedules")
+	@Produces(MediaType.APPLICATION_JSON)
+	@Deprecated
+	public Response deleteSchedulesOld(@PathParam("jobName") String jobName, @PathParam("groupName") String groupName) {
+		return deleteSchedules(jobName, groupName);
+	}
+}

--- a/console/backend/src/main/java/nl/nn/adapterframework/management/web/DeprecationFilter.java
+++ b/console/backend/src/main/java/nl/nn/adapterframework/management/web/DeprecationFilter.java
@@ -1,0 +1,104 @@
+/*
+   Copyright 2023 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.management.web;
+
+import java.lang.reflect.Method;
+
+import javax.annotation.Priority;
+import javax.ws.rs.Path;
+import javax.ws.rs.Priorities;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.Provider;
+
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.core.env.Environment;
+
+import lombok.Setter;
+
+/**
+ * Manages deprecations per resource/collection.
+ * 
+ * Default JAX-RS provider and is automatically picked-up by the FF!API Spring context because of the package (component) scanner.
+ * 
+ * @since   7.8.1
+ * @author  Niels Meijer
+ */
+
+@Provider
+@Priority(Priorities.USER)
+public class DeprecationFilter implements ContainerRequestFilter, EnvironmentAware {
+
+	public static final String ALLOW_DEPRECATED_ENDPOINTS_KEY = "iaf-api.allowDeprecated";
+	private static final Response DEPRECATION_ERROR = Response.status(Response.Status.BAD_REQUEST).build();
+	private static final Response SERVER_ERROR = Response.status(Response.Status.INTERNAL_SERVER_ERROR).build();
+
+	private Logger log = LogManager.getLogger(this);
+	private @Setter Environment environment;
+
+	@Override
+	public void filter(ContainerRequestContext requestContext) {
+		Message message = JAXRSUtils.getCurrentMessage();
+		Method method = (Method)message.get("org.apache.cxf.resource.method");
+		if(method == null) {
+			log.error("unable to fetch resource method from CXF Message");
+			requestContext.abortWith(SERVER_ERROR);
+			return;
+		}
+
+		if(method.isAnnotationPresent(Deprecated.class)) {
+			if(!allowDeprecatedEndpoints()) {
+				requestContext.abortWith(DEPRECATION_ERROR);
+			}
+			log.warn("endpoint [{}] has been deprecated, set property [{}=true] to restore functionality", getFullPath(method), ALLOW_DEPRECATED_ENDPOINTS_KEY);
+		}
+	}
+
+	// The basepath is usually a '/', but path may also start with a slash.
+	// Ensure a valid path is returned.
+	private String getFullPath(Method method) {
+		Path classPath = method.getDeclaringClass().getAnnotation(Path.class);
+		final String basePath = (classPath != null) ? classPath.value() : "/";
+
+		StringBuilder pathToUse = new StringBuilder();
+		if(!basePath.startsWith("/")) {
+			pathToUse.append("/");
+		}
+		pathToUse.append(basePath);
+
+		Path methodPath = method.getAnnotation(Path.class);
+		if(methodPath != null) {
+			final String path = methodPath.value();
+			pathToUse.append( (basePath.endsWith("/") && path.startsWith("/")) ? path.substring(1) : path);
+		}
+		return pathToUse.toString();
+	}
+
+	/** Get a property from the Spring Environment. */
+	@SuppressWarnings("unchecked")
+	private <T> T getProperty(String key, T defaultValue) {
+		return environment.getProperty(key, (Class<T>) defaultValue.getClass(), defaultValue);
+	}
+
+	private boolean allowDeprecatedEndpoints() {
+		return getProperty(ALLOW_DEPRECATED_ENDPOINTS_KEY, false);
+	}
+}

--- a/console/backend/src/main/java/nl/nn/adapterframework/management/web/FrankApiBase.java
+++ b/console/backend/src/main/java/nl/nn/adapterframework/management/web/FrankApiBase.java
@@ -125,6 +125,10 @@ public abstract class FrankApiBase implements ApplicationContextAware, Initializ
 		return environment.getProperty(key, (Class<T>) defaultValue.getClass(), defaultValue);
 	}
 
+	protected final boolean allowDeprecatedEndpoints() {
+		return getProperty(DeprecationFilter.ALLOW_DEPRECATED_ENDPOINTS_KEY, false);
+	}
+
 	protected JAXRSServiceFactoryBean getJAXRSService() {
 		return serviceFactory;
 	}

--- a/console/backend/src/main/java/nl/nn/adapterframework/management/web/Init.java
+++ b/console/backend/src/main/java/nl/nn/adapterframework/management/web/Init.java
@@ -48,7 +48,7 @@ import org.apache.cxf.jaxrs.model.OperationResourceInfo;
 public class Init extends FrankApiBase {
 
 	private String getHATEOASImplementation() {
-		return getProperty("ibis-api.hateoasImplementation", "default");
+		return getProperty("iaf-api.hateoasImplementation", "default");
 	}
 
 	private boolean isMonitoringEnabled() {
@@ -80,8 +80,15 @@ public class Init extends FrankApiBase {
 				if(method.getDeclaringClass().getName().endsWith("ShowMonitors") && !isMonitoringEnabled()) {
 					continue;
 				}
+				boolean deprecated = method.getAnnotation(Deprecated.class) != null;
 
 				Map<String, Object> resource = new HashMap<>(4);
+
+				if(deprecated) {
+					if(!allowDeprecatedEndpoints()) continue; // Skip all
+
+					resource.put("deprecated", true);
+				}
 
 				if(method.isAnnotationPresent(GET.class))
 					resource.put("type", "GET");
@@ -103,7 +110,6 @@ public class Init extends FrankApiBase {
 				if(rolesAllowed != null && displayAllowedRoles) {
 					resource.put("allowed", rolesAllowed.value());
 				}
-
 
 				if(("hal".equalsIgnoreCase(getHATEOASImplementation()))) {
 					if(method.isAnnotationPresent(Relation.class))

--- a/console/backend/src/main/java/nl/nn/adapterframework/management/web/ShowScheduler.java
+++ b/console/backend/src/main/java/nl/nn/adapterframework/management/web/ShowScheduler.java
@@ -44,7 +44,7 @@ import nl.nn.adapterframework.util.RequestUtils;
  */
 
 @Path("/")
-public final class ShowScheduler extends FrankApiBase {
+public class ShowScheduler extends FrankApiBase {
 
 	@GET
 	@RolesAllowed({"IbisObserver", "IbisDataAdmin", "IbisAdmin", "IbisTester"})

--- a/console/backend/src/test/java/nl/nn/adapterframework/management/web/TestDeprecationFilter.java
+++ b/console/backend/src/test/java/nl/nn/adapterframework/management/web/TestDeprecationFilter.java
@@ -1,0 +1,171 @@
+package nl.nn.adapterframework.management.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.SortedSet;
+import java.util.TreeSet;
+
+import javax.ws.rs.Path;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+
+import org.apache.cxf.message.Message;
+import org.apache.cxf.message.MessageImpl;
+import org.apache.cxf.phase.Phase;
+import org.apache.cxf.phase.PhaseInterceptorChain;
+import org.apache.logging.log4j.Level;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.core.env.Environment;
+
+import nl.nn.adapterframework.util.TestAppender;
+
+public class TestDeprecationFilter {
+
+	private static final String CXF_METHOD_KEY = "org.apache.cxf.resource.method";
+
+	@Test
+	public void testDefaultBehaviour() throws Exception {
+		DeprecationFilter filter = new DeprecationFilter();
+		Environment env = mock(Environment.class);
+		when(env.getProperty(any(), any(), any())).thenReturn(false);
+		filter.setEnvironment(env);
+
+		ContainerRequestContext request = mock(ContainerRequestContext.class);
+		setMethod(ClassWithSlash.class, "normalMethod");
+
+		// Act
+		filter.filter(request);
+
+		// Assert
+		verify(request, never()).abortWith(any(Response.class));
+	}
+
+	@Test
+	public void testDeprecatedMethodNotAllowed() throws Exception {
+		DeprecationFilter filter = new DeprecationFilter();
+		Environment env = mock(Environment.class);
+		when(env.getProperty(any(), any(), any())).thenReturn(false);
+		filter.setEnvironment(env);
+
+		ContainerRequestContext request = mock(ContainerRequestContext.class);
+		ArgumentCaptor<Response> messageCapture = ArgumentCaptor.forClass(Response.class);
+		doNothing().when(request).abortWith(messageCapture.capture());
+
+		setMethod(ClassWithSlash.class, "deprecatedMethod");
+
+		// Act
+		filter.filter(request);
+
+		// Assert
+		verify(request, times(1)).abortWith(any(Response.class));
+		assertEquals(400, messageCapture.getValue().getStatus());
+	}
+
+	@Test
+	public void testDeprecatedMethodAllowed() throws Exception {
+		TestAppender appender = TestAppender.newBuilder().build();
+		TestAppender.setRootLogLevel(Level.WARN);
+		TestAppender.addToRootLogger(appender);
+		try {
+			DeprecationFilter filter = new DeprecationFilter();
+			Environment env = mock(Environment.class);
+			when(env.getProperty(any(), any(), any())).thenReturn(true);
+			filter.setEnvironment(env);
+
+			ContainerRequestContext request = mock(ContainerRequestContext.class);
+			ArgumentCaptor<Response> messageCapture = ArgumentCaptor.forClass(Response.class);
+			doNothing().when(request).abortWith(messageCapture.capture());
+
+			setMethod(ClassWithSlash.class, "deprecatedMethod");
+
+			// Act
+			filter.filter(request);
+
+			// Assert
+			verify(request, never()).abortWith(any(Response.class));
+		} finally {
+			TestAppender.removeAppender(appender);
+			TestAppender.setRootLogLevel(Level.ERROR);
+		}
+		assertTrue(appender.contains("endpoint [/request/path2] has been deprecated"));
+	}
+
+	@Test
+	public void testDeprecatedMethodWithCombinedPath() throws Exception {
+		TestAppender appender = TestAppender.newBuilder().build();
+		TestAppender.setRootLogLevel(Level.WARN);
+		TestAppender.addToRootLogger(appender);
+		try {
+			DeprecationFilter filter = new DeprecationFilter();
+			Environment env = mock(Environment.class);
+			when(env.getProperty(any(), any(), any())).thenReturn(true);
+			filter.setEnvironment(env);
+
+			ContainerRequestContext request = mock(ContainerRequestContext.class);
+			ArgumentCaptor<Response> messageCapture = ArgumentCaptor.forClass(Response.class);
+			doNothing().when(request).abortWith(messageCapture.capture());
+
+			setMethod(ClassWithCombinedPath.class, "deprecatedMethod");
+
+			// Act
+			filter.filter(request);
+
+			// Assert
+			verify(request, never()).abortWith(any(Response.class));
+		} finally {
+			TestAppender.removeAppender(appender);
+			TestAppender.setRootLogLevel(Level.ERROR);
+		}
+		assertTrue(appender.contains("endpoint [/base/path/request] has been deprecated"));
+	}
+
+	private void setMethod(Class<?> targetClass, String methodName) throws Exception {
+		Message message = new MessageImpl();
+		Method method = targetClass.getMethod(methodName, new Class[] {});
+		message.put(CXF_METHOD_KEY, method);
+
+		SortedSet<Phase> ps = new TreeSet<>();
+		PhaseInterceptorChain chain = new PhaseInterceptorChain(ps);
+		Field currentMessageField = PhaseInterceptorChain.class.getDeclaredField("CURRENT_MESSAGE");
+		currentMessageField.setAccessible(true);
+		@SuppressWarnings("unchecked")
+		ThreadLocal<Message> threadLocal = (ThreadLocal<Message>) currentMessageField.get(chain);
+		threadLocal.set(message);
+	}
+
+	@Path("/")
+	private static class ClassWithSlash {
+
+		@Path("/request/path1")
+		public Response normalMethod() {
+			return Response.accepted().build();
+		}
+
+		@Path("/request/path2")
+		@Deprecated
+		public Response deprecatedMethod() {
+			return Response.accepted().build();
+		}
+	}
+
+	@Path("base/path")
+	private static class ClassWithCombinedPath {
+
+		@Path("/request")
+		@Deprecated
+		public Response deprecatedMethod() {
+			return Response.accepted().build();
+		}
+	}
+}

--- a/console/backend/src/test/java/nl/nn/adapterframework/util/TestAppender.java
+++ b/console/backend/src/test/java/nl/nn/adapterframework/util/TestAppender.java
@@ -1,0 +1,135 @@
+/*
+   Copyright 2020 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.util;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.core.Filter;
+import org.apache.logging.log4j.core.Layout;
+import org.apache.logging.log4j.core.LogEvent;
+import org.apache.logging.log4j.core.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.AbstractAppender;
+import org.apache.logging.log4j.core.config.Configurator;
+
+public class TestAppender extends AbstractAppender {
+	private final List<String> logMessages = new ArrayList<>();
+	private final List<LogEvent> logEvents = new ArrayList<>();
+	private Level minLogLevel = Level.DEBUG;
+
+	public static <B extends Builder<B>> B newBuilder() {
+		return new Builder<B>().asBuilder().setName("jUnit-Test-Appender");
+	}
+
+	public static class Builder<B extends Builder<B>> extends AbstractAppender.Builder<B> {
+
+		private Level minLogLevel = null;
+
+
+		public B minLogLevel(Level level) {
+			this.minLogLevel = level;
+			return asBuilder();
+		}
+
+		public TestAppender build() {
+			TestAppender appender = new TestAppender(getName(), getFilter(), getOrCreateLayout());
+			if (this.minLogLevel != null) {
+				appender.minLogLevel = this.minLogLevel;
+			}
+			return appender;
+		}
+	}
+
+	private TestAppender(String name, Filter filter, Layout<? extends Serializable> layout) {
+		super(name, filter, layout, false, null);
+		start();
+	}
+
+	@Override
+	public void append(LogEvent logEvent) {
+		if (this.minLogLevel != null && !logEvent.getLevel().isMoreSpecificThan(this.minLogLevel)) {
+			return;
+		}
+		logMessages.add((String) this.toSerializable(logEvent));
+		logEvents.add(logEvent);
+	}
+
+	public int getNumberOfAlerts() {
+		return logMessages.size();
+	}
+
+	public List<String> getLogLines() {
+		return new ArrayList<>(logMessages);
+	}
+
+	public List<LogEvent> getLogEvents() {
+		return new ArrayList<>(logEvents);
+	}
+
+	private static Logger getRootLogger() {
+		return (Logger) LogManager.getRootLogger();
+	}
+
+	public static void addToRootLogger(TestAppender appender) {
+		Logger logger = getRootLogger();
+		logger.addAppender(appender);
+	}
+
+	public static void addToLogger(String loggerName, TestAppender appender) {
+		Logger logger = (Logger) LogManager.getLogger(loggerName);
+		logger.addAppender(appender);
+	}
+
+	public static void removeAppender(TestAppender appender) {
+		Logger logger = getRootLogger();
+		logger.removeAppender(appender);
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder sb = new StringBuilder();
+		for (String log : getLogLines()) {
+			sb.append(log);
+			sb.append("\n");
+		}
+		return sb.toString();
+	}
+
+	public boolean contains(String msg) {
+		for (String log : getLogLines()) {
+			if(log.contains(msg)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	public void clearLogs() {
+		logMessages.clear();
+	}
+
+	public static void setRootLogLevel(Level loglevel) {
+		LoggerContext logContext = LoggerContext.getContext(false);
+		org.apache.logging.log4j.core.Logger rootLogger = logContext.getRootLogger();
+		if(rootLogger.getLevel() != loglevel) {
+			Configurator.setLevel(rootLogger.getName(), loglevel);
+		}
+	}
+}

--- a/core/src/main/resources/AppConstants.properties
+++ b/core/src/main/resources/AppConstants.properties
@@ -502,6 +502,9 @@ warnings.suppress.integrityCheck=false
 iaf-api.enabled=true
 console.location=iaf/gui/
 iaf-api.hateoasImplementation=default
+
+# Enable deprecated API endpoints
+iaf-api.allowDeprecated=false
 console.active=${iaf-api.enabled}
 
 #Cookie settings


### PR DESCRIPTION
The scheduler endpoints have been renamed in #4069 from .../job/.. to .../jobs/..
These need to be backported (and a fix needs to be added to the release notes).