### PR TITLE
Do not close any session keys in sub-adapter that are also in calling adapter

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/core/PipeLineSession.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeLineSession.java
@@ -107,24 +107,23 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 	 * @param keysToCopy Keys to be copied, separated by {@value ,} or {@value ;}.
 	 *                   If {@code null} then all keys will be copied.
 	 *                   If an empty string then no keys will be copied.
-	 * @param from Child {@link PipeLineSession} from which keys are copied.
 	 * @param to Parent {@link PipeLineSession} or {@link Map}.
 	 */
-	public static void mergeToParentSession(String keysToCopy, PipeLineSession from, Map<String,Object> to) {
+	public void mergeToParentSession(String keysToCopy, Map<String, Object> to) {
 		if (to == null) {
 			return;
 		}
 		LOG.debug("returning context, returned session keys [{}]", keysToCopy);
-		copyIfExists(EXIT_CODE_CONTEXT_KEY, from, to);
-		copyIfExists(EXIT_STATE_CONTEXT_KEY, from, to);
+		copyIfExists(EXIT_CODE_CONTEXT_KEY, to);
+		copyIfExists(EXIT_STATE_CONTEXT_KEY, to);
 		if (StringUtils.isNotEmpty(keysToCopy) && !"*".equals(keysToCopy)) {
 			StringTokenizer st = new StringTokenizer(keysToCopy,",;");
 			while (st.hasMoreTokens()) {
 				String key = st.nextToken();
-				to.put(key, from.get(key));
+				to.put(key, get(key));
 			}
 		} else if (keysToCopy == null || "*".equals(keysToCopy)) { // if keys are not set explicitly ...
-			to.putAll(from);                                      // ... all keys will be copied
+			to.putAll(this);                                      // ... all keys will be copied
 		}
 		Set<AutoCloseable> closeablesInDestination = to.values().stream()
 				.filter(v -> v instanceof AutoCloseable)
@@ -134,12 +133,12 @@ public class PipeLineSession extends HashMap<String,Object> implements AutoClose
 			PipeLineSession toSession = (PipeLineSession) to;
 			closeablesInDestination.addAll(toSession.closeables.keySet());
 		}
-		from.closeables.keySet().removeAll(closeablesInDestination);
+		closeables.keySet().removeAll(closeablesInDestination);
 	}
 
-	private static void copyIfExists(String key, Map<String,Object> from, Map<String,Object> to) {
-		if (from.containsKey(key)) {
-			to.put(key, from.get(key));
+	private void copyIfExists(String key, Map<String, Object> to) {
+		if (containsKey(key)) {
+			to.put(key, get(key));
 		}
 	}
 

--- a/core/src/main/java/nl/nn/adapterframework/receivers/JavaListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/JavaListener.java
@@ -178,7 +178,7 @@ public class JavaListener<M> implements IPushingListener<M>, RequestProcessor, H
 					}
 				}
 			} finally {
-				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), session, context, this);
+				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), session, context);
 			}
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/receivers/JavaListener.java
+++ b/core/src/main/java/nl/nn/adapterframework/receivers/JavaListener.java
@@ -178,7 +178,7 @@ public class JavaListener<M> implements IPushingListener<M>, RequestProcessor, H
 					}
 				}
 			} finally {
-				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), session, context);
+				session.mergeToParentSession(getReturnedSessionKeys(), context);
 			}
 		}
 	}

--- a/core/src/main/java/nl/nn/adapterframework/senders/IbisJavaSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/IbisJavaSender.java
@@ -137,7 +137,7 @@ public class IbisJavaSender extends SenderWithParametersBase implements HasPhysi
 				if (log.isDebugEnabled() && StringUtils.isNotEmpty(getReturnedSessionKeys())) {
 					log.debug("returning values of session keys [" + getReturnedSessionKeys() + "]");
 				}
-				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), subAdapterSession, session);
+				subAdapterSession.mergeToParentSession(getReturnedSessionKeys(), session);
 			}
 			ExitState exitState = (ExitState) subAdapterSession.remove(PipeLineSession.EXIT_STATE_CONTEXT_KEY);
 			Object exitCode = subAdapterSession.remove(PipeLineSession.EXIT_CODE_CONTEXT_KEY);

