### PR TITLE
ASPOSE: Strip MimeType params for converters (7.8)

### DIFF
--- a/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/CisConversionServiceImpl.java
+++ b/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/CisConversionServiceImpl.java
@@ -58,7 +58,7 @@ public class CisConversionServiceImpl implements CisConversionService {
 			mimeType = getMediaType(message, filename);
 		}
 
-		MediaType mediaType = MediaType.asMediaType(mimeType);
+		MediaType mediaType = new MediaType(mimeType.getType(), mimeType.getSubtype()); //Strip all parameters
 		if (isPasswordProtected(mediaType)) {
 			result = CisConversionResult.createPasswordFailureResult(filename, conversionOption, mediaType);
 		} else {

--- a/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/AbstractConvertor.java
+++ b/aspose/src/main/java/nl/nn/adapterframework/extensions/aspose/services/conv/impl/convertors/AbstractConvertor.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2019, 2021-2022 WeAreFrank!
+   Copyright 2019, 2021-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -110,9 +110,9 @@ abstract class AbstractConvertor implements Convertor {
 			result.setPdfResultFile(resultFile);
 			result.setResultFilePath(resultFile.getAbsolutePath());
 
-			LOGGER.debug("Convert to file... " + filename);
+			LOGGER.debug("Convert to file... {}", filename);
 			convert(mediaType, message, result, charset);
-			LOGGER.debug("Convert to file finished. " + filename);
+			LOGGER.debug("Convert to file finished. {}", filename);
 
 		} catch (Exception e) {
 			if (isPasswordException(e)) {
@@ -129,11 +129,9 @@ abstract class AbstractConvertor implements Convertor {
 	protected int getNumberOfPages(File file) throws IOException {
 		int result = 0;
 		if(file != null) {
-			try (InputStream inStream = new FileInputStream(file)){
+			try (InputStream inStream = new FileInputStream(file)) {
 				Document doc = new Document(inStream);
 				result = doc.getPages().size();
-			} catch (IOException e) {
-				throw e;
 			}
 		}
 

--- a/aspose/src/test/java/nl/nn/adapterframework/extensions/aspose/pipe/PdfPipeTest.java
+++ b/aspose/src/test/java/nl/nn/adapterframework/extensions/aspose/pipe/PdfPipeTest.java
@@ -16,6 +16,7 @@
 package nl.nn.adapterframework.extensions.aspose.pipe;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
@@ -40,6 +41,7 @@ import javax.imageio.ImageIO;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.springframework.util.MimeType;
 
 import com.testautomationguru.utility.CompareMode;
 import com.testautomationguru.utility.ImageUtil;
@@ -57,6 +59,7 @@ import nl.nn.adapterframework.testutil.MatchUtils;
 import nl.nn.adapterframework.testutil.TestAssertions;
 import nl.nn.adapterframework.testutil.TestFileUtils;
 import nl.nn.adapterframework.util.LogUtil;
+import nl.nn.adapterframework.util.MessageUtils;
 
 /**
  * Executes defined tests against the PdfPipe to ensure the correct working of this pipe.
@@ -198,6 +201,23 @@ public class PdfPipeTest extends PipeTestBase<PdfPipe> {
 			result = result.replaceAll(ignore, "IGNORE");
 		}
 		return result;
+	}
+
+	@Test
+	public void testFileWithMimeTypeAndCharset() throws Exception {
+		pipe.setAction(DocumentAction.CONVERT);
+		pipe.configure();
+		pipe.start();
+
+		PipeLineSession session = new PipeLineSession();
+		Message input = new UrlMessage(TestFileUtils.getTestFileURL("/Util/MessageUtils/utf8-with-bom.txt"));
+		MimeType mimeType = MessageUtils.computeMimeType(input);
+		assertEquals("UTF-8", mimeType.getParameter("charset")); //ensure we have a charset in the mimetype
+		PipeRunResult result = pipe.doPipe(input, session);
+
+		//returns <main conversionOption="0" mediaType="xxx/xxx" documentName="filename" numberOfPages="1" convertedDocument="xxx.pdf" />
+		String responseXml = result.getResult().asString();
+		assertFalse(responseXml.contains("failureReason"));
 	}
 
 	@Test

--- a/aspose/src/test/java/nl/nn/adapterframework/extensions/aspose/pipe/PdfPipeTest.java
+++ b/aspose/src/test/java/nl/nn/adapterframework/extensions/aspose/pipe/PdfPipeTest.java
@@ -56,6 +56,8 @@ import nl.nn.adapterframework.pipes.PipeTestBase;
 import nl.nn.adapterframework.stream.Message;
 import nl.nn.adapterframework.stream.UrlMessage;
 import nl.nn.adapterframework.testutil.MatchUtils;
+import nl.nn.adapterframework.testutil.MessageTestUtils;
+import nl.nn.adapterframework.testutil.MessageTestUtils.MessageType;
 import nl.nn.adapterframework.testutil.TestAssertions;
 import nl.nn.adapterframework.testutil.TestFileUtils;
 import nl.nn.adapterframework.util.LogUtil;
@@ -210,7 +212,7 @@ public class PdfPipeTest extends PipeTestBase<PdfPipe> {
 		pipe.start();
 
 		PipeLineSession session = new PipeLineSession();
-		Message input = new UrlMessage(TestFileUtils.getTestFileURL("/Util/MessageUtils/utf8-with-bom.txt"));
+		Message input = MessageTestUtils.getMessage(MessageType.CHARACTER_UTF8);
 		MimeType mimeType = MessageUtils.computeMimeType(input);
 		assertEquals("UTF-8", mimeType.getParameter("charset")); //ensure we have a charset in the mimetype
 		PipeRunResult result = pipe.doPipe(input, session);

--- a/aspose/src/test/resources/Util/MessageUtils/utf8-with-bom.txt
+++ b/aspose/src/test/resources/Util/MessageUtils/utf8-with-bom.txt
@@ -1,0 +1,1 @@
+﻿testFile with BOM —•˜›


### PR DESCRIPTION
(cherry picked from commit fd295cc60bbdef852ce9d3ec5e8cdecc69eb6bfd)