### PR TITLE
Make Larva able to retrieve relative resources

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/extensions/test/IbisTester.java
+++ b/core/src/main/java/nl/nn/adapterframework/extensions/test/IbisTester.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2018 Nationale-Nederlanden, 2020 WeAreFrank!
+   Copyright 2018 Nationale-Nederlanden, 2020-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -105,22 +105,25 @@ public class IbisTester {
 			}
 		}
 
+		// This is necessarily because we can't depend on the ladybug module
 		public void runScenarios(ServletContext application,
 				HttpServletRequest request, Writer out, boolean silent)
 				throws IllegalArgumentException, SecurityException,
 				IllegalAccessException, InvocationTargetException,
 				NoSuchMethodException, ClassNotFoundException {
 
-			Class<?>[] args_types = new Class<?>[4];
+			Class<?>[] args_types = new Class<?>[5];
 			args_types[0] = ServletContext.class;
 			args_types[1] = HttpServletRequest.class;
 			args_types[2] = Writer.class;
 			args_types[3] = boolean.class;
-			Object[] args = new Object[4];
+			args_types[4] = String.class;
+			Object[] args = new Object[5];
 			args[0] = application;
 			args[1] = request;
 			args[2] = out;
 			args[3] = silent;
+			args[4] = webAppPath;
 			Class.forName("nl.nn.adapterframework.testtool.TestTool").getMethod("runScenarios", args_types).invoke(null, args);
 		}
 	}

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -44,6 +44,16 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>javax.servlet</groupId>
+			<artifactId>javax.servlet-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.ibissource</groupId>
+			<artifactId>ibis-adapterframework-larva</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/example/src/test/java/nl/nn/adapterframework/extensions/test/TestIbisTester.java
+++ b/example/src/test/java/nl/nn/adapterframework/extensions/test/TestIbisTester.java
@@ -29,5 +29,6 @@ public class TestIbisTester {
 		// Test generic startup time of an ibis with 3 adapters, should take less than 30 seconds.
 		long startupTime = (System.currentTimeMillis() - start);
 		assertTrue(startupTime < 30_000, "Application took ["+startupTime+"ms] to start up, longer than allowed 30s!");
+		ibisTester.testLarva();
 	}
 }

