### PR TITLE
Job response not read and closed: close localSender, Message, PipeLineSession too (#5324)

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/scheduler/job/SendMessageJob.java
+++ b/core/src/main/java/nl/nn/adapterframework/scheduler/job/SendMessageJob.java
@@ -58,7 +58,7 @@ public class SendMessageJob extends JobDef {
 	@Override
 	public void execute() throws JobExecutionException, TimeoutException {
 		try (Message toSendMessage = new Message((getMessage() == null) ? "" : getMessage());
-			 PipeLineSession session = new PipeLineSession()) {
+				PipeLineSession session = new PipeLineSession()) {
 			//Set a messageId that will be forwarded by the localSender to the called adapter. Adapter and job will then share a Ladybug report.
 			session.put(PipeLineSession.CORRELATION_ID_KEY, UUIDUtil.createSimpleUUID());
 

--- a/core/src/main/java/nl/nn/adapterframework/scheduler/job/SendMessageJob.java
+++ b/core/src/main/java/nl/nn/adapterframework/scheduler/job/SendMessageJob.java
@@ -15,9 +15,12 @@
 */
 package nl.nn.adapterframework.scheduler.job;
 
+import java.io.IOException;
+
 import org.apache.commons.lang3.StringUtils;
 
 import lombok.Getter;
+import lombok.Setter;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.configuration.ConfigurationWarning;
 import nl.nn.adapterframework.core.PipeLineSession;
@@ -30,10 +33,9 @@ import nl.nn.adapterframework.util.SpringUtils;
 import nl.nn.adapterframework.util.UUIDUtil;
 
 public class SendMessageJob extends JobDef {
-	private IbisLocalSender localSender = null;
+	private @Setter IbisLocalSender localSender = null;
 	private @Getter String javaListener;
 	private @Getter String message = null;
-
 
 	@Override
 	public void configure() throws ConfigurationException {
@@ -55,19 +57,16 @@ public class SendMessageJob extends JobDef {
 
 	@Override
 	public void execute() throws JobExecutionException, TimeoutException {
-		try {
-			localSender.open();
-			//sendMessage message cannot be NULL
-			Message message = new Message((getMessage()==null) ? "" : getMessage());
-			PipeLineSession session = new PipeLineSession();
+		try (Message toSendMessage = new Message((getMessage() == null) ? "" : getMessage());
+			 PipeLineSession session = new PipeLineSession()) {
 			//Set a messageId that will be forwarded by the localSender to the called adapter. Adapter and job will then share a Ladybug report.
 			session.put(PipeLineSession.CORRELATION_ID_KEY, UUIDUtil.createSimpleUUID());
-			localSender.sendMessageOrThrow(message, session);
-		}
-		catch (SenderException e) {
-			throw new JobExecutionException("unable to send message to javaListener ["+javaListener+"]", e);
-		}
-		finally {
+
+			localSender.open();
+			localSender.sendMessageOrThrow(toSendMessage, session).close();
+		} catch (SenderException | IOException e) {
+			throw new JobExecutionException("unable to send message to javaListener [" + javaListener + "]", e);
+		} finally {
 			try {
 				localSender.close();
 			} catch (SenderException e) {
@@ -90,7 +89,7 @@ public class SendMessageJob extends JobDef {
 		setJavaListener(receiverName); //For backwards compatibility
 	}
 
-	/** message to be send into the pipeline */
+	/** message to be sent into the pipeline */
 	public void setMessage(String message) {
 		if(StringUtils.isNotEmpty(message)) {
 			this.message = message;

--- a/core/src/test/java/nl/nn/adapterframework/scheduler/job/SendMessageJobTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/scheduler/job/SendMessageJobTest.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.SenderException;
@@ -21,7 +20,7 @@ import nl.nn.adapterframework.stream.Message;
 class SendMessageJobTest {
 
 	private final SendMessageJob jobDef = new SendMessageJob();
-	private final IbisLocalSender localSenderMock = Mockito.mock(IbisLocalSender.class);
+	private final IbisLocalSender localSenderMock = mock(IbisLocalSender.class);
 
 	@BeforeEach
 	void setup(){

--- a/core/src/test/java/nl/nn/adapterframework/scheduler/job/SendMessageJobTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/scheduler/job/SendMessageJobTest.java
@@ -1,0 +1,58 @@
+package nl.nn.adapterframework.scheduler.job;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import nl.nn.adapterframework.configuration.ConfigurationException;
+import nl.nn.adapterframework.core.SenderException;
+import nl.nn.adapterframework.core.TimeoutException;
+import nl.nn.adapterframework.senders.IbisLocalSender;
+import nl.nn.adapterframework.stream.Message;
+
+class SendMessageJobTest {
+
+	private final SendMessageJob jobDef = new SendMessageJob();
+	private final IbisLocalSender localSenderMock = Mockito.mock(IbisLocalSender.class);
+
+	@BeforeEach
+	void setup(){
+		jobDef.setMessage("messageMock");
+	}
+
+	@Test
+	void testHappyExecuteCall() throws JobExecutionException, TimeoutException, SenderException, IOException {
+		Message messageMock = mock(Message.class);
+		when(localSenderMock.sendMessageOrThrow(any(), any())).thenReturn(messageMock);
+		jobDef.setLocalSender(localSenderMock);
+		jobDef.execute();
+
+		verify(localSenderMock).sendMessageOrThrow(any(), any());
+		verify(localSenderMock).close();
+		verify(messageMock).close();
+	}
+
+	@Test
+	void testFailingSenderStillGetsClosed() throws TimeoutException, SenderException {
+		when(localSenderMock.sendMessageOrThrow(any(), any())).thenThrow(SenderException.class);
+		jobDef.setLocalSender(localSenderMock);
+		assertThrows(JobExecutionException.class, jobDef::execute);
+
+		verify(localSenderMock).close();
+		verify(localSenderMock).sendMessageOrThrow(any(), any());
+	}
+
+	@Test
+	void testConfigureShouldFailWithoutJavaListener() {
+		assertThrows(ConfigurationException.class, jobDef::configure);
+	}
+
+}


### PR DESCRIPTION
Closing multiple objects when possible. Add unit testing, was partly covered by other unit tests already. Mostly the configure method. 