--- a/core/src/main/java/nl/nn/adapterframework/senders/IbisJavaSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/IbisJavaSender.java
@@ -137,7 +137,7 @@ public class IbisJavaSender extends SenderWithParametersBase implements HasPhysi
 				if (log.isDebugEnabled() && StringUtils.isNotEmpty(getReturnedSessionKeys())) {
 					log.debug("returning values of session keys [" + getReturnedSessionKeys() + "]");
 				}
-				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), subAdapterSession, session, this);
+				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), subAdapterSession, session);
 			}
 			ExitState exitState = (ExitState) subAdapterSession.remove(PipeLineSession.EXIT_STATE_CONTEXT_KEY);
 			Object exitCode = subAdapterSession.remove(PipeLineSession.EXIT_CODE_CONTEXT_KEY);

--- a/core/src/main/java/nl/nn/adapterframework/senders/IbisLocalSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/IbisLocalSender.java
@@ -282,7 +282,7 @@ public class IbisLocalSender extends SenderWithParametersBase implements HasPhys
 				if (StringUtils.isNotEmpty(getReturnedSessionKeys())) {
 					log.debug("returning values of session keys [{}]", getReturnedSessionKeys());
 				}
-				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), subAdapterSession, session, this);
+				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), subAdapterSession, session);
 			}
 
 			ExitState exitState = (ExitState)subAdapterSession.remove(PipeLineSession.EXIT_STATE_CONTEXT_KEY);

--- a/core/src/main/java/nl/nn/adapterframework/senders/IbisLocalSender.java
+++ b/core/src/main/java/nl/nn/adapterframework/senders/IbisLocalSender.java
@@ -282,7 +282,7 @@ public class IbisLocalSender extends SenderWithParametersBase implements HasPhys
 				if (StringUtils.isNotEmpty(getReturnedSessionKeys())) {
 					log.debug("returning values of session keys [{}]", getReturnedSessionKeys());
 				}
-				PipeLineSession.mergeToParentSession(getReturnedSessionKeys(), subAdapterSession, session);
+				subAdapterSession.mergeToParentSession(getReturnedSessionKeys(), session);
 			}
 
 			ExitState exitState = (ExitState)subAdapterSession.remove(PipeLineSession.EXIT_STATE_CONTEXT_KEY);

