### PR TITLE
Bump commons-beanutils to 1.9.4 for every module/project

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -968,11 +968,6 @@
 				<artifactId>jdom2</artifactId>
 				<version>2.0.6.1</version>
 			</dependency>
-			<dependency>
-				<groupId>commons-beanutils</groupId>
-				<artifactId>commons-beanutils</artifactId>
-				<version>1.9.4</version>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 </project>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -955,19 +955,4 @@
 		</profile>
 	</profiles>
 
-	<!-- Lock transient dependency versions to fix CVE's -->
-	<dependencyManagement>
-		<dependencies>
-			<dependency>
-				<groupId>net.minidev</groupId>
-				<artifactId>json-smart</artifactId>
-				<version>2.5.0</version>
-			</dependency>
-			<dependency>
-				<groupId>org.jdom</groupId>
-				<artifactId>jdom2</artifactId>
-				<version>2.0.6.1</version>
-			</dependency>
-		</dependencies>
-	</dependencyManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -241,6 +241,11 @@
 				<artifactId>jakarta.activation</artifactId>
 				<version>2.0.1</version>
 			</dependency>
+			<dependency>
+				<groupId>commons-beanutils</groupId>
+				<artifactId>commons-beanutils</artifactId>
+				<version>1.9.4</version>
+			</dependency>
 
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -241,11 +241,24 @@
 				<artifactId>jakarta.activation</artifactId>
 				<version>2.0.1</version>
 			</dependency>
+
+			<!-- Lock transient dependency versions to fix CVE's -->
 			<dependency>
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
 				<version>1.9.4</version>
 			</dependency>
+			<dependency>
+				<groupId>net.minidev</groupId>
+				<artifactId>json-smart</artifactId>
+				<version>2.5.0</version>
+			</dependency>
+			<dependency>
+				<groupId>org.jdom</groupId>
+				<artifactId>jdom2</artifactId>
+				<version>2.0.6.1</version>
+			</dependency>
+			<!-- End Lock transient deps -->
 
 			<dependency>
 				<groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Only the core bumped beanutils, while other modules where using old vulnerable versions still. 