### PR TITLE
Put Lombok dependency in the provided scope

### DIFF
--- a/akamai/pom.xml
+++ b/akamai/pom.xml
@@ -18,6 +18,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/aspose/pom.xml
+++ b/aspose/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Explicit dependency to mitigate CVE-2022-3171 -->

--- a/aws/pom.xml
+++ b/aws/pom.xml
@@ -18,6 +18,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>com.amazonaws</groupId>

--- a/cmis/pom.xml
+++ b/cmis/pom.xml
@@ -22,6 +22,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/console/backend/pom.xml
+++ b/console/backend/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/console/frontend/pom.xml
+++ b/console/frontend/pom.xml
@@ -18,6 +18,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>

--- a/console/war/pom.xml
+++ b/console/war/pom.xml
@@ -43,6 +43,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -572,6 +572,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- JavaScript -->

--- a/iaf-commons/pom.xml
+++ b/iaf-commons/pom.xml
@@ -23,6 +23,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/ifsa/pom.xml
+++ b/ifsa/pom.xml
@@ -67,6 +67,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/ladybug/pom.xml
+++ b/ladybug/pom.xml
@@ -22,6 +22,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.ibissource</groupId>

--- a/larva/pom.xml
+++ b/larva/pom.xml
@@ -18,6 +18,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.geronimo.specs</groupId>

--- a/management-gateway/pom.xml
+++ b/management-gateway/pom.xml
@@ -14,6 +14,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.ibissource</groupId>

--- a/sap/pom.xml
+++ b/sap/pom.xml
@@ -30,6 +30,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 

--- a/security/pom.xml
+++ b/security/pom.xml
@@ -62,6 +62,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<!-- Test scoped and provided dependencies -->

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -42,6 +42,7 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
Lombok dependency should be in the 'provided' maven scope, instead of 'compile', which is the default. 

Arguments can be found here:
https://projectlombok.org/setup/maven
https://stackoverflow.com/questions/29385921/maven-scope-for-lombok-compile-vs-provided
https://blogs.oracle.com/developers/post/mastering-maven-dependency-basics