### PR TITLE
Lock commons:fileupload and autowire testtool report task

### DIFF
--- a/ladybug/src/main/resources/springIbisTestTool.xml
+++ b/ladybug/src/main/resources/springIbisTestTool.xml
@@ -58,7 +58,7 @@
 	stream can be read after the pipeline has finished (e.g. when Base64Pipe is the last pipe Ladybug would show an
 	empty string while test a pipeline would show the correct result).
 	-->
-	<bean name="closeReportsTask" class="nl.nn.testtool.CloseReportsTask">
+	<bean name="closeReportsTask" class="nl.nn.testtool.CloseReportsTask" autowire="byName">
 		<property name="messageCapturersTime" value="60000"/>
 		<property name="threadsTime" value="-1"/>
 	</bean>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<log4j2.version>2.21.0</log4j2.version>
+		<log4j2.version>2.20.0</log4j2.version><!-- locked version, in newer versions our log configuration no longer works ... -->
 		<cxf.version>3.5.7</cxf.version>
 		<btm.version>3.0.0-mk1</btm.version>
 		<narayana.version>5.12.7.Final</narayana.version>

--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,11 @@
 				<version>1.9.4</version>
 			</dependency>
 			<dependency>
+				<groupId>commons-fileupload</groupId>
+				<artifactId>commons-fileupload</artifactId>
+				<version>1.5</version>
+			</dependency>
+			<dependency>
 				<groupId>net.minidev</groupId>
 				<artifactId>json-smart</artifactId>
 				<version>2.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.target>1.8</maven.compiler.target>
 		<maven.compiler.source>1.8</maven.compiler.source>
-		<log4j2.version>2.20.0</log4j2.version><!-- locked version, in newer versions our log configuration no longer works ... -->
+		<log4j2.version>2.21.1</log4j2.version>
 		<cxf.version>3.5.7</cxf.version>
 		<btm.version>3.0.0-mk1</btm.version>
 		<narayana.version>5.12.7.Final</narayana.version>


### PR DESCRIPTION
See [#1865](https://github.com/apache/logging-log4j2/issues/1865) why we've reverted...