### PR TITLE
Fix for loop when using schemaLocation in Ladybug ResourceProvider

### DIFF
--- a/ladybug/src/main/java/nl/nn/ibistesttool/PipeDescriptionProvider.java
+++ b/ladybug/src/main/java/nl/nn/ibistesttool/PipeDescriptionProvider.java
@@ -188,7 +188,8 @@ public class PipeDescriptionProvider {
 		}
 	}
 
-	private void addResourceNamesToPipeDescription(Node element, PipeDescription pipeDescription) {
+	//Protected for tests
+	protected void addResourceNamesToPipeDescription(Node element, PipeDescription pipeDescription) {
 		NamedNodeMap attributes = element.getAttributes();
 		for (int i = 0, size = attributes.getLength(); i < size; i++) {
 			Attr attribute = (Attr) attributes.item(i);
@@ -197,11 +198,15 @@ public class PipeDescriptionProvider {
 					|| "schema".equals(attribute.getName())
 					|| "wsdl".equals(attribute.getName())
 					|| "fileName".equals(attribute.getName())
+					|| "filename".equals(attribute.getName())
 					|| "schemaLocation".equals(attribute.getName())) {
 				if ("schemaLocation".equals(attribute.getName())) {
-					StringUtil.splitToStream(attribute.getValue(), ", \t\r\n\f")
-							.filter(pipeDescription::doesNotContainResourceName)
-							.forEach(pipeDescription::addResourceName);
+					int index = 0;
+					for(String resourceName : StringUtil.split(attribute.getValue(), ", \t\r\n\f")) {
+						if(index++ % 2 == 1 && pipeDescription.doesNotContainResourceName(resourceName)) {
+							pipeDescription.addResourceName(resourceName);
+						}
+					}
 				} else {
 					String resourceName = attribute.getValue();
 					if (pipeDescription.doesNotContainResourceName(resourceName)) {

--- a/ladybug/src/test/java/nl/nn/ibistesttool/TestPipeDescriptionProvider.java
+++ b/ladybug/src/test/java/nl/nn/ibistesttool/TestPipeDescriptionProvider.java
@@ -1,0 +1,70 @@
+package nl.nn.ibistesttool;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URL;
+import java.util.List;
+
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Node;
+
+import nl.nn.adapterframework.stream.Message;
+
+public class TestPipeDescriptionProvider {
+
+	@Test
+	public void testSchemaLocation() throws Exception {
+		PipeDescriptionProvider provider = new PipeDescriptionProvider();
+		PipeDescription description = new PipeDescription();
+
+		URL url = TestPipeDescriptionProvider.class.getResource("/testSchemaLocation.xml");
+		Message input = Message.asMessage(url);
+		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+		Node root = db.parse(input.asInputSource());
+		provider.addResourceNamesToPipeDescription(root.getFirstChild(), description);
+
+		List<String> resourceNames = description.getResourceNames();
+		assertEquals(1, resourceNames.size());
+		assertTrue(resourceNames.contains("HelloLines/xsd/Lines.xsd"));
+	}
+
+	@Test
+	public void testWithTwoSchemaLocations() throws Exception {
+		PipeDescriptionProvider provider = new PipeDescriptionProvider();
+		PipeDescription description = new PipeDescription();
+
+		URL url = TestPipeDescriptionProvider.class.getResource("/testWithTwoSchemaLocations.xml");
+		Message input = Message.asMessage(url);
+		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+		Node root = db.parse(input.asInputSource());
+		provider.addResourceNamesToPipeDescription(root.getFirstChild(), description);
+
+		List<String> resourceNames = description.getResourceNames();
+		assertEquals(2, resourceNames.size());
+		assertTrue(resourceNames.contains("HelloLines/xsd/Lines.xsd"));
+		assertTrue(resourceNames.contains("HelloLines/xsd/Lines2.xsd"));
+	}
+
+	@Test
+	public void testFilename() throws Exception {
+		PipeDescriptionProvider provider = new PipeDescriptionProvider();
+		PipeDescription description = new PipeDescription();
+
+		URL url = TestPipeDescriptionProvider.class.getResource("/testFilename.xml");
+		Message input = Message.asMessage(url);
+		DocumentBuilder db = DocumentBuilderFactory.newInstance().newDocumentBuilder();
+
+		Node root = db.parse(input.asInputSource());
+		provider.addResourceNamesToPipeDescription(root.getFirstChild(), description);
+
+		List<String> resourceNames = description.getResourceNames();
+		assertEquals(1, resourceNames.size());
+		assertTrue(resourceNames.contains("HelloLines/xsd/Lines.xsd"));
+	}
+}

--- a/ladybug/src/test/resources/log4j4ibis.xml
+++ b/ladybug/src/test/resources/log4j4ibis.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<log4j2:Configuration xmlns:log4j2="log4j-config.xsd" name="${ctx:instance.name}-test">
+	<Appenders>
+		<Console name="stdout">
+			<PatternLayout pattern="%d{HH:mm:ss,SSS} %-5p %C{1}.%M():%L%x %m%n"/>
+		</Console>
+	</Appenders>
+
+	<Loggers>
+		<Logger name="nl.nn" level="DEBUG" />
+
+		<Root level="INFO">
+			<AppenderRef ref="stdout"/>
+		</Root>
+	</Loggers>
+</log4j2:Configuration>

--- a/ladybug/src/test/resources/testFilename.xml
+++ b/ladybug/src/test/resources/testFilename.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<LocalFileSystemPipe
+	name="ValidateInput"
+	filename="HelloLines/xsd/Lines.xsd"
+	>
+	<Forward name="failure" path="Create example plain text message"/>
+	<Forward name="parserError" path="Transform plain text message to XML"/>
+</LocalFileSystemPipe>

--- a/ladybug/src/test/resources/testSchemaLocation.xml
+++ b/ladybug/src/test/resources/testSchemaLocation.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SoapInputValidator
+	name="ValidateInput"
+	schemaLocation="urn:hello-lines HelloLines/xsd/Lines.xsd"
+	addNamespaceToSchema="true"
+	soapBody="lines"
+	allowPlainXml="true"
+	acceptNamespacelessXml="true"
+	rootElementSessionKey="receivedRootElement"
+	reasonSessionKey="validatorMessage"
+	>
+	<Forward name="failure" path="Create example plain text message"/>
+	<Forward name="parserError" path="Transform plain text message to XML"/>
+</SoapInputValidator>

--- a/ladybug/src/test/resources/testWithTwoSchemaLocations.xml
+++ b/ladybug/src/test/resources/testWithTwoSchemaLocations.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<SoapInputValidator
+	name="ValidateInput"
+	schemaLocation="urn:hello-lines HelloLines/xsd/Lines.xsd urn:hello-lines2 HelloLines/xsd/Lines2.xsd"
+	addNamespaceToSchema="true"
+	soapBody="lines"
+	allowPlainXml="true"
+	acceptNamespacelessXml="true"
+	rootElementSessionKey="receivedRootElement"
+	reasonSessionKey="validatorMessage"
+	>
+	<Forward name="failure" path="Create example plain text message"/>
+	<Forward name="parserError" path="Transform plain text message to XML"/>
+</SoapInputValidator>


### PR DESCRIPTION
Since https://github.com/ibissource/iaf/pull/5095 we no longer skip all even entries.