### PR TITLE
Fix AWS S3 FileSystem should not retrieve a truncated list 

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/filesystem/AmazonS3FileSystem.java
+++ b/core/src/main/java/nl/nn/adapterframework/filesystem/AmazonS3FileSystem.java
@@ -348,7 +348,7 @@ public class AmazonS3FileSystem extends FileSystemBase<S3Object> implements IWri
 
 	@Override
 	public boolean folderExists(String folder) throws FileSystemException {
-		ObjectListing objectListing = s3Client.listObjects(bucketName);
+		ObjectListing objectListing = s3Client.listObjects(bucketName, folder);
 		Iterator<S3ObjectSummary> objIter = objectListing.getObjectSummaries().iterator();
 		while (objIter.hasNext()) {
 			S3ObjectSummary s3ObjectSummary = objIter.next();


### PR DESCRIPTION
The method `s3Client.listObjects(bucketName)` returns a truncated list (max 1000) items, by adding the suffix the search is way more efficient and no need to iterate over the entire s3 bucket content.

![image](https://github.com/ibissource/iaf/assets/37303445/a3d47435-774e-4a6b-9f93-beffb04737df)
