### PR TITLE
Fix JDBC/JTA unit tests not running on MS-SQL

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -832,6 +832,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>com.ibm.db2</groupId>
+			<artifactId>jcc</artifactId>
+			<version>${db2.driver.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.microsoft.sqlserver</groupId>
 			<artifactId>mssql-jdbc</artifactId>
 			<version>${mssql.driver.version}</version>

--- a/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTestBase.java
+++ b/core/src/test/java/nl/nn/adapterframework/jdbc/JdbcTestBase.java
@@ -37,6 +37,7 @@ import lombok.Getter;
 import nl.nn.adapterframework.jdbc.JdbcQuerySenderBase.QueryType;
 import nl.nn.adapterframework.jdbc.dbms.IDbmsSupport;
 import nl.nn.adapterframework.jdbc.dbms.IDbmsSupportFactory;
+import nl.nn.adapterframework.jndi.TransactionalDbmsSupportAwareDataSourceProxy;
 import nl.nn.adapterframework.testutil.TestConfiguration;
 import nl.nn.adapterframework.testutil.TransactionManagerType;
 import nl.nn.adapterframework.testutil.URLDataSourceFactory;
@@ -96,7 +97,12 @@ public abstract class JdbcTestBase {
 	public void setup() throws Exception {
 		dataSource = transactionManagerType.getDataSource(productKey);
 
-		String dsInfo = dataSource.toString(); //We can assume a connection has already been made by the URLDataSourceFactory to validate the DataSource/connectivity
+		String dsInfo; //We can assume a connection has already been made by the URLDataSourceFactory to validate the DataSource/connectivity
+		if(dataSource instanceof TransactionalDbmsSupportAwareDataSourceProxy) {
+			dsInfo = ((TransactionalDbmsSupportAwareDataSourceProxy) dataSource).getTargetDataSource().toString();
+		} else {
+			dsInfo = dataSource.toString();
+		}
 		dataSourceInfo = parseDataSourceInfo(dsInfo);
 
 		//The datasourceName must be equal to the ProductKey to ensure we're testing the correct datasource

--- a/core/src/test/java/nl/nn/adapterframework/testutil/URLDataSourceFactory.java
+++ b/core/src/test/java/nl/nn/adapterframework/testutil/URLDataSourceFactory.java
@@ -26,11 +26,12 @@ public class URLDataSourceFactory extends JndiDataSourceFactory {
 	private static final Object[][] TEST_DATASOURCES = {
 			// ProductName, Url, user, password, testPeekDoesntFindRecordsAlreadyLocked
 			{ "H2",         "jdbc:h2:mem:test;LOCK_TIMEOUT=1000", null, null, false, "org.h2.jdbcx.JdbcDataSource" },
-			{ "Oracle",     "jdbc:oracle:thin:@localhost:1521:ORCLCDB", 			"testiaf_user", "testiaf_user00", false, "oracle.jdbc.xa.client.OracleXADataSource" },
-			{ "MS_SQL",     "jdbc:sqlserver://localhost:1433;database=testiaf", 	"testiaf_user", "testiaf_user00", false, "com.microsoft.sqlserver.jdbc.SQLServerXADataSource" },
+// Unit tests in 7.8 are not DB2 compatible for now.
+//			{ "DB2",        "jdbc:db2://localhost:50000/testiaf", "testiaf_user", "testiaf_user00", false, "com.ibm.db2.jcc.DB2XADataSource" },
+			{ "Oracle",     "jdbc:oracle:thin:@localhost:1521:XE", 			"testiaf_user", "testiaf_user00", false, "oracle.jdbc.xa.client.OracleXADataSource" },
+			{ "MS_SQL",     "jdbc:sqlserver://localhost:1433;database=testiaf;lockTimeout=10000", 	"testiaf_user", "testiaf_user00", false, "com.microsoft.sqlserver.jdbc.SQLServerXADataSource" },
 			{ "MySQL",      "jdbc:mysql://localhost:3307/testiaf?sslMode=DISABLED&disableMariaDbDriver=1&pinGlobalTxToPhysicalConnection=true&serverTimezone=Europe/Amsterdam", "testiaf_user", "testiaf_user00", true, "com.mysql.cj.jdbc.MysqlXADataSource" },
-			//{ "MariaDB",   "jdbc:mariadb://localhost:3306/testiaf", 				"testiaf_user", "testiaf_user00", false }, // can have only one entry per product key
-			{ "MariaDB",   "jdbc:mysql://localhost:3306/testiaf?sslMode=DISABLED&disableMariaDbDriver=true&pinGlobalTxToPhysicalConnection=true&serverTimezone=Europe/Amsterdam", "testiaf_user", "testiaf_user00", false, "com.mysql.cj.jdbc.MysqlXADataSource" },
+			{ "MariaDB",    "jdbc:mariadb://localhost:3306/testiaf", 				"testiaf_user", "testiaf_user00", false, "org.mariadb.jdbc.MariaDbDataSource" }, // can have only one entry per product key
 			{ "PostgreSQL", "jdbc:postgresql://localhost:5432/testiaf", 			"testiaf_user", "testiaf_user00", true, "org.postgresql.xa.PGXADataSource" }
 		};
 
@@ -50,22 +51,22 @@ public class URLDataSourceFactory extends JndiDataSourceFactory {
 				try { //Attempt to add the DataSource and skip it if it cannot be instantiated
 					DataSource ds = createDataSource(product, url, userId, password, testPeek, xaImplClassName);
 					// Check if we can make a connection
-					if(validateConnection(ds)) {
+					if(validateConnection(product, ds)) {
 						availableDatasources.add(product);
+						log.info("adding DataSource {} for testing", product);
 					}
 				} catch (Exception e) {
 					log.info("ignoring DataSource, cannot complete setup", e);
-					e.printStackTrace();
 				}
 			}
 		}
 	}
 
-	private boolean validateConnection(DataSource ds) {
-		try(Connection connection = ds.getConnection()) {
+	private boolean validateConnection(String product, DataSource ds) {
+		try(Connection ignored = ds.getConnection()) {
 			return true;
 		} catch (Throwable e) {
-			log.warn("Cannot connect to ["+ds+"], skipping:"+e.getMessage());
+			log.warn("Cannot connect to [" + product + "], skipping:"+e.getMessage());
 		}
 		return false;
 	}


### PR DESCRIPTION
Improve logging of test configuration.

(DB2 remains broken in the unit tests, CREATE TABLE statements in test appear incompatible w/DB2).

Backport of improvements also in 7.9.