### PR TITLE
Alternate fix for #5377, null result value

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/core/PipeLineResult.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeLineResult.java
@@ -16,7 +16,6 @@
 package nl.nn.adapterframework.core;
 
 import lombok.Getter;
-import lombok.NonNull;
 import lombok.Setter;
 import nl.nn.adapterframework.core.PipeLine.ExitState;
 import nl.nn.adapterframework.stream.Message;
@@ -33,12 +32,19 @@ import nl.nn.adapterframework.stream.Message;
  */
 public class PipeLineResult {
 
-	private @Getter @Setter @NonNull Message result = Message.NULL_MESSAGE;
+	private @Setter Message result;
 	private @Getter @Setter ExitState state;
 	private @Getter @Setter int exitCode;
 
 	public boolean isSuccessful() {
 		return getState()==ExitState.SUCCESS;
+	}
+
+	public Message getResult() {
+		if (result == null) {
+			return Message.nullMessage();
+		}
+		return result;
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/core/PipeLineResult.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeLineResult.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2020, 2022 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2020, 2022-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -16,6 +16,7 @@
 package nl.nn.adapterframework.core;
 
 import lombok.Getter;
+import lombok.NonNull;
 import lombok.Setter;
 import nl.nn.adapterframework.core.PipeLine.ExitState;
 import nl.nn.adapterframework.stream.Message;
@@ -32,7 +33,7 @@ import nl.nn.adapterframework.stream.Message;
  */
 public class PipeLineResult {
 
-	private @Getter @Setter Message result;
+	private @Getter @Setter @NonNull Message result = Message.NULL_MESSAGE;
 	private @Getter @Setter ExitState state;
 	private @Getter @Setter int exitCode;
 

--- a/core/src/main/java/nl/nn/adapterframework/core/PipeRunResult.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeRunResult.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2013 Nationale-Nederlanden, 2020, 2022 WeAreFrank!
+   Copyright 2013 Nationale-Nederlanden, 2020, 2022-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ import nl.nn.adapterframework.stream.Message;
  * </ul><br/>
  * <code>Pipe</code>s return a <code>PipeRunResult</code> with the information
  * as above.
- * 
+ *
  * @author Johan Verrips
  * @see PipeForward
  * @see nl.nn.adapterframework.pipes.AbstractPipe#doPipe
@@ -40,7 +40,7 @@ import nl.nn.adapterframework.stream.Message;
 public class PipeRunResult {
 
 	private @Getter @Setter PipeForward pipeForward;
-	private @Getter Message result;
+	private @Getter Message result = Message.NULL_MESSAGE;
 
 	public PipeRunResult() {
 		super();

--- a/core/src/main/java/nl/nn/adapterframework/core/PipeRunResult.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/PipeRunResult.java
@@ -40,7 +40,7 @@ import nl.nn.adapterframework.stream.Message;
 public class PipeRunResult {
 
 	private @Getter @Setter PipeForward pipeForward;
-	private @Getter Message result = Message.NULL_MESSAGE;
+	private Message result;
 
 	public PipeRunResult() {
 		super();
@@ -53,6 +53,13 @@ public class PipeRunResult {
 
 	public void setResult(Object result) {
 		this.result = Message.asMessage(result);
+	}
+
+	public Message getResult() {
+		if (result == null) {
+			return Message.nullMessage();
+		}
+		return result;
 	}
 
 	@Override

--- a/core/src/main/java/nl/nn/adapterframework/core/SenderResult.java
+++ b/core/src/main/java/nl/nn/adapterframework/core/SenderResult.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
    limitations under the License.
 */
 package nl.nn.adapterframework.core;
+
+import javax.annotation.Nonnull;
 
 import org.apache.commons.lang3.StringUtils;
 
@@ -33,22 +35,21 @@ public class SenderResult {
 	private @Getter @Setter String forwardName;
 
 	public SenderResult(String result) {
-		this(new Message(result));
+		this(Message.asMessage(result));
 	}
 
-	public SenderResult(Message result) {
+	public SenderResult(@Nonnull Message result) {
 		this(true, result, null, null);
 	}
 
-	public SenderResult(Message result, String errorMessage) {
+	public SenderResult(@Nonnull Message result, String errorMessage) {
 		this(StringUtils.isEmpty(errorMessage), result, errorMessage, null);
 	}
 
-	public SenderResult(boolean success, Message result, String errorMessage, String forwardName) {
+	public SenderResult(boolean success, @Nonnull Message result, String errorMessage, String forwardName) {
 		this.success = success;
 		this.forwardName = forwardName;
 		this.result = result;
 		this.errorMessage = errorMessage;
 	}
-
 }

--- a/core/src/main/java/nl/nn/adapterframework/stream/Message.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/Message.java
@@ -74,6 +74,7 @@ import nl.nn.adapterframework.util.StringUtil;
 import nl.nn.adapterframework.util.XmlUtils;
 
 public class Message implements Serializable, Closeable {
+	public static final Message NULL_MESSAGE = nullMessage(new MessageContext());
 	public static final long MESSAGE_SIZE_UNKNOWN = -1L;
 	public static final long MESSAGE_MAX_IN_MEMORY_DEFAULT = 512L * 1024L;
 	private static final String MESSAGE_MAX_IN_MEMORY_PROPERTY = "message.max.memory.size";
@@ -174,7 +175,7 @@ public class Message implements Serializable, Closeable {
 
 	@Nonnull
 	public static Message nullMessage() {
-		return nullMessage(new MessageContext());
+		return NULL_MESSAGE;
 	}
 
 	@Nonnull
@@ -796,6 +797,9 @@ public class Message implements Serializable, Closeable {
 	}
 
 	public static Message asMessage(Object object) {
+		if (object == null) {
+			return NULL_MESSAGE;
+		}
 		if (object instanceof Message) {
 			return (Message) object;
 		}

--- a/core/src/main/java/nl/nn/adapterframework/stream/Message.java
+++ b/core/src/main/java/nl/nn/adapterframework/stream/Message.java
@@ -74,7 +74,6 @@ import nl.nn.adapterframework.util.StringUtil;
 import nl.nn.adapterframework.util.XmlUtils;
 
 public class Message implements Serializable, Closeable {
-	public static final Message NULL_MESSAGE = nullMessage(new MessageContext());
 	public static final long MESSAGE_SIZE_UNKNOWN = -1L;
 	public static final long MESSAGE_MAX_IN_MEMORY_DEFAULT = 512L * 1024L;
 	private static final String MESSAGE_MAX_IN_MEMORY_PROPERTY = "message.max.memory.size";
@@ -175,7 +174,7 @@ public class Message implements Serializable, Closeable {
 
 	@Nonnull
 	public static Message nullMessage() {
-		return NULL_MESSAGE;
+		return nullMessage(new MessageContext());
 	}
 
 	@Nonnull
@@ -798,7 +797,7 @@ public class Message implements Serializable, Closeable {
 
 	public static Message asMessage(Object object) {
 		if (object == null) {
-			return NULL_MESSAGE;
+			return nullMessage();
 		}
 		if (object instanceof Message) {
 			return (Message) object;


### PR DESCRIPTION
Alternate fix that prevents a message in a result from ever having the value NULL.