### PR TITLE
Reduce and improve security logging

### DIFF
--- a/console/backend/src/main/java/nl/nn/adapterframework/management/web/ServletDispatcher.java
+++ b/console/backend/src/main/java/nl/nn/adapterframework/management/web/ServletDispatcher.java
@@ -83,7 +83,7 @@ public class ServletDispatcher extends CXFServlet implements DynamicRegistration
 		 */
 		final String method = request.getMethod();
 		if(!method.equalsIgnoreCase("GET") && !method.equalsIgnoreCase("OPTIONS")) {
-			secLog.info(HttpUtils.getExtendedCommandIssuedBy(request));
+			secLog.debug("received http request from URI [{}:{}] issued by [{}]", method, request.getRequestURI(), HttpUtils.getCommandIssuedBy(request));
 		}
 
 		//TODO add X-Rate-Limit to prevent possible clients to flood the IAF API

--- a/console/backend/src/main/java/nl/nn/adapterframework/management/web/ShowConfiguration.java
+++ b/console/backend/src/main/java/nl/nn/adapterframework/management/web/ShowConfiguration.java
@@ -16,7 +16,7 @@
 package nl.nn.adapterframework.management.web;
 
 import java.io.InputStream;
-import java.util.LinkedHashMap;
+import java.util.Map;
 
 import javax.annotation.security.PermitAll;
 import javax.annotation.security.RolesAllowed;
@@ -72,7 +72,7 @@ public final class ShowConfiguration extends FrankApiBase {
 	@Path("/configurations")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response fullReload(LinkedHashMap<String, Object> json) throws ApiException {
+	public Response fullReload(Map<String, Object> json) throws ApiException {
 		Object value = json.get("action");
 		if(value instanceof String && "reload".equals(value)) {
 			RequestMessageBuilder builder = RequestMessageBuilder.create(this, BusTopic.IBISACTION);
@@ -119,7 +119,7 @@ public final class ShowConfiguration extends FrankApiBase {
 	@Path("/configurations/{configuration}")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response reloadConfiguration(@PathParam("configuration") String configurationName, LinkedHashMap<String, Object> json) throws ApiException {
+	public Response reloadConfiguration(@PathParam("configuration") String configurationName, Map<String, Object> json) throws ApiException {
 		Object value = json.get("action");
 		if(value instanceof String && "reload".equals(value)) {
 			RequestMessageBuilder builder = RequestMessageBuilder.create(this, BusTopic.IBISACTION);
@@ -148,14 +148,24 @@ public final class ShowConfiguration extends FrankApiBase {
 	@Path("/configurations/{configuration}/versions/{version}")
 	@Consumes(MediaType.APPLICATION_JSON)
 	@Produces(MediaType.APPLICATION_JSON)
-	public Response manageConfiguration(@PathParam("configuration") String configurationName, @PathParam("version") String encodedVersion, @QueryParam("datasourceName") String datasourceName, LinkedHashMap<String, Object> json) throws ApiException {
+	public Response manageConfiguration(@PathParam("configuration") String configurationName, @PathParam("version") String encodedVersion, @QueryParam("datasourceName") String datasourceName, Map<String, Object> json) throws ApiException {
 		RequestMessageBuilder builder = RequestMessageBuilder.create(this, BusTopic.CONFIGURATION, BusAction.MANAGE);
 		builder.addHeader("configuration", configurationName);
 		builder.addHeader("version", HttpUtils.urlDecode(encodedVersion));
 		if(json.containsKey("activate")) {
-			builder.addHeader("activate", json.get("activate"));
+			Object obj = json.get("activate");
+			if(obj instanceof Boolean) {
+				builder.addHeader("activate", (Boolean) json.get("activate"));
+			} else {
+				throw new ApiException("activate must be of type boolean");
+			}
 		} else if(json.containsKey("autoreload")) {
-			builder.addHeader("autoreload", json.get("autoreload"));
+			Object obj = json.get("autoreload");
+			if(obj instanceof Boolean) {
+				builder.addHeader("autoreload", (Boolean) json.get("autoreload"));
+			} else {
+				throw new ApiException("autoreload must be of type boolean");
+			}
 		}
 		builder.addHeader(BusMessageUtils.HEADER_DATASOURCE_NAME_KEY, datasourceName);
 		return callSyncGateway(builder);

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -165,7 +165,6 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-text</artifactId>
-			<version>1.10.0</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>

--- a/core/src/main/resources/log4j4ibis.properties
+++ b/core/src/main/resources/log4j4ibis.properties
@@ -26,3 +26,6 @@ log.lengthLogRecords=-1
 
 # list of packages to be suppressed in stacktraces
 log.stacktrace.filters=nl.nn.adapterframework.processors,nl.nn.ibistesttool,org.springframework.aop,org.springframework.cglib.proxy,sun.reflect,java.lang.reflect,org.springframework.integration.handler,org.springframework.security.web
+
+# security loglevel
+security.log.level=INFO

--- a/core/src/main/resources/log4j4ibis.xml
+++ b/core/src/main/resources/log4j4ibis.xml
@@ -116,7 +116,7 @@
 			<AppenderRef ref="msg-text"/>
 			<AppenderRef ref="msg-json"/>
 		</Logger>
-		<Logger name="SEC" additivity="false" level="INFO">
+		<Logger name="SEC" additivity="false" level="${ctx:security.log.level}">
 			<AppenderRef ref="security"/>
 		</Logger>
 		<Logger name="HEARTBEAT" additivity="false" level="INFO">

--- a/iaf-commons/src/main/java/nl/nn/adapterframework/util/HttpUtils.java
+++ b/iaf-commons/src/main/java/nl/nn/adapterframework/util/HttpUtils.java
@@ -23,16 +23,16 @@ import java.util.List;
 import javax.servlet.http.HttpServletRequest;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * Some utilities for working with HTTP.
  * 
  * @author Peter Leeuwenburgh
  */
+@Log4j2
 public class HttpUtils {
-	private static Logger LOG = LogManager.getLogger(HttpUtils.class);
 
 	public static String getCommandIssuedBy(HttpServletRequest request) {
 		String commandIssuedBy = " remoteHost [" + request.getRemoteHost() + "]";
@@ -85,7 +85,7 @@ public class HttpUtils {
 		try {
 			return URLDecoder.decode(input, StreamUtil.DEFAULT_INPUT_STREAM_ENCODING);
 		} catch (UnsupportedEncodingException e) {
-			LOG.warn("unable to decode input using charset ["+StreamUtil.DEFAULT_INPUT_STREAM_ENCODING+"]", e);
+			log.warn("unable to decode input using charset [{}]", StreamUtil.DEFAULT_INPUT_STREAM_ENCODING, e);
 			throw new IllegalArgumentException(e);
 		}
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -451,6 +451,11 @@
 				<version>3.13.0</version>
 			</dependency>
 			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>1.10.0</version>
+			</dependency>
+			<dependency>
 				<groupId>commons-codec</groupId>
 				<artifactId>commons-codec</artifactId>
 				<version>1.16.0</version>


### PR DESCRIPTION
Results in the following log line:
`
2023-09-29 12:00:21,728 [http-nio-80-exec-2] created bus request from URI [PUT:http://localhost/iaf-test/iaf/api/server/logging] issued by remoteHost [0:0:0:0:0:0:0:1] remoteAddress [0:0:0:0:0:0:0:1] remoteUser [Admin] with headers [enableDebugger=true, logLevel=WARN, maxMessageLength=-1, logIntermediaryResults=true] payload [NONE]
`