### PR TITLE
add unregister for all rootscope $on handlers

### DIFF
--- a/console/frontend/src/main/frontend/js/app/app.config.js
+++ b/console/frontend/src/main/frontend/js/app/app.config.js
@@ -362,7 +362,7 @@ appModule.config(['$httpProvider', function ($httpProvider) {
 					breadcrumbs: 'Monitors'
 				},
 				params: {
-					configuration: { value: null, squash: true },
+					configuration: { value: "", squash: true },
 				},
 			})
 			.state('pages.monitors_editTrigger', {

--- a/console/frontend/src/main/frontend/js/app/views/adapterstatistics/adapterstatistics.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/adapterstatistics/adapterstatistics.component.js
@@ -55,13 +55,17 @@ const adapterstatisticsController = function ($rootScope, Api, $stateParams, Swe
 			ctrl.populateBoundaries(); //AppConstants already loaded
         }
         else {
-			$rootScope.$on('appConstants', ctrl.populateBoundaries); //Wait for appConstants trigger to load
+			ctrl.unregister$on = $rootScope.$on('appConstants', ctrl.populateBoundaries); //Wait for appConstants trigger to load
         }
 
         $timeout(function () {
             ctrl.refresh();
         }, 1000);
     };
+
+	ctrl.$onDestroy = function(){
+		if(ctrl.unregister$on) ctrl.unregister$on();
+	}
 
     ctrl.refresh = function () {
         ctrl.refreshing = true;

--- a/console/frontend/src/main/frontend/js/app/views/configurations/configurations-manage/configurations-manage.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/configurations/configurations-manage/configurations-manage.component.js
@@ -6,11 +6,15 @@ const ConfigurationsManagaController = function ($rootScope, Api, appService) {
 
 	ctrl.$onInit = function () {
 		ctrl.configurations = appService.configurations;
-		$rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
+		ctrl.unregister$on = $rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
 		Api.Get("server/configurations", function (data) {
 			appService.updateConfigurations(data);
 		});
 	};
+
+	ctrl.$onDestroy = function(){
+		ctrl.unregister$on();
+	}
 };
 
 appModule.component('configurationsManage', {

--- a/console/frontend/src/main/frontend/js/app/views/configurations/configurations-show/configurations-show.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/configurations/configurations-show/configurations-show.component.js
@@ -9,9 +9,13 @@ const ConfigurationsShowController = function ($scope, Api, $state, $location, $
 
 	ctrl.$onInit = function () {
 		ctrl.configurations = appService.configurations;
-		$rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
+		ctrl.unregister$on = $rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
 		ctrl.getConfiguration();
 	};
+
+	ctrl.$onDestroy = function(){
+		ctrl.unregister$on();
+	}
 
 	ctrl.update = function () {
 		ctrl.getConfiguration();

--- a/console/frontend/src/main/frontend/js/app/views/configurations/configurations-upload/configurations-upload.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/configurations/configurations-upload/configurations-upload.component.js
@@ -5,16 +5,6 @@ const ConfigurationsUploadController = function ($scope, Api, appConstants, $roo
 
 	ctrl.datasources = {};
 	ctrl.form = {};
-
-	$rootScope.$on('appConstants', function () {
-		ctrl.form.datasource = appConstants['jdbc.datasource.default'];
-	});
-
-	Api.Get("jdbc", function (data) {
-		$.extend(ctrl, data);
-		ctrl.form.datasource = (appConstants['jdbc.datasource.default'] != undefined) ? appConstants['jdbc.datasource.default'] : data.datasources[0];
-	});
-
 	ctrl.form = {
 		datasource: "",
 		encoding: "",
@@ -22,8 +12,22 @@ const ConfigurationsUploadController = function ($scope, Api, appConstants, $roo
 		activate_config: true,
 		automatic_reload: false,
 	};
-
 	ctrl.file = null;
+
+	ctrl.$onInit = function () {
+		ctrl.unregister$on = $rootScope.$on('appConstants', function () {
+			ctrl.form.datasource = appConstants['jdbc.datasource.default'];
+		});
+
+		Api.Get("jdbc", function (data) {
+			$.extend(ctrl, data);
+			ctrl.form.datasource = (appConstants['jdbc.datasource.default'] != undefined) ? appConstants['jdbc.datasource.default'] : data.datasources[0];
+		});
+	}
+
+	ctrl.$onDestroy = function () {
+		ctrl.unregister$on();
+	}
 
 	ctrl.updateFile = function (file) {
 		ctrl.file = file;

--- a/console/frontend/src/main/frontend/js/app/views/environment-variables/environment-variables.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/environment-variables/environment-variables.component.js
@@ -24,7 +24,7 @@ const EnvironmentVariablesController = function ($scope, Api, appConstants, $roo
 		}
 
         ctrl.configurations = appService.configurations;
-        $rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
+        ctrl.unregister$on = $rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
 
         Api.Get("environmentvariables", function (data) {
             var instanceName = null;
@@ -39,6 +39,10 @@ const EnvironmentVariablesController = function ($scope, Api, appConstants, $roo
             ctrl.systemProperties = convertPropertiesToArray(data["System Properties"]);
         });
     };
+
+	ctrl.$onDestroy = function(){
+		ctrl.unregister$on();
+	}
 
     ctrl.changeConfiguration = function (name) {
         ctrl.selectedConfiguration = name;

--- a/console/frontend/src/main/frontend/js/app/views/ibisstore-summary/ibisstore-summary.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/ibisstore-summary/ibisstore-summary.component.js
@@ -7,7 +7,7 @@ const ibisStoreSummaryController = function ($rootScope, Api, $location, appCons
     ctrl.form = {};
 
     ctrl.$onInit = function () {
-		$rootScope.$on('appConstants', function () {
+		ctrl.unregister$on = $rootScope.$on('appConstants', function () {
             ctrl.form.datasource = appConstants['jdbc.datasource.default'];
         });
 
@@ -21,6 +21,10 @@ const ibisStoreSummaryController = function ($rootScope, Api, $location, appCons
 			ctrl.fetch(datasource);
         };
     };
+
+	ctrl.$onDestroy = function(){
+		ctrl.unregister$on();
+	}
 
 	ctrl.fetch = function(datasource) {
         Api.Post("jdbc/summary", JSON.stringify({ datasource: datasource }), function (data) {

--- a/console/frontend/src/main/frontend/js/app/views/inlinestore/inlinestore.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/inlinestore/inlinestore.component.js
@@ -1,6 +1,6 @@
 import { appModule } from "../../app.module";
 
-const InlineStoreController = function (Api) {
+const InlineStoreController = function (Api, appService) {
     const ctrl = this;
 
 	ctrl.$onInit = function () {
@@ -15,6 +15,6 @@ const InlineStoreController = function (Api) {
 };
 
 appModule.component('inlineStore', {
-    controller: ['Api', InlineStoreController],
+    controller: ['Api', 'appService', InlineStoreController],
     templateUrl: 'js/app/views/inlinestore/inlinestore.component.html'
 });

--- a/console/frontend/src/main/frontend/js/app/views/liquibase/liquibase.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/liquibase/liquibase.component.js
@@ -21,9 +21,13 @@ const LiquibaseController = function ($rootScope, Api, Misc, appService) {
             };
         };
 
-		$rootScope.$on('configurations', findFirstAvailabeConfiguration);
+		ctrl.unregister$on = $rootScope.$on('configurations', findFirstAvailabeConfiguration);
         findFirstAvailabeConfiguration();
     };
+
+	ctrl.$onDestroy = function(){
+		ctrl.unregister$on();
+	}
 
     ctrl.download = function () {
         window.open(Misc.getServerPath() + "iaf/api/jdbc/liquibase/");

--- a/console/frontend/src/main/frontend/js/app/views/monitors/monitors.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/monitors/monitors.component.js
@@ -11,18 +11,22 @@ const MonitorsController = function (Api, $state, Misc, $rootScope, appService) 
 
 	ctrl.$onInit = function () {
 		ctrl.configurations = appService.configurations;
-		$rootScope.$on('configurations', function () {
+		ctrl.unregister$on = $rootScope.$on('configurations', function () {
 			ctrl.configurations = appService.configurations;
 
 			if (ctrl.configurations.length > 0) {
 				ctrl.updateConfigurations();
 			}
 		});
-		
+
 		if (ctrl.configurations.length > 0) {
 			ctrl.updateConfigurations();
 		}
 	};
+
+	ctrl.$onDestroy = function(){
+		ctrl.unregister$on();
+	}
 
 	ctrl.updateConfigurations = function(){
 		var configName = $state.params.configuration; //See if the configuration query param is populated
@@ -32,8 +36,7 @@ const MonitorsController = function (Api, $state, Misc, $rootScope, appService) 
 
 	ctrl.changeConfiguration = function (name) {
 		ctrl.selectedConfiguration = name;
-
-		if ($state.params.configuration == "" || $state.params.configuration != name) { //Update the URL
+		if ($state.current.component === "monitors" && ($state.params.configuration == "" || $state.params.configuration != name)) { //Update the URL
 			$state.transitionTo('pages.monitors', { configuration: name }, { notify: false, reload: false });
 		}
 

--- a/console/frontend/src/main/frontend/js/app/views/scheduler/scheduler-add/scheduler-add.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/scheduler/scheduler-add/scheduler-add.component.js
@@ -17,14 +17,20 @@ const SchedulerAddController = function ($scope, Api, $rootScope, appService) {
         locker: false,
         lockkey: "",
     };
+	ctrl.unregister$on = [];
 
     ctrl.$onInit = function () {
         ctrl.configurations = appService.configurations;
-        $rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
+		ctrl.unregister$on.push($rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; }));
 
         ctrl.adapters = appService.adapters;
-        $rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; });
+		ctrl.unregister$on.push($rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; }));
     };
+
+	ctrl.$onDestroy = function(){
+		for (const unregister of ctrl.unregister$on)
+			unregister();
+	}
 
     ctrl.submit = function () {
         var fd = new FormData();

--- a/console/frontend/src/main/frontend/js/app/views/scheduler/scheduler-edit/scheduler-edit.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/scheduler/scheduler-edit/scheduler-edit.component.js
@@ -19,15 +19,16 @@ const SchedulerEditController = function ($scope, Api, $stateParams, $rootScope,
 		locker: false,
 		lockkey: "",
 	};
+	ctrl.unregister$on = [];
 
     ctrl.$onInit = function () {
         var url = "schedules/" + $stateParams.group + "/jobs/" + $stateParams.name;
 
         ctrl.configurations = appService.configurations;
-        $rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
+		ctrl.unregister$on.push($rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; }));
 
         ctrl.adapters = appService.adapters;
-        $rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; });
+		ctrl.unregister$on($rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; }));
 
         Api.Get(url, function (data) {
             ctrl.selectedConfiguration = data.configuration;
@@ -45,6 +46,11 @@ const SchedulerEditController = function ($scope, Api, $stateParams, $rootScope,
             };
         });
     };
+
+	ctrl.$onDestroy = function(){
+		for (const unregister of ctrl.unregister$on)
+			unregister();
+	}
 
 	ctrl.submit = function (form) {
 		var fd = new FormData();
@@ -65,7 +71,7 @@ const SchedulerEditController = function ($scope, Api, $stateParams, $rootScope,
 		fd.append("message", ctrl.form.message);
 		fd.append("description", ctrl.form.description);
 		fd.append("locker", ctrl.form.locker);
-        
+
 		if (ctrl.form.lockkey)
 			fd.append("lockkey", ctrl.form.lockkey);
 

--- a/console/frontend/src/main/frontend/js/app/views/scheduler/scheduler.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/scheduler/scheduler.component.js
@@ -15,10 +15,14 @@ const SchedulerController = function ($rootScope, $timeout, Api, Poller, $state,
         }, true, 5000);
 
 		ctrl.databaseSchedulesEnabled = appService.databaseSchedulesEnabled;
-		$rootScope.$on('databaseSchedulesEnabled', function (){
+		ctrl.unregister$on = $rootScope.$on('databaseSchedulesEnabled', function (){
 			ctrl.databaseSchedulesEnabled = appService.databaseSchedulesEnabled;
 		});
     };
+
+	ctrl.$onDestroy = function(){
+		ctrl.unregister$on();
+	}
 
     ctrl.$onDestroy = function () {
         Poller.remove("schedules");

--- a/console/frontend/src/main/frontend/js/app/views/security-items/security-items.component.html
+++ b/console/frontend/src/main/frontend/js/app/views/security-items/security-items.component.html
@@ -51,7 +51,7 @@
 						</table>
 					</div>
 				</div>
-				<div class="col-md-5 m-t-md table-responsive" ng-if="authEntries.length > 0">
+				<div class="col-md-5 m-t-md table-responsive" ng-if="$ctrl.authEntries.length > 0">
 					<div class="ibox-title">
 						<h4>Used Authentication Entries</h4>
 					</div>

--- a/console/frontend/src/main/frontend/js/app/views/status/status.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/status/status.component.js
@@ -21,6 +21,7 @@ const StatusController = function ($scope, $rootScope, Api, Poller, $filter, $st
 
 	ctrl.isConfigStubbed = {};
 	ctrl.isConfigReloading = {};
+	ctrl.unregister$on = [];
 
 	ctrl.$onInit = function () {
 		var hash = $location.hash();
@@ -52,15 +53,15 @@ const StatusController = function ($scope, $rootScope, Api, Poller, $filter, $st
 		ctrl.alerts = appService.alerts;
 		ctrl.messageLog = appService.messageLog;
 		ctrl.adapters = appService.adapters;
-		$rootScope.$on('configurations', ctrl.check4StubbedConfigs);
-		$rootScope.$on('summaries', function () {
+		ctrl.unregister$on.push($rootScope.$on('configurations', ctrl.check4StubbedConfigs));
+		ctrl.unregister$on.push($rootScope.$on('summaries', function () {
 			ctrl.adapterSummary = appService.adapterSummary;
 			ctrl.receiverSummary = appService.receiverSummary;
 			ctrl.messageSummary = appService.messageSummary;
-		});
-		$rootScope.$on('alerts', function () { ctrl.alerts = appService.alerts; }, true);
-		$rootScope.$on('messageLog', function () { ctrl.messageLog = appService.messageLog; });
-		$rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; });
+		}));
+		ctrl.unregister$on.push($rootScope.$on('alerts', function () { ctrl.alerts = appService.alerts; }, true));
+		ctrl.unregister$on.push($rootScope.$on('messageLog', function () { ctrl.messageLog = appService.messageLog; }));
+		ctrl.unregister$on.push($rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; }));
 
 		ctrl.getProcessStateIcon = appService.getProcessStateIcon;
 		ctrl.getProcessStateIconColor = appService.getProcessStateIconColor;
@@ -68,6 +69,11 @@ const StatusController = function ($scope, $rootScope, Api, Poller, $filter, $st
 		if ($state.params.configuration != "All")
 			ctrl.changeConfiguration($state.params.configuration);
 	};
+
+	ctrl.$onDestroy = function () {
+		for (const unregister of ctrl.unregister$on)
+			unregister();
+	}
 
 	ctrl.showContent = function (adapter) {
 		if (adapter.status == "stopped") {

--- a/console/frontend/src/main/frontend/js/app/views/test-pipeline/test-pipeline.component.js
+++ b/console/frontend/src/main/frontend/js/app/views/test-pipeline/test-pipeline.component.js
@@ -12,15 +12,21 @@ const TestPipelineController = function ($scope, Api, Alert, $rootScope, appServ
     ctrl.sessionKeyIndex = 1;
     ctrl.sessionKeyIndices = [ctrl.sessionKeyIndex];
 
-    ctrl.sessionKeys = [];
+	ctrl.sessionKeys = [];
+	ctrl.unregister$on = [];
 
     ctrl.$onInit = function () {
         ctrl.configurations = appService.configurations;
-        $rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; });
+		ctrl.unregister$on.push($rootScope.$on('configurations', function () { ctrl.configurations = appService.configurations; }));
 
         ctrl.adapters = appService.adapters;
-        $rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; });
+		ctrl.unregister$on.push($rootScope.$on('adapters', function () { ctrl.adapters = appService.adapters; }));
     };
+
+	ctrl.$onDestroy = function(){
+		for (const unregister of ctrl.unregister$on)
+			unregister();
+	}
 
     ctrl.addNote = function (type, message, removeQueue) {
         ctrl.state.push({ type: type, message: message });


### PR DESCRIPTION
Also fixed various small issue found during testing
* inlinestore giving an error because appService wasnt being injected
* added $onInit to configurations-upload, this might not have been an actual issue but stability and consistency is important

Fixes issue found by @nielsm5 where moving from 'monitors' to 'manage configurations' would trigger monitors' rootscope$on which caused the router to transition back to 'monitors' page