### PR TITLE
Close SenderResult to avoid leaks

### DIFF
--- a/larva/src/main/java/nl/nn/adapterframework/testtool/SenderThread.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/SenderThread.java
@@ -63,6 +63,7 @@ public class SenderThread extends Thread {
 			session.put(PipeLineSession.CORRELATION_ID_KEY, correlationId);
 			SenderResult result = sender.sendMessage(new Message(request), session);
 			response = result.getResult().asString();
+			result.getResult().close();
 		} catch(SenderException e) {
 			if (convertExceptionToMessage) {
 				response = Util.throwableToXml(e);

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/queues/QueueWrapper.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/queues/QueueWrapper.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 
+import lombok.extern.log4j.Log4j2;
 import nl.nn.adapterframework.configuration.ConfigurationException;
 import nl.nn.adapterframework.core.IConfigurable;
 import nl.nn.adapterframework.core.IListener;
@@ -37,6 +38,7 @@ import nl.nn.adapterframework.core.IWithParameters;
 import nl.nn.adapterframework.core.ListenerException;
 import nl.nn.adapterframework.core.PipeLineSession;
 import nl.nn.adapterframework.core.SenderException;
+import nl.nn.adapterframework.core.SenderResult;
 import nl.nn.adapterframework.core.TimeoutException;
 import nl.nn.adapterframework.http.WebServiceListener;
 import nl.nn.adapterframework.parameters.Parameter;
@@ -54,6 +56,7 @@ import nl.nn.adapterframework.testtool.XsltProviderListener;
 import nl.nn.adapterframework.util.DomBuilderException;
 import nl.nn.adapterframework.util.XmlUtils;
 
+@Log4j2
 public class QueueWrapper extends HashMap<String, Object> implements Queue {
 	private static final String CONVERT_MESSAGE_TO_EXCEPTION_KEY = "convertExceptionToMessage";
 	private static final String PIPELINESESSION_KEY = "session";
@@ -303,9 +306,14 @@ public class QueueWrapper extends HashMap<String, Object> implements Queue {
 			fileSender.sendMessage(fileContent);
 			return TestTool.RESULT_OK;
 		}
-		if(get() instanceof DelaySender) {
-			DelaySender delaySender = (DelaySender)get();
-			delaySender.sendMessage(new Message(fileContent), null);
+		if (get() instanceof DelaySender) {
+			DelaySender delaySender = (DelaySender) get();
+			SenderResult senderResult = delaySender.sendMessage(new Message(fileContent), null);
+			try {
+				senderResult.getResult().close();
+			} catch (IOException e) {
+				log.warn("Could not close senderResult for queue {}", get(), e);
+			}
 			return TestTool.RESULT_OK;
 		}
 		if(get() instanceof XsltProviderListener) {


### PR DESCRIPTION
Also close these SenderResult objects. Came out of a search. 
More will follow separately. 