### PR TITLE
Fix zip with empty files added by sub-adapters

### DIFF
--- a/core/src/main/java/nl/nn/adapterframework/collection/Collection.java
+++ b/core/src/main/java/nl/nn/adapterframework/collection/Collection.java
@@ -18,10 +18,9 @@ package nl.nn.adapterframework.collection;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.logging.log4j.Logger;
-
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.log4j.Log4j2;
 import nl.nn.adapterframework.core.INamedObject;
 import nl.nn.adapterframework.core.PipeLineSession;
 import nl.nn.adapterframework.parameters.ParameterValueList;
@@ -32,17 +31,17 @@ import nl.nn.adapterframework.util.LogUtil;
 /**
  * Aggregator which handles the collection of {@link ICollector collector parts}.
  * Ensures they are closed if required and 'builds' the collection.
- * 
+ *
  * @author Niels Meijer
  *
  * @param <C> Collector to use, which creates the parts
  * @param <P> Parts to be added to each collection
  */
+@Log4j2
 public class Collection<C extends ICollector<P>, P> implements AutoCloseable, INamedObject {
 	private @Getter @Setter String name;
 	private final List<P> parts;
 	private final C collector;
-	private Logger log = LogUtil.getLogger(this);
 
 	public Collection(C collector) {
 		this.collector = collector;

--- a/core/src/main/java/nl/nn/adapterframework/compression/ZipWriter.java
+++ b/core/src/main/java/nl/nn/adapterframework/compression/ZipWriter.java
@@ -98,6 +98,7 @@ public class ZipWriter implements ICollector<MessageZipEntry> {
 			if (StringUtils.isEmpty(filename) && contents != input) {
 				filename = input.asString();
 			}
+			session.unscheduleCloseOnSessionExit(contents);
 			MessageZipEntry entry = new MessageZipEntry(contents, filename);
 			if (includeFileHeaders) {
 				entry.computeFileHeaders();

--- a/core/src/main/java/nl/nn/adapterframework/pipes/UnzipPipe.java
+++ b/core/src/main/java/nl/nn/adapterframework/pipes/UnzipPipe.java
@@ -131,7 +131,7 @@ public class UnzipPipe extends FixedForwardPipe {
 			}
 		}
 		if (StringUtils.isEmpty(getCollectFileContentsBase64Encoded())) {
-			base64Extensions = new ArrayList<String>();
+			base64Extensions = new ArrayList<>();
 		} else {
 			base64Extensions = Arrays.asList(getCollectFileContentsBase64Encoded().split(","));
 		}

--- a/core/src/main/java/nl/nn/adapterframework/util/StreamCaptureUtils.java
+++ b/core/src/main/java/nl/nn/adapterframework/util/StreamCaptureUtils.java
@@ -202,8 +202,10 @@ public class StreamCaptureUtils {
 						// Make the bytes available for debugger even when the stream was not used (might be because the
 						// pipe or sender that normally consumes the stream is stubbed by the debugger)
 						int len = read(new byte[maxSize]);
-						if (log.isTraceEnabled()) log.trace(len+" bytes available at close");
+						log.trace("{} bytes available at close", len);
 					}
+				} catch (Exception e) {
+					log.debug("Exception checking remaining bytes at close, ignoring: {}", e::getMessage);
 				} finally {
 					super.close();
 				}
@@ -273,12 +275,14 @@ public class StreamCaptureUtils {
 			@Override
 			public void close() throws IOException {
 				try {
-					if (charsRead<maxSize && ready()) {
+					if (charsRead < maxSize && ready()) {
 						// Make the bytes available for debugger even when the stream was not used (might be because the
 						// pipe or sender that normally consumes the stream is stubbed by the debugger)
 						int len = read(new char[maxSize]);
-						if (log.isTraceEnabled()) log.trace(len+" chararacters available at close");
+						log.trace("{} characters available at close", len);
 					}
+				} catch (Exception e) {
+					log.debug("Exception checking remaining characters at close, ignoring: {}", e::getMessage);
 				} finally {
 					super.close();
 				}

--- a/test/src/main/configurations/MainConfig/ConfigurationZip.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationZip.xml
@@ -300,14 +300,18 @@
 				<param name="filename" value="${testdata.dir}/ziperator.zip"/>
 			</pipe>
 
+			<!-- Data for the files in the ZIP to be created. All static in-built so we do not need a FilePipe -->
 			<pipe
 					name="Get File List"
 					className="nl.nn.adapterframework.pipes.FixedResultPipe"
 					returnString="&lt;files&gt;
-									&lt;file&gt;file1.txt&lt;/file&gt;
-									&lt;file&gt;file2.txt&lt;/file&gt;
-									&lt;file&gt;file3.txt&lt;/file&gt;
-								&lt;/files&gt;"
+	&lt;file&gt;&lt;filename&gt;file1.txt&lt;/filename&gt;&lt;contents&gt;File1 Contents
+&lt;/contents&gt;&lt;/file&gt;
+	&lt;file&gt;&lt;filename&gt;file2.txt&lt;/filename&gt;&lt;contents&gt;Contents of File 2
+&lt;/contents&gt;&lt;/file&gt;
+	&lt;file&gt;&lt;filename&gt;file3.txt&lt;/filename&gt;&lt;contents&gt;File The Third, contents thereof
+&lt;/contents&gt;&lt;/file&gt;
+&lt;/files&gt;"
 			/>
 
 			<pipe
@@ -409,6 +413,14 @@
 				<exit path="READY" state="success"/>
 			</exits>
 
+			<pipe name="Extract File Contents From Message Into Session"
+				  className="nl.nn.adapterframework.pipes.EchoPipe"
+				  elementToMove="contents"
+				  elementToMoveSessionKey="fileContents"/>
+			<pipe name="Get File Contents For Zip"
+				  className="nl.nn.adapterframework.pipes.GetFromSession"
+				  sessionKey="fileContents"/>
+
 			<!-- Encode/decode causes the original to be registered for close at end of this sub-adapter, issue 5702 -->
 			<pipe name="Encode" className="nl.nn.adapterframework.pipes.Base64Pipe"
 				  direction="encode"/>
@@ -416,7 +428,7 @@
 				  direction="decode"/>
 
 			<pipe className="nl.nn.adapterframework.compression.ZipWriterPipe" collectionName="zipHandle" name="WriteDataToZipStream">
-				<param name="filename" sessionKey="originalMessage" xpathExpression="file"/>
+				<param name="filename" sessionKey="originalMessage" xpathExpression="file/filename"/>
 				<forward name="success" path="READY"/>
 			</pipe>
 		</pipeline>

--- a/test/src/main/configurations/MainConfig/ConfigurationZip.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationZip.xml
@@ -316,7 +316,7 @@
 					collectResults="false" elementXPathExpression="/files/file"
 					>
 				<sender className="nl.nn.adapterframework.senders.IbisLocalSender"
-						javaListener="ibis4test-zip-iterator-sub">
+						javaListener="ibis4test-zip-iterator-add-files">
 					<param name="zipHandle" sessionKey="zipHandle"/>
 				</sender>
 			</pipe>
@@ -334,10 +334,26 @@
 					name="Create unzip target directory"
 					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
 					action="mkdir"
-					getInputFromFixedValue="${testdata.dir}/unziperator"
+					getInputFromFixedValue="${testdata.dir}/unziperator">
+
+				<forward name="success" path="Create result file"/>
+				<forward name="exception" path="Create result file"/>
+			</pipe>
+			<pipe
+					name="Create result file"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					action="create"
+					filename="${testdata.dir}/result.xml"
 			/>
 			<pipe
-					name="UnZip"
+					name="Write opening tag"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					action="append"
+					filename="${testdata.dir}/result.xml"
+					getInputFromFixedValue="&lt;result&gt;"
+			/>
+			<pipe
+					name="Unzip"
 					className="nl.nn.adapterframework.pipes.UnzipPipe"
 					processFile="true"
 					getInputFromFixedValue="${testdata.dir}/ziperator.zip"
@@ -345,25 +361,47 @@
 					assumeDirectoryExists="true"
 			/>
 			<pipe
-					name="Get Filename first result file"
-					className="nl.nn.adapterframework.pipes.XsltPipe"
-					xpathExpression="/results/result[1]/fileName/text()"
+					name="ForEachFile"
+					className="nl.nn.adapterframework.pipes.ForEachChildElementPipe"
+					collectResults="false" elementXPathExpression="/results/result/fileName"
+			>
+				<sender className="nl.nn.adapterframework.senders.IbisLocalSender"
+						javaListener="ibis4test-zip-iterator-collect-files">
+					<param name="zipHandle" sessionKey="zipHandle"/>
+				</sender>
+			</pipe>
+			<pipe
+					name="Write closing tag"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					action="append"
+					filename="${testdata.dir}/result.xml"
+					getInputFromFixedValue="&lt;/result&gt;"
 			/>
 			<pipe
-					name="readFile"
+					name="Remove unzip target directory"
 					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
-					action="read"
+					action="rmdir"
+					getInputFromFixedValue="${testdata.dir}/unziperator">
+
+				<forward name="success" path="Read Result File"/>
+				<forward name="exception" path="Read Result File"/>
+			</pipe>
+			<pipe
+					name="Read Result File"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					filename="${testdata.dir}/result.xml"
+					action="readDelete"
 			/>
 		</pipeline>
 	</adapter>
 
-	<adapter name="Zip-Iterator-Sub">
+	<adapter name="Zip-Iterator-Sub1-Add-To-Zip">
 		<receiver
-			name="Zip-Iterator-Sub"
+			name="Zip-Iterator-Sub1-Add-To-Zip"
 			>
 			<listener
 				className="nl.nn.adapterframework.receivers.JavaListener"
-				name="ibis4test-zip-iterator-sub"
+				name="ibis4test-zip-iterator-add-files"
 				/>
 		</receiver>
 		<pipeline>
@@ -381,6 +419,35 @@
 				<param name="filename" sessionKey="originalMessage" xpathExpression="file"/>
 				<forward name="success" path="READY"/>
 			</pipe>
+		</pipeline>
+	</adapter>
+
+	<adapter name="Zip-Iterator-Sub2-Collect-Files">
+		<receiver
+			name="Zip-Iterator-Sub2-Collect-Files"
+			>
+			<listener
+				className="nl.nn.adapterframework.receivers.JavaListener"
+				name="ibis4test-zip-iterator-collect-files"
+				/>
+		</receiver>
+		<pipeline>
+			<exits>
+				<exit path="READY" state="success"/>
+			</exits>
+
+			<pipe
+					name="Read File"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					action="read">
+				<param name="filename" xpathExpression="fileName"/>
+			</pipe>
+			<pipe
+					name="Write File"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					action="append"
+					filename="${testdata.dir}/result.xml"
+			/>
 		</pipeline>
 	</adapter>
 </module>

--- a/test/src/main/configurations/MainConfig/ConfigurationZip.xml
+++ b/test/src/main/configurations/MainConfig/ConfigurationZip.xml
@@ -3,7 +3,7 @@
 		<receiver
 			name="Zip - Main"
 			maxRetries="0">
-			<listener 
+			<listener
 				className="nl.nn.adapterframework.receivers.JavaListener"
 				serviceName="ibis4test-unzip"
 			/>
@@ -20,34 +20,34 @@
 
 			<pipe
 				name="UnZip"
-				className="nl.nn.adapterframework.pipes.UnzipPipe" 
+				className="nl.nn.adapterframework.pipes.UnzipPipe"
 				directory="${testdata.dir}/zip"
 				assumeDirectoryExists="true"
 				>
 				<forward name="success" path="READY"/>
 			</pipe>
-			
+
 			<pipe
 				name="NestedZipRead"
 				getInputFromSessionKey="stream"
-				className="nl.nn.adapterframework.compression.ZipIteratorPipe" 
+				className="nl.nn.adapterframework.compression.ZipIteratorPipe"
 				>
 				<sender className="nl.nn.adapterframework.senders.IbisLocalSender" javaListener="ibis4test-unzipNested" >
 					<param name="zipdata" sessionKey="zipdata" />
 				</sender>
 				<forward name="success" path="READY"/>
 			</pipe>
-			
+
 			<pipe
 				name="ReCreateZip"
-				className="nl.nn.adapterframework.pipes.FixedResultPipe" 
+				className="nl.nn.adapterframework.pipes.FixedResultPipe"
 				returnString="${testdata.dir}/zip/recreated.zip"
 				>
 				<forward name="success" path="create a new zip collection with a specified name"/>
 			</pipe>
 			<pipe
 				name="create a new zip collection with a specified name"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="open"
 				backwardsCompatibility="true"
 				>
@@ -57,8 +57,8 @@
 			<pipe
 				name="Iterate over a zip file and add the content to a new zip archive"
 				getInputFromSessionKey="stream"
-				className="nl.nn.adapterframework.compression.ZipIteratorPipe" 
-				
+				className="nl.nn.adapterframework.compression.ZipIteratorPipe"
+
 				>
 				<sender className="nl.nn.adapterframework.senders.IbisLocalSender" javaListener="ibis4test-RecreateZip" >
 					<param name="zipdata" sessionKey="zipdata" />
@@ -68,7 +68,7 @@
 			</pipe>
 			<pipe
 				name="ReCreateZip4"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="close"
 				backwardsCompatibility="true"
 				>
@@ -77,18 +77,18 @@
 
 			<pipe
 				name="SimpleZip"
-				className="nl.nn.adapterframework.pipes.FixedResultPipe" 
+				className="nl.nn.adapterframework.pipes.FixedResultPipe"
 				returnString="${testdata.dir}/zip/simple.zip"
 			/>
 			<pipe
 				name="SimpleZip2"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="open"
 				backwardsCompatibility="true"
 			/>
 			<pipe
 				name="SimpleZip3"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="write"
 				getInputFromSessionKey="originalMessage"
 				>
@@ -96,31 +96,31 @@
 			</pipe>
 			<pipe
 				name="SimpleZip4"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="close"
 			/>
 			<pipe
 				name="klaar"
-				className="nl.nn.adapterframework.pipes.EchoPipe" 
+				className="nl.nn.adapterframework.pipes.EchoPipe"
 				getInputFromFixedValue="klaar"
 				>
 				<forward name="success" path="READY"/>
 			</pipe>
-			
+
 			<pipe
 				name="SimpleZipX"
-				className="nl.nn.adapterframework.pipes.FixedResultPipe" 
+				className="nl.nn.adapterframework.pipes.FixedResultPipe"
 				returnString="${testdata.dir}/zip/simple.zip"
 			/>
 			<pipe
 				name="SimpleZipX2"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="open"
 				backwardsCompatibility="true"
 			/>
 			<pipe
 				name="SimpleZipX3"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="write" completeFileHeader="true"
 				getInputFromSessionKey="originalMessage"
 				>
@@ -128,12 +128,12 @@
 			</pipe>
 			<pipe
 				name="SimpleZipX4"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="close"
 			/>
 			<pipe
 				name="klaarX"
-				className="nl.nn.adapterframework.pipes.EchoPipe" 
+				className="nl.nn.adapterframework.pipes.EchoPipe"
 				getInputFromFixedValue="klaarX"
 				>
 				<forward name="success" path="READY"/>
@@ -162,7 +162,7 @@
 				  </sender>
 				  <forward name="success" path="RemoveZipDirectory"/>
 			</pipe>
-			
+
 			<pipe name="RemoveZipDirectory"
 				  className="nl.nn.adapterframework.pipes.SenderPipe"
 				  preserveInput="true"
@@ -193,16 +193,16 @@
 			<exits>
 				<exit path="READY" state="success"/>
 			</exits>
-			
+
 			<pipe
 				name="ReadOuterZipEntry"
 				getInputFromSessionKey="zipdata"
-				className="nl.nn.adapterframework.compression.ZipIteratorPipe" 
+				className="nl.nn.adapterframework.compression.ZipIteratorPipe"
 				streamingContents="false"
 				contentsSessionKey="nestedZipData"
 				charset="ISO-8859-1"
 				>
-				<sender className="nl.nn.adapterframework.senders.FixedResultSender" 
+				<sender className="nl.nn.adapterframework.senders.FixedResultSender"
 					filename="zip/NameAndContents.txt"
 				 >
 					<param name="name"  />
@@ -210,17 +210,17 @@
 				</sender>
 				<forward name="success" path="READY"/>
 			</pipe>
-			
+
 		</pipeline>
 	</adapter>
 
 
 	<adapter name="Zip-Recreate 1" >
-		<receiver 
-			name="Zip-Recreate 1" 
+		<receiver
+			name="Zip-Recreate 1"
 			maxRetries="0">
-			<listener 
-				className="nl.nn.adapterframework.receivers.JavaListener" 
+			<listener
+				className="nl.nn.adapterframework.receivers.JavaListener"
 				name="ibis4test-RecreateZip"
 			/>
 		</receiver>
@@ -228,10 +228,10 @@
 			<exits>
 				<exit path="READY" state="success"/>
 			</exits>
-			
+
 			<pipe
 				name="make entry"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
 				action="stream"
 				backwardsCompatibility="true"
 				>
@@ -240,10 +240,10 @@
 			</pipe>
 			<pipe
 				name="start nested zip"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
-				action="open" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
+				action="open"
 				zipWriterHandle="zipwriter2"
-				closeOutputstreamOnExit="false" 
+				closeOutputstreamOnExit="false"
 				backwardsCompatibility="true"
 				>
 				<forward name="success" path="ZipRead"/>
@@ -251,12 +251,12 @@
 			<pipe
 				name="ZipRead"
 				getInputFromSessionKey="zipdata"
-				className="nl.nn.adapterframework.compression.ZipIteratorPipe" 
+				className="nl.nn.adapterframework.compression.ZipIteratorPipe"
 				streamingContents="false"
 				charset="ISO-8859-1"
 				contentsSessionKey="nestedZipData"
 				>
-				<sender className="nl.nn.adapterframework.compression.ZipWriterSender" 
+				<sender className="nl.nn.adapterframework.compression.ZipWriterSender"
 					zipWriterHandle="zipwriter2"
 					backwardsCompatibility="true"
 				>
@@ -266,14 +266,121 @@
 			</pipe>
 			<pipe
 				name="close nested zip"
-				className="nl.nn.adapterframework.compression.ZipWriterPipe" 
-				action="close" 
+				className="nl.nn.adapterframework.compression.ZipWriterPipe"
+				action="close"
 				zipWriterHandle="zipwriter2"
 				backwardsCompatibility="true"
 				>
 				<forward name="success" path="READY"/>
 			</pipe>
-			
+
+		</pipeline>
+	</adapter>
+
+	<adapter name="Zip-Iterator-Main">
+		<receiver
+			name="Zip-Iterator-Main"
+			>
+			<listener
+				className="nl.nn.adapterframework.receivers.JavaListener"
+				serviceName="ibis4test-zip-iterator-main"
+				/>
+		</receiver>
+		<pipeline>
+			<exits>
+				<exit path="READY" state="success"/>
+			</exits>
+
+			<pipe
+					name="Open"
+					className="nl.nn.adapterframework.compression.ZipWriterPipe"
+					action="open"
+					collectionName="zipHandle"
+			>
+				<param name="filename" value="${testdata.dir}/ziperator.zip"/>
+			</pipe>
+
+			<pipe
+					name="Get File List"
+					className="nl.nn.adapterframework.pipes.FixedResultPipe"
+					returnString="&lt;files&gt;
+									&lt;file&gt;file1.txt&lt;/file&gt;
+									&lt;file&gt;file2.txt&lt;/file&gt;
+									&lt;file&gt;file3.txt&lt;/file&gt;
+								&lt;/files&gt;"
+			/>
+
+			<pipe
+					name="ForEachFileEntry"
+					className="nl.nn.adapterframework.pipes.ForEachChildElementPipe"
+					collectResults="false" elementXPathExpression="/files/file"
+					>
+				<sender className="nl.nn.adapterframework.senders.IbisLocalSender"
+						javaListener="ibis4test-zip-iterator-sub">
+					<param name="zipHandle" sessionKey="zipHandle"/>
+				</sender>
+			</pipe>
+
+			<pipe
+					name="Close"
+					className="nl.nn.adapterframework.compression.ZipWriterPipe"
+					action="close"
+					collectionName="zipHandle"
+			/>
+
+			<!-- Read first file from the ZIP to verify the contents have been written correctly -->
+
+			<pipe
+					name="Create unzip target directory"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					action="mkdir"
+					getInputFromFixedValue="${testdata.dir}/unziperator"
+			/>
+			<pipe
+					name="UnZip"
+					className="nl.nn.adapterframework.pipes.UnzipPipe"
+					processFile="true"
+					getInputFromFixedValue="${testdata.dir}/ziperator.zip"
+					directory="${testdata.dir}/unziperator"
+					assumeDirectoryExists="true"
+			/>
+			<pipe
+					name="Get Filename first result file"
+					className="nl.nn.adapterframework.pipes.XsltPipe"
+					xpathExpression="/results/result[1]/fileName/text()"
+			/>
+			<pipe
+					name="readFile"
+					className="nl.nn.adapterframework.pipes.LocalFileSystemPipe"
+					action="read"
+			/>
+		</pipeline>
+	</adapter>
+
+	<adapter name="Zip-Iterator-Sub">
+		<receiver
+			name="Zip-Iterator-Sub"
+			>
+			<listener
+				className="nl.nn.adapterframework.receivers.JavaListener"
+				name="ibis4test-zip-iterator-sub"
+				/>
+		</receiver>
+		<pipeline>
+			<exits>
+				<exit path="READY" state="success"/>
+			</exits>
+
+			<!-- Encode/decode causes the original to be registered for close at end of this sub-adapter, issue 5702 -->
+			<pipe name="Encode" className="nl.nn.adapterframework.pipes.Base64Pipe"
+				  direction="encode"/>
+			<pipe name="Decode" className="nl.nn.adapterframework.pipes.Base64Pipe"
+				  direction="decode"/>
+
+			<pipe className="nl.nn.adapterframework.compression.ZipWriterPipe" collectionName="zipHandle" name="WriteDataToZipStream">
+				<param name="filename" sessionKey="originalMessage" xpathExpression="file"/>
+				<forward name="success" path="READY"/>
+			</pipe>
 		</pipeline>
 	</adapter>
 </module>

--- a/test/src/test/testtool/Zip/ZipWriter/output-3.xml
+++ b/test/src/test/testtool/Zip/ZipWriter/output-3.xml
@@ -1,1 +1,1 @@
-<result><file>file1.txt</file><file>file2.txt</file><file>file3.txt</file></result>
+<result>File1 Contents Contents of File 2 File The Third, contents thereof </result>

--- a/test/src/test/testtool/Zip/ZipWriter/output-3.xml
+++ b/test/src/test/testtool/Zip/ZipWriter/output-3.xml
@@ -1,1 +1,1 @@
-<file>file1.txt</file>
+<result><file>file1.txt</file><file>file2.txt</file><file>file3.txt</file></result>

--- a/test/src/test/testtool/Zip/ZipWriter/output-3.xml
+++ b/test/src/test/testtool/Zip/ZipWriter/output-3.xml
@@ -1,0 +1,1 @@
+<file>file1.txt</file>

--- a/test/src/test/testtool/Zip/ZipWriter/scenario03.properties
+++ b/test/src/test/testtool/Zip/ZipWriter/scenario03.properties
@@ -1,0 +1,9 @@
+scenario.description = ZipWriter, create zip iterating over multiple files
+
+include = ../common.properties
+
+java.CreateZip.className=nl.nn.adapterframework.senders.IbisJavaSender
+java.CreateZip.serviceName=ibis4test-zip-iterator-main
+
+step1.java.CreateZip.writeline = <dummy-test-trigger/>
+step2.java.CreateZip.read = output-3.xml


### PR DESCRIPTION
Tested that without this fix, the included IAF-Test scenario produces a ZIP file with only 0-byte files, like in the original issue. The scenario produces only `<result></result>` as output, manually checking the ZIP file shows 0 byte files.

With the fix the ZIP file contains the actual data it is supposed to.
