### PR TITLE
Use unbounded threadpool executor

### DIFF
--- a/core/src/main/resources/SpringApplicationContext.xml
+++ b/core/src/main/resources/SpringApplicationContext.xml
@@ -257,10 +257,11 @@
 
 	<bean
 		name="taskExecutor"
-		class="org.springframework.core.task.SimpleAsyncTaskExecutor"
+		class="org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"
 		scope="singleton"
 	>
-		<property name="ThreadFactory" ref="namedThreadFactory"/>
+		<property name="threadFactory" ref="namedThreadFactory"/>
+		<property name="queueCapacity" value="0"/>
 	</bean>
 
 	<bean


### PR DESCRIPTION
Instead of a simple task executor that creates a new thread for every task, allow recycling threads using the threadpool executor with a configuration that does not limit the number of threads.