--- a/core/src/test/java/nl/nn/adapterframework/core/PipeLineSessionTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/core/PipeLineSessionTest.java
@@ -296,7 +296,10 @@ public class PipeLineSessionTest {
 		from.put(PipeLineSession.EXIT_CODE_CONTEXT_KEY, "exitCode");
 		from.put(PipeLineSession.EXIT_STATE_CONTEXT_KEY, "exitState");
 
+		// Same key different objects; same object different keys.
+		// Afterwards message1 should be closed and message2 should not be.
 		from.put("d", message1);
+		from.put("e", message2);
 		to.put("d", message2);
 
 		from.scheduleCloseOnSessionExit(message1, "test-d");

--- a/core/src/test/java/nl/nn/adapterframework/core/PipeLineSessionTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/core/PipeLineSessionTest.java
@@ -273,7 +273,7 @@ public class PipeLineSessionTest {
 		from.put("b", 16);
 
 		// Act
-		PipeLineSession.mergeToParentSession(keys, from, to, null);
+		PipeLineSession.mergeToParentSession(keys, from, to);
 
 		// Assert
 		assertEquals(from,to);
@@ -293,7 +293,7 @@ public class PipeLineSessionTest {
 		to.put("c", message1);
 
 		// Act
-		PipeLineSession.mergeToParentSession(keys, from, to, null);
+		PipeLineSession.mergeToParentSession(keys, from, to);
 
 		// Assert
 		assertEquals(from,to);
@@ -316,7 +316,7 @@ public class PipeLineSessionTest {
 		from.scheduleCloseOnSessionExit(closeable, "test-d");
 
 		// Act
-		PipeLineSession.mergeToParentSession(keysToCopy, from, to, null);
+		PipeLineSession.mergeToParentSession(keysToCopy, from, to);
 
 		from.close();
 
@@ -360,7 +360,7 @@ public class PipeLineSessionTest {
 		from.scheduleCloseOnSessionExit(message1, "test-d");
 
 		// Act
-		PipeLineSession.mergeToParentSession(keys, from, to, null);
+		PipeLineSession.mergeToParentSession(keys, from, to);
 
 		from.close();
 
@@ -383,7 +383,7 @@ public class PipeLineSessionTest {
 		PipeLineSession to = new PipeLineSession();
 		from.put("a", 15);
 		from.put("b", 16);
-		PipeLineSession.mergeToParentSession("", from, to, null);
+		PipeLineSession.mergeToParentSession("", from, to);
 		assertEquals(0,to.size());
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/core/PipeLineSessionTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/core/PipeLineSessionTest.java
@@ -273,7 +273,7 @@ public class PipeLineSessionTest {
 		from.put("b", 16);
 
 		// Act
-		PipeLineSession.mergeToParentSession(keys, from, to);
+		from.mergeToParentSession(keys, to);
 
 		// Assert
 		assertEquals(from,to);
@@ -293,7 +293,7 @@ public class PipeLineSessionTest {
 		to.put("c", message1);
 
 		// Act
-		PipeLineSession.mergeToParentSession(keys, from, to);
+		from.mergeToParentSession(keys, to);
 
 		// Assert
 		assertEquals(from,to);
@@ -316,7 +316,7 @@ public class PipeLineSessionTest {
 		from.scheduleCloseOnSessionExit(closeable, "test-d");
 
 		// Act
-		PipeLineSession.mergeToParentSession(keysToCopy, from, to);
+		from.mergeToParentSession(keysToCopy, to);
 
 		from.close();
 
@@ -360,7 +360,7 @@ public class PipeLineSessionTest {
 		from.scheduleCloseOnSessionExit(message1, "test-d");
 
 		// Act
-		PipeLineSession.mergeToParentSession(keys, from, to);
+		from.mergeToParentSession(keys, to);
 
 		from.close();
 
@@ -383,7 +383,7 @@ public class PipeLineSessionTest {
 		PipeLineSession to = new PipeLineSession();
 		from.put("a", 15);
 		from.put("b", 16);
-		PipeLineSession.mergeToParentSession("", from, to);
+		from.mergeToParentSession("", to);
 		assertEquals(0,to.size());
 	}
 }

--- a/core/src/test/java/nl/nn/adapterframework/senders/IbisLocalSenderTest.java
+++ b/core/src/test/java/nl/nn/adapterframework/senders/IbisLocalSenderTest.java
@@ -149,6 +149,7 @@ class IbisLocalSenderTest {
 			session.put("my-parameter1", "parameter1-value");
 			session.put("my-parameter2", Message.asMessage("parameter2-value"));
 			Message message = new Message("my-parameter1");
+			session.put("session-message", message);
 
 			// Act
 			SenderResult result = sender.sendMessage(message, session);
@@ -162,7 +163,8 @@ class IbisLocalSenderTest {
 				() -> assertEquals("parameter2-value", session.getString("my-parameter2")),
 				() -> assertTrue(session.containsKey("this-doesnt-exist"), "After request the pipeline-session should contain key [this-doesnt-exist]"),
 				() -> assertNull(session.get("this-doesnt-exist"), "Key not in return from service should have value [NULL]"),
-				() -> assertFalse(session.containsKey("key-not-configured-for-copy"), "Session should not contain key 'key-not-configured-for-copy'")
+				() -> assertFalse(session.containsKey("key-not-configured-for-copy"), "Session should not contain key 'key-not-configured-for-copy'"),
+				() -> assertEquals("my-parameter1", message.asString())
 			);
 		}
 	}
@@ -349,6 +351,7 @@ class IbisLocalSenderTest {
 	private static IbisLocalSender createIbisLocalSenderWithDummyServiceClient() throws ListenerException, ConfigurationException {
 		ServiceDispatcher.getInstance().registerServiceClient(SERVICE_NAME, ((message, session) -> {
 			session.put("key-not-configured-for-copy", "dummy-value");
+			session.put(PipeLineSession.ORIGINAL_MESSAGE_KEY, message);
 			session.scheduleCloseOnSessionExit(Message.asMessage(session.get("my-parameter1")), "param1");
 			session.scheduleCloseOnSessionExit(Message.asMessage(session.get("my-parameter2")), "param2");
 			return session.getMessage(message.asObject().toString());


### PR DESCRIPTION
* Better fix for the issue of closed session keys after calling a sub-adapter, plus unit-tests that catch and demonstrate the problem.
* More complete fixes for closeables that appear in multiple sessions, and more tests added to catch different situations.