--- a/iaf-commons/src/main/java/nl/nn/adapterframework/util/ClassUtils.java
+++ b/iaf-commons/src/main/java/nl/nn/adapterframework/util/ClassUtils.java
@@ -225,12 +225,12 @@ public abstract class ClassUtils {
 
 	private static Object parseValueToSet(Method m, String value) throws IllegalArgumentException {
 		Class<?> setterArgumentClass = m.getParameters()[0].getType();
-		String fieldName = StringUtil.lcFirst(m.getName().substring(3));
 
 		//Try to parse as primitive
 		try {
 			return convertToType(setterArgumentClass, value);
 		} catch (IllegalArgumentException e) {
+			String fieldName = StringUtil.lcFirst(m.getName().substring(3));
 			throw new IllegalArgumentException("cannot set field ["+fieldName+"]: " + e.getMessage(), e);
 		}
 	}

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/LarvaServlet.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/LarvaServlet.java
@@ -138,7 +138,9 @@ public class LarvaServlet extends HttpServletBase {
 		resp.setContentType("text/html");
 		writer.append(getTemplate("Larva Test Tool"));
 
-		String realPath = getServletContext().getRealPath("/iaf/");
+		String servletPath = req.getServletPath();
+		int i = servletPath.lastIndexOf('/');
+		String realPath = getServletContext().getRealPath(servletPath.substring(0, i+1));
 
 		TestTool.runScenarios(getServletContext(), req, writer, realPath);
 		writer.append("</body></html>");

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/TestTool.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/TestTool.java
@@ -138,11 +138,13 @@ public class TestTool {
 		return IbisApplicationServlet.getIbisContext(application);
 	}
 
+
 	public static void runScenarios(ServletContext application, HttpServletRequest request, Writer out, String realPath) {
 		runScenarios(application, request, out, false, realPath);
 	}
 
-	private static void runScenarios(ServletContext application, HttpServletRequest request, Writer out, boolean silent, String realPath) {
+	// Invoked by the IbisTester class
+	public static void runScenarios(ServletContext application, HttpServletRequest request, Writer out, boolean silent, String realPath) {
 		String paramLogLevel = request.getParameter("loglevel");
 		String paramAutoScroll = request.getParameter("autoscroll");
 		String paramExecute = request.getParameter("execute");

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/XsltProviderListener.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/XsltProviderListener.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2021 WeAreFrank!
+   Copyright 2021 - 2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -42,7 +42,6 @@ public class XsltProviderListener implements IConfigurable, AutoCloseable {
 	private @Getter @Setter String name;
 
 	private String filename;
-	private boolean fromClasspath = false;
 	private int xsltVersion=0; // set to 0 for auto detect.
 	private boolean namespaceAware = true;
 	private TransformerPool transformerPool = null;
@@ -54,13 +53,7 @@ public class XsltProviderListener implements IConfigurable, AutoCloseable {
 			throw new ConfigurationException("Could not find filename property for " + getName());
 		}
 		try {
-			Resource stylesheet;
-
-			if (fromClasspath) {
-				stylesheet = Resource.getResource(filename);
-			} else {
-				stylesheet = Resource.getResource(this, filename);
-			}
+			Resource stylesheet = Resource.getResource(this, filename);
 			if(stylesheet == null) {
 				throw new ConfigurationException("Could not find file ["+filename+"]");
 			}
@@ -90,10 +83,6 @@ public class XsltProviderListener implements IConfigurable, AutoCloseable {
 
 	public void setFilename(String filename) {
 		this.filename = filename;
-	}
-
-	public void setFromClasspath(boolean fromClasspath) {
-		this.fromClasspath = fromClasspath;
 	}
 
 	public void setXsltVersion(int xsltVersion) {

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/queues/QueueCreator.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/queues/QueueCreator.java
@@ -16,7 +16,6 @@
 package nl.nn.adapterframework.testtool.queues;
 
 import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/queues/QueueWrapper.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/queues/QueueWrapper.java
@@ -1,5 +1,5 @@
 /*
-   Copyright 2022 WeAreFrank!
+   Copyright 2022-2023 WeAreFrank!
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -54,6 +54,7 @@ import nl.nn.adapterframework.testtool.SenderThread;
 import nl.nn.adapterframework.testtool.TestTool;
 import nl.nn.adapterframework.testtool.XsltProviderListener;
 import nl.nn.adapterframework.util.DomBuilderException;
+import nl.nn.adapterframework.util.StringUtil;
 import nl.nn.adapterframework.util.XmlUtils;
 
 @Log4j2
@@ -67,7 +68,7 @@ public class QueueWrapper extends HashMap<String, Object> implements Queue {
 	private QueueWrapper(IConfigurable configurable) {
 		super();
 
-		queueKey = QueueUtils.firstCharToLower(configurable.getClass().getSimpleName());
+		queueKey = StringUtil.lcFirst(configurable.getClass().getSimpleName());
 		put(queueKey, configurable);
 
 		if(configurable instanceof IPushingListener) {
@@ -260,8 +261,7 @@ public class QueueWrapper extends HashMap<String, Object> implements Queue {
 		return (IConfigurable) get(queueKey);
 	}
 
-	public static QueueWrapper createQueue(String className, Properties queueProperties, int defaultTimeout, String correlationId) { //TODO use correlationId
-		IConfigurable configurable = QueueUtils.createInstance(className);
+	public static QueueWrapper create(IConfigurable configurable, Properties queueProperties, int defaultTimeout, String correlationId) { //TODO use correlationId
 		QueueUtils.invokeSetters(configurable, queueProperties);
 		return create(configurable).invokeSetters(defaultTimeout, queueProperties);
 	}

--- a/larva/src/main/java/nl/nn/adapterframework/testtool/queues/RelativePathDirectoryClassLoader.java
+++ b/larva/src/main/java/nl/nn/adapterframework/testtool/queues/RelativePathDirectoryClassLoader.java
@@ -1,0 +1,44 @@
+/*
+   Copyright 2023 WeAreFrank!
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+package nl.nn.adapterframework.testtool.queues;
+
+import java.net.URL;
+
+import nl.nn.adapterframework.configuration.classloaders.DirectoryClassLoader;
+
+/**
+ * First searches to the Scenario root directory
+ * Then attempts relative paths (to the scenario root directory)
+ * Then delegates to it's parent
+ */
+public class RelativePathDirectoryClassLoader extends DirectoryClassLoader {
+
+	public RelativePathDirectoryClassLoader() {
+		super(Thread.currentThread().getContextClassLoader());
+	}
+
+	@Override
+	public URL getResource(String name, boolean useParent) {
+		URL url = super.getResource(name, false);
+		if(url == null) {
+			url = getLocalResource(name);
+		}
+		if(url == null && useParent) {
+			url = getParent().getResource(name);
+		}
+		return url;
+	}
+}

--- a/test/src/test/testtool/XsltProviderListener/scenario01.properties
+++ b/test/src/test/testtool/XsltProviderListener/scenario01.properties
@@ -3,7 +3,7 @@ scenario.description = Test the XsltProviderListener from testtool directory
 include = ../global.properties
 
 java.XsltProviderListener.className=nl.nn.adapterframework.testtool.XsltProviderListener
-java.XsltProviderListener.filename=01/name.xsl
+java.XsltProviderListener.filename=../XsltProviderListener/01/name.xsl
 
 step1.java.XsltProviderListener.read = 01/in.xml
 step2.java.XsltProviderListener.write = 01/out.xml

--- a/test/src/test/testtool/XsltProviderListener/scenario02.properties
+++ b/test/src/test/testtool/XsltProviderListener/scenario02.properties
@@ -3,7 +3,7 @@ scenario.description = Test the XsltProviderListener from classpath
 include = ../global.properties
 
 java.XsltProviderListener.className=nl.nn.adapterframework.testtool.XsltProviderListener
-java.XsltProviderListener.fromClasspath=true
+# xslt file is located in the core module
 java.XsltProviderListener.filename=xml/xsl/xml2json.xsl
 
 step1.java.XsltProviderListener.read = 02/in.xml


### PR DESCRIPTION
I broke the behavior in #3759 by using the reflection way of instantiating the XsltProviderListener. Before it used the `filename.absolutepath` property instead of the `filename`.