### PR TITLE
Use Maven Central repository first

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1045,6 +1045,14 @@
 
 	<repositories>
 		<repository>
+			<id>central</id>
+			<name>Central Repository</name>
+			<url>https://repo.maven.apache.org/maven2/</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</repository>
+		<repository>
 			<id>ibissource</id>
 			<url>https://nexus.frankframework.org/content/groups/public</url>
 		</repository>
@@ -1176,6 +1184,14 @@
 				<module>idin</module>
 			</modules>
 			<repositories>
+				<repository>
+					<id>central</id>
+					<name>Central Repository</name>
+					<url>https://repo.maven.apache.org/maven2/</url>
+					<snapshots>
+						<enabled>false</enabled>
+					</snapshots>
+				</repository>
 				<repository>
 					<id>proprietary</id>
 					<url>https://nexus.frankframework.org/content/repositories/private/</url>


### PR DESCRIPTION
Use Maven Central repository first instead of downloading everything from Frank's Nexus first.

Came to see this while upgrading deps for Java 11.